### PR TITLE
fix: Drag&Drop boxes for Payment Methods will display

### DIFF
--- a/source/Application/Controller/Admin/ListComponentAjax.php
+++ b/source/Application/Controller/Admin/ListComponentAjax.php
@@ -220,7 +220,7 @@ class ListComponentAjax extends Base
             $this->$function();
             $this->dispatchEvent(new AfterAdminAjaxRequestProcessedEvent());
         } else {
-            $sQAdd = $this->getQuery();
+            $sQAdd = $this->_getQuery();
 
             // formatting SQL queries
             $sQ = $this->getDataQuery($sQAdd);


### PR DESCRIPTION
## Summary

- Fixes drag & drop sorting for Payment Methods in the admin panel by calling `_getQuery()` instead of `getQuery()` in `ListComponentAjax.php`

## Changes

- `source/Application/Controller/Admin/ListComponentAjax.php`: corrected method call from `getQuery()` to `_getQuery()` so the drag & drop reorder boxes render correctly

## Test plan

- [ ] Open admin panel → Shop Settings → Payment Methods
- [ ] Confirm drag & drop sorting boxes are visible and functional
