### PR TITLE
Add the option to prevent entries from being deleted

### DIFF
--- a/source/Application/views/admin/tpl/actions_list.tpl
+++ b/source/Application/views/admin/tpl/actions_list.tpl
@@ -101,7 +101,7 @@ window.onload = function ()
                 [{oxmultilang ident="PROMOTIONS_MAIN_TYPE_ACTION"}]
             [{/if}]
         </a></div></td>
-    <td class="[{$listclass}]">[{if !$listitem->isOx() && !$readonly && $listitem->oxactions__oxtype->value > 0}]<a href="Javascript:top.oxid.admin.deleteThis('[{$listitem->oxactions__oxid->value}]');" class="delete" id="del.[{$_cnt}]" [{include file="help.tpl" helpid=item_delete}]></a>[{/if}]</td>
+    <td class="[{$listclass}]">[{if !$listitem->isOx() && !$readonly && $listitem->oxactions__oxnodelete->value == 0}]<a href="Javascript:top.oxid.admin.deleteThis('[{$listitem->oxactions__oxid->value}]');" class="delete" id="del.[{$_cnt}]" [{include file="help.tpl" helpid=item_delete}]></a>[{/if}]</td>
     [{/block}]
 </tr>
 [{if $blWhite == "2"}]

--- a/source/Application/views/admin/tpl/content_list.tpl
+++ b/source/Application/views/admin/tpl/content_list.tpl
@@ -90,7 +90,7 @@ window.onload = function ()
             <td valign="top" class="[{$listclass}]" height="15"><div class="listitemfloating"><a href="Javascript:top.oxid.admin.editThis('[{$listitem->oxcontents__oxid->value}]');" class="[{$listclass}]">[{if $listitem->oxcontents__oxtitle->value}][{$listitem->oxcontents__oxtitle->value}][{else}]---[{/if}]</a></div></td>
             <td valign="top" class="[{$listclass}]"><div class="listitemfloating"><a href="Javascript:top.oxid.admin.editThis('[{$listitem->oxcontents__oxid->value}]');" class="[{$listclass}]">[{$listitem->oxcontents__oxloadid->value}]</a></div></td>
             <td class="[{$listclass}]">
-            [{if !$readonly}]
+            [{if !$readonly && $listitem->oxcontents__oxnodelete->value != 1}]
             <a href="Javascript:top.oxid.admin.deleteThis('[{$listitem->oxcontents__oxid->value}]');" class="delete" id="del.[{$_cnt}]" alt="" [{include file="help.tpl" helpid=item_delete}]></a>
             [{/if}]
             </td>

--- a/source/migration/data/Version20250924111451.php
+++ b/source/migration/data/Version20250924111451.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of O3-Shop.
+ *
+ * O3-Shop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * O3-Shop is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with O3-Shop.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * @copyright  Copyright (c) 2022 OXID eSales AG (https://www.oxid-esales.com)
+ * @copyright  Copyright (c) 2022 O3-Shop (https://www.o3-shop.com)
+ * @license    https://www.gnu.org/licenses/gpl-3.0  GNU General Public License 3 (GPLv3)
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\EshopCommunity\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250924111451 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Add OXNODELETE column to oxactions and oxcontents tables for deletion protection';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->connection->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+
+        $this->addSql("ALTER TABLE `oxactions` ADD COLUMN `OXNODELETE` TINYINT(1) NOT NULL DEFAULT 0 COMMENT '1 = must not be deleted, 0 = default' AFTER `OXSORT`");
+
+        $this->addSql("ALTER TABLE `oxcontents` ADD COLUMN `OXNODELETE` TINYINT(1) NOT NULL DEFAULT 0 COMMENT '1 = must not be deleted, 0 = default' AFTER `OXISPLAIN`");
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->connection->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+
+        $this->addSql("ALTER TABLE `oxactions` DROP COLUMN `OXNODELETE`");
+
+        $this->addSql("ALTER TABLE `oxcontents` DROP COLUMN `OXNODELETE`");
+    }
+}


### PR DESCRIPTION
So far, it is only possible to protect actions from deletion. This option is not available for banners or CMS pages.
Only one additional column is created in the relevant tables and the if conditions are slightly adjusted. Protecting entries is only controlled via the database.