### PR TITLE
Adds configurable log directory

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -22,7 +22,8 @@ O3SHOP_CONF_COMPILEDIR="/home/runner/work/shop-ce/shop-ce/source/tmp"
 O3SHOP_CONF_ADMINSSLURL=""
 
 ## MISC
-O3SHOP_CONF_LOG_LEVEL="error"
+O3SHOP_CONF_LOG_LEVEL="error" #Log Levels: emergency, alert, critical, error, warning, notice, info, debug
+O3SHOP_CONF_LOG_DIR="/../logs" # starting from O3SHOP_CONF_SHOPDIR
 O3SHOP_CONF_DEBUG=0
 O3SHOP_CONF_ADMINEMAIL=""
 O3SHOP_CONF_SKIPVIEWUSAGE=0

--- a/.env.example
+++ b/.env.example
@@ -21,8 +21,8 @@ O3SHOP_CONF_COMPILEDIR="/var/www/html/source/tmp"
 O3SHOP_CONF_ADMINSSLURL=""
 
 ## MISC
-O3SHOP_CONF_LOG_LEVEL="error" // Log Levels: emergency, alert, critical, error, warning, notice, info, debug
-O3SHOP_CONF_DEBUG=0
+O3SHOP_CONF_LOG_LEVEL="error" #Log Levels: emergency, alert, critical, error, warning, notice, info, debug
+O3SHOP_CONF_LOG_DIR="/../logs" # starting from O3SHOP_CONF_SHOPDIRO3SHOP_CONF_DEBUG=0
 O3SHOP_CONF_ADMINEMAIL=""
 O3SHOP_CONF_SKIPVIEWUSAGE=0
 O3SHOP_CONF_DELSETUPDIR=1

--- a/source/Core/Config.php
+++ b/source/Core/Config.php
@@ -118,6 +118,13 @@ class Config extends \OxidEsales\Eshop\Core\Base
     protected $sShopDir = null;
 
     /**
+     * Shops Log directory
+     *
+     * @var string
+     */
+    protected $sLogDir = null;
+
+    /**
      * Shops compile directory
      *
      * @var string
@@ -502,6 +509,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
         //adding trailing slashes
         $fileUtils = Registry::getUtilsFile();
         $this->sShopDir = $fileUtils->normalizeDir($this->sShopDir);
+        $this->sLogDir = $fileUtils->normalizeDir($this->sLogDir);
         $this->sCompileDir = $fileUtils->normalizeDir($this->sCompileDir);
         $this->sShopURL = $fileUtils->normalizeDir($this->sShopURL);
         $this->sSSLShopURL = $fileUtils->normalizeDir($this->sSSLShopURL);
@@ -2183,7 +2191,7 @@ class Config extends \OxidEsales\Eshop\Core\Base
      */
     public function getLogsDir()
     {
-        return $this->getConfigParam('sShopDir') . 'log/';
+        return $this->getConfigParam('sShopDir') . $this->sLogDir;
     }
 
     /**

--- a/source/Setup/.env.dist
+++ b/source/Setup/.env.dist
@@ -20,7 +20,8 @@ O3SHOP_CONF_COMPILEDIR="<sCompileDir>"
 O3SHOP_CONF_ADMINSSLURL=""
 
 ## MISC
-O3SHOP_CONF_LOG_LEVEL="error"
+O3SHOP_CONF_LOG_LEVEL="error" #Log Levels: emergency, alert, critical, error, warning, notice, info, debug
+O3SHOP_CONF_LOG_DIR="/../logs" # starting from O3SHOP_CONF_SHOPDIR
 O3SHOP_CONF_DEBUG=0
 O3SHOP_CONF_ADMINEMAIL=""
 O3SHOP_CONF_SKIPVIEWUSAGE=0


### PR DESCRIPTION
Adds the possibility to configure the log directory via environment variable.

This allows for greater flexibility in managing logs, especially in containerized environments. It ensures logs can be stored outside of the shop directory.

The log directory is now configurable via the `O3SHOP_CONF_LOG_DIR` environment variable. A default value is set relative to the shop directory outside of the webspace.