### PR TITLE
dev: replace wave-theme zip bootstrap with git clone (#114)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,8 @@ composer.lock
 
 .env
 /.phpstorm.meta.php/oxid.meta.php
-/source/Application/views/wave/*
-/source/Application/views/o3-theme/*
+/source/Application/views/wave
+/source/Application/views/o3-theme
 /source/out/pictures/generated/*
 /source/out/pictures/master/category/*
 
@@ -58,8 +58,8 @@ composer.lock
 /source/out/pictures/master/product/*
 /source/out/pictures/master/wrapping/img_ecard_03_wp.jpg
 /source/out/pictures/promo/*
-/source/out/wave/*
-/source/out/o3-theme/*
+/source/out/wave
+/source/out/o3-theme
 /var/configuration/shops/1.yaml
 /var/generated/generated_services.yaml
 docker/database/data

--- a/README.md
+++ b/README.md
@@ -45,6 +45,49 @@ Once the setup is complete, all emails are sent to Mailpit. You reach it at http
 
 Adminer is included in the standard installation. Try http://localhost:8081.
 
+### Working on the storefront theme
+
+The first `./docker.sh start` clones the storefront themes directly into the served paths via `git`:
+
+- `source/Application/views/wave/` ← https://github.com/o3-shop/wave-theme
+- `source/Application/views/o3-theme/` ← https://github.com/o3-shop/o3-Theme
+
+So those directories ARE the upstream working trees. `git pull`, `git status`, and commits work in place — no out-of-tree clone or symlink dance.
+
+Apache serves theme assets through symlinks pointing back into each working tree:
+
+- `source/out/wave` → `../Application/views/wave/out/wave`
+- `source/out/o3-theme` → `../Application/views/o3-theme/out/o3-theme`
+
+This means asset edits show up live without re-copying anything.
+
+#### Pushing theme changes upstream
+
+The clone uses HTTPS so anonymous read works without SSH keys. To push back, switch the remote once:
+
+```sh
+cd source/Application/views/wave
+git remote set-url origin git@github.com:o3-shop/wave-theme.git
+```
+
+Same for `source/Application/views/o3-theme/` ↔ `git@github.com:o3-shop/o3-Theme.git`.
+
+#### Migrating from the old detached snapshot
+
+If you set up shop-ce before this change, your `source/Application/views/wave/` is a detached snapshot from the old `wget`+`unzip` bootstrap with no `.git/` subdirectory. The next `./docker.sh start` will detect this, abort with a loud warning, and tell you exactly what to do.
+
+The one-liner is:
+
+```sh
+./docker.sh stop && rm -rf source/Application/views/wave source/out/wave && ./docker.sh start
+```
+
+The entrypoint deliberately refuses to delete those paths itself — they're gitignored, so any in-progress theme edits there are not version-controlled by anything else and would be silently destroyed. If you have uncommitted edits, copy them out of the directory first, then run the cleanup, then replay them onto the fresh working tree (where you can commit and push them).
+
+#### Windows host caveat
+
+The bootstrap symlinks `source/out/<theme>` into the cloned tree. Apache runs in the Linux container and follows the symlink fine on any host OS, so the storefront renders normally everywhere. On Windows hosts where shop-ce is checked out under `C:\...` (Windows-native FS via Docker Desktop's bridge), Windows-side tooling (IDE indexing, `git status` from PowerShell against the `out/` path) may show the symlink as broken — that's a host-side cosmetic issue only; the shop runs. WSL2-native FS (`\\wsl$\...`) and Mac/Linux hosts have no issue.
+
 ### Testing 
 
 To run the tests, you have two choices. 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -38,39 +38,91 @@ setup_environment() {
     fi
 }
 
-# Function to download and install theme
-install_theme() {
-    log "${YELLOW}Installing Wave theme...${NC}"
-    
-    # Check if theme is already installed
-    if [ -d "source/Application/views/wave" ] && [ "$(ls -A source/Application/views/wave)" ]; then
-        log "Wave theme appears to be already installed, skipping"
-        return 0
+# Clones a theme repo into source/Application/views/<theme> and symlinks
+# source/out/<theme> at its in-tree out/<theme> so Apache serves assets
+# directly out of the working tree.
+#
+# Args: <theme-name> <git-url>
+install_theme_from_git() {
+    local theme="$1"
+    local repo_url="$2"
+    local view_dir="source/Application/views/${theme}"
+    local out_dir="source/out/${theme}"
+
+    log "${YELLOW}Installing ${theme} theme...${NC}"
+
+    if [ -d "$view_dir" ] && [ "$(ls -A "$view_dir")" ]; then
+        if [ ! -d "$view_dir/.git" ]; then
+            handle_error "$(cat <<EOF
+
+Detected old detached snapshot at ${view_dir} (no .git/ subdirectory).
+This is the layout the previous wget/unzip bootstrap produced. The entrypoint
+now expects a git working tree there so you can pull/commit/push to
+${repo_url} directly.
+
+If you have NO uncommitted edits in ${view_dir}, run:
+
+    ./docker.sh stop
+    rm -rf ${view_dir} ${out_dir}
+    ./docker.sh start
+
+If you DO have uncommitted edits there — be careful: ${view_dir} is gitignored,
+so nothing is version-controlled by anything. Steps:
+
+    1. Copy your edits somewhere safe OUTSIDE ${view_dir} (e.g. ~/${theme}-edits/).
+    2. Run the three commands above.
+    3. After ./docker.sh start, ${view_dir} is a real ${theme} working tree.
+       Replay your edits there, then commit and push to ${repo_url}.
+
+Aborting so no work is destroyed.
+EOF
+            )"
+        fi
+        log "${theme}: working tree already present, skipping clone"
+    else
+        log "Cloning ${theme} from ${repo_url}..."
+        git clone --branch main "$repo_url" "$view_dir" \
+            || handle_error "Failed to clone ${theme} from ${repo_url}"
     fi
-    
-    # Download theme
-    log "Downloading theme from GitHub..."
-    wget -q https://github.com/o3-shop/wave-theme/archive/refs/heads/main.zip -O main.zip || handle_error "Failed to download theme"
-    
-    # Extract theme
-    log "Extracting theme..."
-    unzip -q main.zip || handle_error "Failed to extract theme archive"
-    
-    # Copy theme files
-    log "Copying theme files to appropriate directories..."
-    mkdir -p source/out/ || handle_error "Failed to create out directory"
-    cp -r wave-theme-main/out/* source/out/ || handle_error "Failed to copy theme out files"
-    
-    mkdir -p source/Application/views/wave || handle_error "Failed to create theme views directory"
-    rm -rf wave-theme-main/out
-    cp -r wave-theme-main/* source/Application/views/wave || handle_error "Failed to copy theme view files"
-    
-    # Clean up
-    log "Cleaning up temporary files..."
-    rm -rf wave-theme-main
-    rm main.zip
-    
-    log "${GREEN}Wave theme installed successfully${NC}"
+
+    if [ -e "$out_dir" ] && [ ! -L "$out_dir" ]; then
+        handle_error "$(cat <<EOF
+
+${out_dir} exists and is a regular directory.
+Expected: a symlink pointing to ../Application/views/${theme}/out/${theme}
+(so Apache serves theme assets directly out of the working tree).
+
+This is leftover content from the previous wget/unzip bootstrap. Safe to remove:
+the canonical assets live under ${view_dir}/out/${theme} now.
+
+Run:
+
+    ./docker.sh stop
+    rm -rf ${view_dir} ${out_dir}
+    ./docker.sh start
+
+(Removing ${view_dir} too keeps both paths in sync — the next start re-clones
+the working tree and re-creates the symlink in one shot.)
+
+Aborting.
+EOF
+        )"
+    fi
+    if [ ! -e "$out_dir" ]; then
+        mkdir -p source/out || handle_error "Failed to create source/out"
+        ln -s "../Application/views/${theme}/out/${theme}" "$out_dir" \
+            || handle_error "Failed to create symlink ${out_dir} -> ../Application/views/${theme}/out/${theme}"
+    fi
+
+    log "${GREEN}${theme} theme ready${NC}"
+}
+
+install_theme() {
+    install_theme_from_git wave https://github.com/o3-shop/wave-theme.git
+}
+
+install_o3_theme() {
+    install_theme_from_git o3-theme https://github.com/o3-shop/o3-Theme.git
 }
 
 # Function to install dependencies
@@ -156,6 +208,7 @@ main() {
     install_demodata || exit 127
     setup_db || exit 127
     install_theme || exit 127
+    install_o3_theme || exit 127
     start_apache || exit 127
 }
 


### PR DESCRIPTION
## Summary

- Replace `wget`+`unzip`+`cp` of `wave-theme/main.zip` with an idempotent `git clone` into `source/Application/views/wave/`, so the served path IS the upstream working tree — `git pull`/`commit`/`push` work in place. Same shape wired in for `o3-theme` ahead of the cutover.
- `source/out/<theme>` is now a symlink into the in-tree `out/<theme>`, so theme asset edits show up live without re-bootstrapping.
- Existing devs running the old detached snapshot (no `.git/`) get a loud, copy-pasteable abort with the exact cleanup command — no auto-delete (the path is gitignored, in-progress edits would be silently destroyed), no auto-skip (defeats the cutover).
- `.gitignore`: drop trailing `/*` on the four bootstrap paths to ignore the path itself, not just contents — otherwise `git add` would stage either the symlink or an embedded-repo gitlink.
- README gains a "Working on the storefront theme" section covering the new working-tree behaviour, SSH-remote flip for pushing, the migration one-liner, and the Windows symlink caveat.

## Test plan

Verified end-to-end against a local environment that started in the old detached-snapshot state:

- [x] **Fail-fast on real existing detached snapshot** — entrypoint detects no `.git/`, aborts with full multi-line message (paths and repo URL substituted), container exits(1).
- [x] **Cleanup + fresh install** — `rm -rf source/Application/views/wave source/out/wave && ./docker.sh start` clones both wave-theme and o3-Theme on `main`, creates both symlinks, container reaches healthy.
- [x] **Working trees clean** — `cd source/Application/views/wave && git status` clean, on `main`. Same for o3-theme. _(Issue AC item.)_
- [x] **Symlinks correct** — `readlink source/out/wave` → `../Application/views/wave/out/wave`. Same for o3-theme.
- [x] **Storefront renders** — `http://localhost:8080` returns 200, real `styles.css` (273 KB) served through the wave symlink. _(Issue AC item.)_
- [x] **Idempotent re-run** — `./docker.sh stop && ./docker.sh start` with no cleanup logs "working tree already present, skipping clone" for both themes; storefront still healthy.
- [x] **Fail-fast on non-symlink `source/out/wave`** — replaced symlink with a regular dir to simulate post-cutover leftover; entrypoint aborts with the second message variant.
- [x] **`git` available in image** — already at `docker/Dockerfile:20`, no Dockerfile change needed.
- [x] **`.gitignore` covers the new layout** — `git add --dry-run` confirms all four bootstrap paths are ignored (no symlink staging, no gitlink staging).

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)