### PR TITLE
B 1.5 updating dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "o3-shop/smarty": "~2.6.34",
         "doctrine/dbal": "<=2.12.1",
         "doctrine/collections": "^1.4.0",
-        "monolog/monolog": "^v1.23.0",
+        "monolog/monolog": "^v2.10",
         "psr/container": "1.0.*",
         "symfony/event-dispatcher": "^3.4",
         "symfony/dependency-injection": "^3.4.26",

--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,7 @@
             }
         },
         "branch-alias": {
-            "dev-main": "dev-b-1.5-changes"
+            "dev-main": "1.4.x-dev"
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/collections": "^1.4.0",
         "monolog/monolog": "^v1.23.0",
         "psr/container": "1.0.*",
-        "symfony/event-dispatcher": "^3.4",
+        "symfony/event-dispatcher": "^4.4",
         "symfony/dependency-injection": "^3.4.26",
         "symfony/config": "~3.3 || ~4.0",
         "symfony/yaml": "~3.4 || ~4.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/collections": "^1.4.0",
         "monolog/monolog": "^v1.23.0",
         "psr/container": "1.0.*",
-        "symfony/event-dispatcher": "^4.4",
+        "symfony/event-dispatcher": "^3.4",
         "symfony/dependency-injection": "^3.4.26",
         "symfony/config": "~3.3 || ~4.0",
         "symfony/yaml": "~3.4 || ~4.0",

--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,7 @@
             }
         },
         "branch-alias": {
-            "dev-main": "1.4.x-dev"
+            "dev-main": "dev-b-1.5-changes"
         }
     },
     "config": {


### PR DESCRIPTION
I've upgraded Monolog from version 1.x to 2.x. With this update, syslog usage should now be compatible with PHP versions greater than 7.2.