### PR TITLE
Add cache clearing command and container startup integration

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -143,6 +143,12 @@ setup_db() {
   bin/o3-setup
 }
 
+clear_cache() {
+    log "${YELLOW}Clearing cache...${NC}"
+    /var/www/html/bin/oe-console oe:cache:clear || handle_error "Failed to clear cache"
+    log "${GREEN}Cache cleared successfully${NC}"
+}
+
 
 # Main execution
 main() {
@@ -155,6 +161,7 @@ main() {
     install_demodata || exit 127
     setup_db || exit 127
     install_theme || exit 127
+    clear_cache || exit 127
     start_apache || exit 127
 }
 

--- a/source/Internal/Framework/Module/Command/ClearCacheCommand.php
+++ b/source/Internal/Framework/Module/Command/ClearCacheCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace OxidEsales\EshopCommunity\Internal\Framework\Module\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ClearCacheCommand extends Command
+{
+    protected static $defaultName = 'oe:cache:clear';
+
+    protected function configure()
+    {
+        $this->setDescription('Clears the application cache');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+
+        $output->writeln('Clearing cache...');
+
+        $DIR = __DIR__;
+        $tmp = $DIR . '/../../../../tmp';
+        $smarty = $DIR . '/../../../../tmp/smarty';
+
+        $this->deleteContents($tmp);
+        $this->deleteContents($smarty);
+        // Your cache-clearing logic here
+        $output->writeln('Cache cleared successfully.');
+    }
+
+    protected function deleteContents($path)
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+        $files = scandir($path);
+        foreach ($files as $file) {
+            if ($file === '.' || $file === '..' || $file === '.htaccess') {
+                continue;
+            }
+            $fullPath = $path . DIRECTORY_SEPARATOR . $file;
+            if (is_dir($fullPath)) {
+                $this->deleteContents($fullPath);
+                rmdir($fullPath);
+            } else {
+                unlink($fullPath);
+            }
+        }
+    }
+}

--- a/source/Internal/Framework/Module/Command/services.yaml
+++ b/source/Internal/Framework/Module/Command/services.yaml
@@ -26,3 +26,8 @@ services:
     class: OxidEsales\EshopCommunity\Internal\Framework\Module\Command\ApplyModulesConfigurationCommand
     tags:
       - { name: 'console.command', command: 'oe:module:apply-configuration' }
+
+  oxid_esales.command.clear_cache_command:
+    class: OxidEsales\EshopCommunity\Internal\Framework\Module\Command\ClearCacheCommand
+    tags:
+      - { name: 'console.command', command: 'oe:cache:clear' }


### PR DESCRIPTION
## Summary

This PR adds cache clearing functionality to the O3-Shop:

### Changes
- Added `oe:cache:clear` command that can be executed via `bin/oe-console oe:cache:clear`
- Integrated cache clearing into container startup process to ensure clean cache state

### Benefits
- Provides a convenient way to clear the shop cache via command line
- Ensures containers start with a clean cache state, preventing stale cache issues
- Improves development and deployment reliability

### Usage
```bash
bin/oe-console oe:cache:clear
```

The cache clearing is now automatically executed when containers start up, ensuring a consistent and clean environment. 