### PR TITLE
Make Log Level as .env.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,6 @@ O3SHOP_CONF_DBUSER="o3shop"
 O3SHOP_CONF_DBPWD="o3shop"
 O3SHOP_CONF_DBROOT="supersecret"
 
-
 ## URL and paths
 O3SHOP_CONF_SHOPURL="http://localhost:8090"
 O3SHOP_CONF_SSLSHOPURL="${O3SHOP_CONF_SHOPURL}"
@@ -22,6 +21,7 @@ O3SHOP_CONF_COMPILEDIR="/var/www/html/source/tmp"
 O3SHOP_CONF_ADMINSSLURL=""
 
 ## MISC
+O3SHOP_CONF_LOG_LEVEL="error" // Log Levels: emergency, alert, critical, error, warning, notice, info, debug
 O3SHOP_CONF_DEBUG=0
 O3SHOP_CONF_ADMINEMAIL=""
 O3SHOP_CONF_SKIPVIEWUSAGE=0

--- a/source/config.inc.php.dist
+++ b/source/config.inc.php.dist
@@ -74,7 +74,7 @@ $this->sO3SHOPPHP = "o3shop.php";
 /**
  * String PSR3 log level Psr\Log\LogLevel
  */
-$this->sLogLevel = 'error';
+$this->sLogLevel = $_ENV['O3SHOP_CONF_LOG_LEVEL'];
 
 /**
  * Log all modifications performed in Admin


### PR DESCRIPTION
A new `.env` variable has been added to enable customisable log levels via environment configuration.