### PR TITLE
feat: phpunit-ini-safety

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,6 +170,9 @@ jobs:
       - name: 🗄️ Create Test Database
         run: mysql -h 127.0.0.1 -P 3306 -u root -proot -e "CREATE DATABASE IF NOT EXISTS o3shop_test;"
 
+      - name: 🔒 Check PHPUnit INI Safety (GHSA-qrr6-mg7r-m243)
+        run: php bin/check-phpunit-ini-safety.php
+
       - name: ✅ Run PHPUnit (with Coverage)
         id: phpunit
         continue-on-error: true

--- a/bin/check-phpunit-ini-safety.php
+++ b/bin/check-phpunit-ini-safety.php
@@ -1,0 +1,50 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Guard against GHSA-qrr6-mg7r-m243: argument injection via newline in PHPUnit <ini> values.
+ * Mirrors the validation that phpunit/phpunit 12.5.22 / 13.1.6 added in JobRunner::settingsToParameters().
+ */
+
+$root = dirname(__DIR__);
+
+$patterns = [
+    $root . '/phpunit.xml',
+    $root . '/phpunit.xml.dist',
+    $root . '/tests/phpunit.xml',
+    $root . '/tests/phpunit.xml.dist',
+];
+
+$files = array_filter($patterns, 'file_exists');
+
+if (empty($files)) {
+    fwrite(STDERR, "[SKIP] No phpunit.xml files found — nothing to check.\n");
+    exit(0);
+}
+
+$rc = 0;
+
+foreach ($files as $file) {
+    $xml = new DOMDocument();
+    if (!$xml->load($file)) {
+        fwrite(STDERR, "[ERROR] Could not parse {$file}\n");
+        $rc = 1;
+        continue;
+    }
+
+    foreach ($xml->getElementsByTagName('ini') as $node) {
+        $name  = $node->getAttribute('name');
+        $value = $node->getAttribute('value');
+
+        if (preg_match('/[\r\n]/', $value)) {
+            fwrite(STDERR, "[FAIL] {$file}: <ini name='{$name}'> value contains CR/LF — "
+                . "rejected per GHSA-qrr6-mg7r-m243\n");
+            $rc = 1;
+        }
+    }
+}
+
+if ($rc === 0) {
+    echo "[OK] All phpunit.xml <ini> values are safe.\n";
+}
+
+exit($rc);

--- a/bin/check-phpunit-ini-safety.php
+++ b/bin/check-phpunit-ini-safety.php
@@ -1,5 +1,6 @@
 #!/usr/bin/env php
 <?php
+
 /**
  * Guard against GHSA-qrr6-mg7r-m243: argument injection via newline in PHPUnit <ini> values.
  * Mirrors the validation that phpunit/phpunit 12.5.22 / 13.1.6 added in JobRunner::settingsToParameters().
@@ -32,7 +33,7 @@ foreach ($files as $file) {
     }
 
     foreach ($xml->getElementsByTagName('ini') as $node) {
-        $name  = $node->getAttribute('name');
+        $name = $node->getAttribute('name');
         $value = $node->getAttribute('value');
 
         if (preg_match('/[\r\n]/', $value)) {


### PR DESCRIPTION
## Summary

- Adds `bin/check-phpunit-ini-safety.php` — a pre-flight scanner that parses every `phpunit.xml` / `phpunit.xml.dist` under the repo root and rejects any `<ini>` element whose `value` attribute contains a CR or LF character.
- Wires the check into `.github/workflows/tests.yml` as a blocking step that runs before PHPUnit on every PHP matrix leg.

## Motivation

**GHSA-qrr6-mg7r-m243** (PHPUnit ≤ 12.5.21 / ≤ 13.1.5, CVSS 7.8 High): `JobRunner::settingsToParameters()` forwards `<ini>` values to child PHP processes as `-d name=value` without stripping newlines. A newline inside the value is parsed by the child as a new directive, enabling injection of `auto_prepend_file`, `open_basedir`, `disable_functions`, etc.

The upstream fix (12.5.22 / 13.1.6) requires PHP ≥ 8.2 / ≥ 8.3, which is incompatible with this repo's `"php": "^7.4 || ^8.0"` floor. A direct version bump is not feasible without first raising the PHP minimum. This check closes the same attack surface at the CI layer.

## How the check works

The script mirrors the validation added upstream:

```
for each phpunit.xml / phpunit.xml.dist:
    for each <ini name="…" value="…"> element:
        if value contains \r or \n → print diagnostic, exit 1
```

An attacker would encode the newline as `&#10;` in XML (attribute-value normalisation decodes it before it reaches PHP). The regex `/[\r\n]/` catches both the decoded form and a literal newline, matching exactly what the patched `JobRunner` now rejects.

## Test plan

- [ ] Confirm CI passes on this branch (no `<ini>` elements exist in `tests/phpunit.xml` today).
- [ ] Locally verify detection: add `<ini name="x" value="foo&#10;bar"/>` to `tests/phpunit.xml`, run `php bin/check-phpunit-ini-safety.php`, confirm exit 1 and `[FAIL]` output, then revert.
- [ ] Confirm the new workflow step appears before `Run PHPUnit` in the Actions run log.

## Limitations / follow-up

- The 9.x PHPUnit line is EOL; the underlying vulnerability is not patched upstream for this version. Raising the PHP floor to ≥ 8.2 and bumping to PHPUnit 12.x (or migrating off `o3-shop/testing-library`'s transitive pin) would eliminate the vulnerability entirely and should be tracked as a separate issue.
- Issue #100 (move PHPUnit from `require` to `require-dev`) remains open; until resolved, the vulnerable test runner can reach production installations.
