### PR TITLE
Update NavigationController.php

### DIFF
--- a/source/Application/Controller/Admin/NavigationController.php
+++ b/source/Application/Controller/Admin/NavigationController.php
@@ -144,7 +144,7 @@ class NavigationController extends \OxidEsales\Eshop\Application\Controller\Admi
     {
         $messages = [];
 
-        if ($this->getConfig()->getConfigParam('blCheckSysReq') !== false) {
+        if ($this->getConfig()->getConfigParam('blCheckSysReq')) {
             // check if system requirements are ok
             $oSysReq = oxNew(\OxidEsales\Eshop\Core\SystemRequirements::class);
             if (!$oSysReq->getSysReqStatus()) {


### PR DESCRIPTION
When installing the Demodata, the blCheckSysReq key is not present in oxconfig. getConfigParam returns NULL in this case.


Since `NULL !== false` the sys-req-check was falsely enabled. 