### PR TITLE
B 1.5 security hotfix

### DIFF
--- a/source/Core/Smarty/Plugin/function.oxcontent.php
+++ b/source/Core/Smarty/Plugin/function.oxcontent.php
@@ -67,7 +67,12 @@ function smarty_function_oxcontent($params, &$smarty)
                     Registry::getLang()->getBaseLanguage(),
                     Registry::getConfig()->getShopId()
                 );
-                $text = $smarty->fetch($resourceName);
+                try {
+                    $text = $smarty->fetch($resourceName);
+                } catch (\Throwable $error) {
+                    Registry::getLogger()->error($error->getMessage(), [$error]);
+                    $text = '';
+                }
                 $smarty->compile_check = Registry::getConfig()->getConfigParam('blCheckTemplates');
             }
         }


### PR DESCRIPTION
The security hotfix has been added to the core of the O3 shop. This means that the hotfix module does not need to be installed.