### PR TITLE
test: Playwright E2E infra + §356a revocation suite + #116 regression

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 AGENTS.md export-ignore
+tests/Acceptance/playwright/** export-ignore

--- a/docker.sh
+++ b/docker.sh
@@ -313,6 +313,16 @@ case "$1" in
     cs-fixer)
         run_php_cs_fixer || exit 127
         ;;
+    playwright)
+        shift
+        cd "$MY_DIR/tests/Acceptance/playwright" || exit 127
+        if [ ! -d node_modules ]; then
+            echo "Installing Playwright dependencies (one-time)..."
+            npm install || exit 127
+            npx playwright install chromium || exit 127
+        fi
+        npx playwright test "$@" || exit 127
+        ;;
     *)
         echo "Usage: $0 <command> [options]"
         echo ""
@@ -326,6 +336,7 @@ case "$1" in
         echo "  test-all-coverage  Run php-cs-fixer, then full test suite with coverage report"
         echo "  cs-fixer     Run php-cs-fixer on the entire codebase"
         echo "  quarantine   Run slow/special @group quarantine tests only"
+        echo "  playwright   Run the Playwright browser test suite (auto-installs deps on first run)"
         echo ""
         echo "Options for 'test':"
         echo "  --fast       Skip shop install, call phpunit directly"

--- a/tests/Acceptance/README.md
+++ b/tests/Acceptance/README.md
@@ -1,0 +1,84 @@
+# Browser / Acceptance Tests
+
+This directory hosts O3-Shop's browser-driven acceptance tests. Two suites
+live side by side, in different states of maturity.
+
+| Subdir / file                          | Suite                       | Maturity                |
+|----------------------------------------|-----------------------------|-------------------------|
+| `Admin/`, `Frontend/`, `Javascript/`   | Codeception + Selenium      | Stable, in CI           |
+| `*TestCase.php`, `*.php` test files    | Codeception base / helpers  | Stable, in CI           |
+| `playwright/`                          | Playwright + TypeScript     | **Experimental** (see below) |
+
+## Codeception / Selenium suite (stable)
+
+The PHP files here drive the shop through a real Selenium-controlled
+browser. They extend `AcceptanceTestCase` (or one of its specialisations:
+`AdminTestCase`, `FrontendTestCase`, `FlowThemeTestCase`,
+`JavascriptTestCase`) which come from `o3-shop/testing-library`.
+
+Coverage:
+- `Admin/` — admin panel: navigation, product/category/user CRUD, SEO,
+  AJAX, basket workflows, query-logger.
+- `Frontend/` — storefront: navigation, basket, product info, contact
+  form, CSRF, post-update validation, shop-setup.
+- `Javascript/` — storefront-side JS sanity.
+
+These run in CI today via the standard test runners.
+
+## Playwright suite (experimental — `playwright/`)
+
+A net-new browser-test infrastructure built on **Playwright + TypeScript**,
+introduced alongside the Codeception suite with the long-term intent of
+**replacing** it. See `playwright/README.md` for layout, conventions, and
+how to run.
+
+Today's coverage:
+- Smoke spec (storefront, admin auth, Mailpit, MySQL reachability).
+- §356a BGB electronic revocation feature: storefront submission form,
+  admin config form, admin detail view.
+- Issue #116 regression: `oxiddebitnote` payment-method toggle in the
+  o3-theme checkout payment page.
+
+> ## ⚠️ Experimental — not yet in CI/CD
+>
+> The Playwright suite is **explicitly experimental**. It is not wired into
+> any CI/CD pipeline yet, and merging or releasing must not depend on its
+> green status.
+>
+> It will be promoted into regular CI/CD only **once stable, verified,
+> probed and approved** — that means:
+>
+> 1. **Stable** across multiple consecutive full-suite runs on developer
+>    machines and a fresh shop install.
+> 2. **Verified** against representative deployments (German + English
+>    storefront, demo-data shop).
+> 3. **Probed** for flake — repeated runs with `--repeat-each=N`, headed +
+>    headless, with and without warm caches.
+> 4. **Approved** by the maintainers (issue / PR review sign-off).
+>
+> Until then: run it locally, treat failures as data, and **do not** gate
+> releases or merges on it.
+
+## Running
+
+```bash
+# Codeception / Selenium (stable)
+./docker.sh test       # via PHPUnit harness
+# or via Codeception/testing-library entrypoints — see o3-shop/testing-library
+
+# Playwright (experimental)
+./docker.sh playwright                        # whole suite
+./docker.sh playwright tests/admin/revocation # one feature
+./docker.sh playwright -g "submits"           # by test-name regex
+```
+
+The Playwright runner auto-installs Node deps + Chromium on first run.
+
+## Adding tests
+
+- **Bug fixes / regressions on existing features** that the Codeception
+  suite already covers → add a Codeception test next to the existing
+  ones (Stable suite).
+- **New features and anything net-new** → write the Playwright spec.
+  When the Playwright suite reaches the bar above, the existing
+  Codeception tests will be migrated and this README updated.

--- a/tests/Acceptance/playwright/.gitignore
+++ b/tests/Acceptance/playwright/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+test-results/
+playwright-report/
+blob-report/
+.auth/
+*.log
+*.tsbuildinfo

--- a/tests/Acceptance/playwright/README.md
+++ b/tests/Acceptance/playwright/README.md
@@ -1,0 +1,124 @@
+# O3-Shop Playwright Tests
+
+End-to-end browser tests for O3-Shop CE using **Playwright + TypeScript**.
+
+This is the new browser-test infrastructure being built in parallel to the
+existing Codeception/Selenium suite at `tests/Acceptance/`. The Codeception
+suite will be retired once Playwright coverage is sufficient.
+
+## Quick start
+
+```bash
+cd tests/Acceptance/playwright
+npm install
+npm run install-browsers
+npm test
+```
+
+You need the shop running first — `./docker.sh start` from the repo root.
+
+## Directory layout
+
+```
+tests/Acceptance/playwright/
+├── package.json              # Node deps (Playwright, mysql2, TS)
+├── playwright.config.ts      # test runner config
+├── tsconfig.json
+├── globalSetup.ts            # pre-flight credential check (fail fast)
+├── fixtures/                 # Playwright test fixtures
+│   ├── index.ts              # composed `test` export — import this in specs
+│   ├── auth.ts               # admin / customer auth contexts (per-test login)
+│   ├── mailpit.ts            # Mailpit REST client (read + clear inbox)
+│   └── db.ts                 # mysql2 client + revocation row helpers
+├── helpers/                  # non-fixture utilities
+│   ├── urls.ts               # canonical admin / storefront URLs
+│   └── config.ts             # set/reset oxconfig values via DB
+├── pages/                    # Page Object Models — mirror the surface
+│   ├── admin/
+│   │   ├── BaseAdminPage.ts
+│   │   └── LoginPage.ts
+│   └── storefront/
+│       └── BaseStorefrontPage.ts
+└── tests/                    # specs — directory mirrors `pages/`
+    └── smoke.spec.ts         # pipeline-validation test
+```
+
+When new feature tests land:
+
+- New POMs go in `pages/admin/<feature>/` or `pages/storefront/<feature>/`.
+- Specs go in `tests/admin/<feature>/` or `tests/storefront/<feature>/`,
+  one `*.spec.ts` per surface under that feature.
+- New fixtures (e.g. for a feature-specific seed) go in `fixtures/`,
+  composed into the `test` export in `fixtures/index.ts`.
+
+## Running
+
+| Command | What it does |
+|---|---|
+| `npm test` | Run all specs, headless |
+| `npm run test:ui` | Open Playwright UI mode (great for picking single tests) |
+| `npm run test:headed` | Run headless=false so you can watch the browser |
+| `npm run test:debug` | Step through with the Playwright Inspector |
+| `npm run report` | Open the last HTML report |
+| `npm run codegen` | Generate test code by clicking around the shop |
+
+Filter examples:
+
+```bash
+npm test -- tests/admin/revocation/        # only one folder
+npm test -- -g "submits successfully"      # by test name
+npm test -- --headed --workers=1           # interactive single-runner
+```
+
+## Environment variables
+
+| Var | Default | Purpose |
+|---|---|---|
+| `SHOP_URL` | `http://localhost:8080` | Storefront base URL |
+| `ADMIN_USER` | `admin@example.com` | Admin login (used by globalSetup) |
+| `ADMIN_PASS` | `admin123` | Admin password |
+| `MAILPIT_URL` | `http://localhost:8025` | Mailpit base URL for the REST API |
+| `DB_HOST` | `127.0.0.1` | MySQL host |
+| `DB_PORT` | `3306` | MySQL port (mapped from the docker mariadb service) |
+| `DB_USER` | `root` | MySQL user |
+| `DB_PASS` | `supersecret` | MySQL password (matches `docker/.env` `O3SHOP_CONF_DBROOT`) |
+| `DB_NAME` | `o3shop` | OXID database name (matches `docker/.env` `O3SHOP_CONF_DBNAME`) |
+
+## Conventions
+
+- **Selectors live in Page Object classes** under `pages/` — never inline in
+  specs. POM methods are imperative (`fillName()`, `clickResend()`) or
+  return locators (`get nameInput()`).
+- **Tests clean up after themselves**. Seed via `db` fixture, delete by
+  OXID at the end. No global truncate.
+- **Mailpit** is reset between tests (the `mailpit` fixture handles this).
+- **Form-input-preservation invariant**: when a server-side validation
+  rejects a submit, assert that the user's submitted values are still in
+  the form on the re-render — never make the user re-type.
+- **Graceful-degradation invariant**: storefront flows must not break on
+  missing assets — assert fallback behaviour, not error pages.
+
+## Adding a new test surface
+
+1. Pick the surface (admin / storefront), pick the feature.
+2. Create `pages/<surface>/<feature>/<Thing>Page.ts` extending the relevant
+   base page object. Encapsulate every selector + interaction here.
+3. Create `tests/<surface>/<feature>/<thing>.spec.ts` with `test.describe`
+   blocks per behaviour.
+4. If you need a new fixture (DB seeder, external service stub), add it
+   under `fixtures/` and re-export the composed `test` from
+   `fixtures/index.ts`.
+
+## Troubleshooting
+
+- **globalSetup fails with "admin login failed"**: the shop is up but the
+  admin credentials don't work. Check `ADMIN_USER` / `ADMIN_PASS` and the
+  shop install state.
+- **globalSetup hangs**: shop isn't reachable at `SHOP_URL`. Run
+  `./docker.sh start` and curl the URL manually.
+- **`Cannot find module 'mysql2'`**: run `npm install`.
+- **Browser binary missing**: run `npm run install-browsers`.
+- **Why a fresh login on every admin test?** OXID admin sessions use a
+  per-request stoken plus a `force_admin_sid` URL param emitted at login
+  time; cookie storageState alone gets rejected by the next request. The
+  existing Codeception suite logs in fresh per test for the same reason.

--- a/tests/Acceptance/playwright/fixtures/auth.ts
+++ b/tests/Acceptance/playwright/fixtures/auth.ts
@@ -1,0 +1,57 @@
+import { test as base, BrowserContext, Page } from '@playwright/test';
+
+const ADMIN_USER = process.env.ADMIN_USER ?? 'admin@example.com';
+const ADMIN_PASS = process.env.ADMIN_PASS ?? 'admin123';
+
+export interface AuthFixtures {
+  /** A page already authenticated as the shop admin. */
+  adminPage: Page;
+  /** An unauthenticated storefront page. */
+  storefrontPage: Page;
+  /** A long-lived admin browser context (rare — most tests want adminPage). */
+  adminContext: BrowserContext;
+}
+
+/**
+ * OXID admin sessions bind security tokens to a single browser session and
+ * a sequence of redirects after `checklogin` (the cookie alone is not
+ * sufficient — see the existing Codeception suite which logs in fresh per
+ * test). For that reason this fixture performs a real login per test.
+ *
+ * Cost: ~1.5–2 s per admin test. Worth it for reliability; if the suite
+ * grows past ~50 admin tests, revisit storageState + a session-anchoring
+ * navigation.
+ */
+export const test = base.extend<AuthFixtures>({
+  adminContext: async ({ browser }, use) => {
+    const ctx = await browser.newContext();
+    await use(ctx);
+    await ctx.close();
+  },
+
+  adminPage: async ({ adminContext, baseURL }, use) => {
+    if (!baseURL) {
+      throw new Error('adminPage fixture: baseURL is not configured.');
+    }
+
+    const page = await adminContext.newPage();
+    await page.goto(`${baseURL}/admin/`, { waitUntil: 'domcontentloaded' });
+    await page.locator('#usr').fill(ADMIN_USER);
+    await page.locator('#pwd').fill(ADMIN_PASS);
+    await Promise.all([
+      page.waitForLoadState('domcontentloaded'),
+      page.locator('form#login input[type="submit"]').click(),
+    ]);
+    await page.waitForSelector('frame[name="basefrm"]', { timeout: 10_000 });
+
+    await use(page);
+    await page.close();
+  },
+
+  storefrontPage: async ({ browser }, use) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await use(page);
+    await ctx.close();
+  },
+});

--- a/tests/Acceptance/playwright/fixtures/db.ts
+++ b/tests/Acceptance/playwright/fixtures/db.ts
@@ -1,0 +1,115 @@
+import mysql, { Pool, RowDataPacket } from 'mysql2/promise';
+
+export interface DbConfig {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  database: string;
+}
+
+export const DEFAULT_DB_CONFIG: DbConfig = {
+  host: process.env.DB_HOST ?? '127.0.0.1',
+  port: Number(process.env.DB_PORT ?? 3306),
+  user: process.env.DB_USER ?? 'root',
+  password: process.env.DB_PASS ?? 'supersecret',
+  database: process.env.DB_NAME ?? 'o3shop',
+};
+
+export class DbClient {
+  private readonly pool: Pool;
+
+  constructor(config: DbConfig = DEFAULT_DB_CONFIG) {
+    this.pool = mysql.createPool({
+      ...config,
+      waitForConnections: true,
+      connectionLimit: 5,
+      queueLimit: 0,
+    });
+  }
+
+  async query<T = RowDataPacket>(sql: string, params: unknown[] = []): Promise<T[]> {
+    const [rows] = await this.pool.query<RowDataPacket[]>(sql, params);
+    return rows as T[];
+  }
+
+  async execute(sql: string, params: unknown[] = []): Promise<void> {
+    await this.pool.execute(sql, params);
+  }
+
+  async close(): Promise<void> {
+    await this.pool.end();
+  }
+
+  /**
+   * Insert a synthetic revocation row for tests that need pre-existing
+   * data. Caller is responsible for cleaning up via `deleteRevocation`.
+   */
+  async seedRevocation(input: {
+    oxid?: string;
+    shopId?: number;
+    lang?: number;
+    name: string;
+    orderIdent: string;
+    email: string;
+    freeText?: string;
+    submittedAt?: Date;
+    sendFailed?: boolean;
+  }): Promise<string> {
+    const oxid = input.oxid ?? cryptoRandom();
+    const submittedAt = input.submittedAt ?? new Date();
+    await this.execute(
+      `INSERT INTO o3revocation
+         (OXID, OXSHOPID, OXLANG, OXSUBMITTED, OXNAME, OXORDERIDENT, OXEMAIL, OXFREETEXT, OXSENDFAILED)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        oxid,
+        input.shopId ?? 1,
+        input.lang ?? 0,
+        submittedAt,
+        input.name,
+        input.orderIdent,
+        input.email,
+        input.freeText ?? null,
+        input.sendFailed ? 1 : 0,
+      ],
+    );
+    return oxid;
+  }
+
+  async findRevocationByOrderIdent(orderIdent: string): Promise<string | null> {
+    const rows = await this.query<{ OXID: string }>(
+      `SELECT OXID FROM o3revocation WHERE OXORDERIDENT = ? ORDER BY OXSUBMITTED DESC LIMIT 1`,
+      [orderIdent],
+    );
+    return rows[0]?.OXID ?? null;
+  }
+
+  async readRevocationFlags(oxid: string): Promise<{ sendFailed: number; submitted: Date } | null> {
+    const rows = await this.query<{ OXSENDFAILED: number; OXSUBMITTED: Date }>(
+      `SELECT OXSENDFAILED, OXSUBMITTED FROM o3revocation WHERE OXID = ? LIMIT 1`,
+      [oxid],
+    );
+    const row = rows[0];
+    if (!row) return null;
+    return { sendFailed: row.OXSENDFAILED, submitted: row.OXSUBMITTED };
+  }
+
+  async deleteRevocation(oxid: string): Promise<void> {
+    await this.execute(`DELETE FROM o3revocation WHERE OXID = ?`, [oxid]);
+  }
+
+  async revocationExists(oxid: string): Promise<boolean> {
+    const rows = await this.query<{ c: number }>(
+      `SELECT COUNT(*) AS c FROM o3revocation WHERE OXID = ?`,
+      [oxid],
+    );
+    return (rows[0]?.c ?? 0) > 0;
+  }
+}
+
+function cryptoRandom(): string {
+  return [...crypto.getRandomValues(new Uint8Array(16))]
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/tests/Acceptance/playwright/fixtures/index.ts
+++ b/tests/Acceptance/playwright/fixtures/index.ts
@@ -1,0 +1,30 @@
+import { test as authTest, AuthFixtures } from './auth';
+import { MailpitClient } from './mailpit';
+import { DbClient } from './db';
+
+export interface ServiceFixtures {
+  /** Mailpit client; inbox is cleared before each test. */
+  mailpit: MailpitClient;
+  /** Long-lived MySQL pool; closed at worker teardown. */
+  db: DbClient;
+}
+
+export const test = authTest.extend<ServiceFixtures>({
+  mailpit: async ({}, use) => {
+    const client = new MailpitClient();
+    await client.clearInbox();
+    await use(client);
+  },
+
+  db: [
+    async ({}, use) => {
+      const client = new DbClient();
+      await use(client);
+      await client.close();
+    },
+    { scope: 'worker' },
+  ],
+});
+
+export { expect } from '@playwright/test';
+export type { AuthFixtures, MailpitClient, DbClient };

--- a/tests/Acceptance/playwright/fixtures/mailpit.ts
+++ b/tests/Acceptance/playwright/fixtures/mailpit.ts
@@ -1,0 +1,76 @@
+const MAILPIT_URL = process.env.MAILPIT_URL ?? 'http://localhost:8025';
+
+export interface MailpitMessage {
+  ID: string;
+  From: { Name: string; Address: string };
+  To: { Name: string; Address: string }[];
+  Subject: string;
+  Created: string;
+  Snippet: string;
+}
+
+export interface MailpitSearchOptions {
+  to?: string;
+  subject?: string;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}
+
+export class MailpitClient {
+  constructor(private readonly baseURL: string = MAILPIT_URL) {}
+
+  async clearInbox(): Promise<void> {
+    const res = await fetch(`${this.baseURL}/api/v1/messages`, { method: 'DELETE' });
+    if (!res.ok) {
+      throw new Error(`Mailpit clearInbox failed: ${res.status} ${res.statusText}`);
+    }
+  }
+
+  async listMessages(): Promise<MailpitMessage[]> {
+    const res = await fetch(`${this.baseURL}/api/v1/messages`);
+    if (!res.ok) {
+      throw new Error(`Mailpit listMessages failed: ${res.status} ${res.statusText}`);
+    }
+    const body = (await res.json()) as { messages?: MailpitMessage[] };
+    return body.messages ?? [];
+  }
+
+  async getMessageBody(id: string): Promise<{ html: string; text: string }> {
+    const res = await fetch(`${this.baseURL}/api/v1/message/${id}`);
+    if (!res.ok) {
+      throw new Error(`Mailpit getMessageBody failed: ${res.status} ${res.statusText}`);
+    }
+    const body = (await res.json()) as { HTML?: string; Text?: string };
+    return { html: body.HTML ?? '', text: body.Text ?? '' };
+  }
+
+  /**
+   * Poll the inbox until a message matching the given filter arrives, or
+   * the timeout expires. Throws if no match is found in time.
+   */
+  async waitForMessage(opts: MailpitSearchOptions = {}): Promise<MailpitMessage> {
+    const timeout = opts.timeoutMs ?? 10_000;
+    const interval = opts.pollIntervalMs ?? 250;
+    const deadline = Date.now() + timeout;
+
+    while (Date.now() < deadline) {
+      const messages = await this.listMessages();
+      const match = messages.find((m) => {
+        if (opts.to && !m.To.some((t) => t.Address.toLowerCase() === opts.to!.toLowerCase())) {
+          return false;
+        }
+        if (opts.subject && !m.Subject.includes(opts.subject)) {
+          return false;
+        }
+        return true;
+      });
+      if (match) {
+        return match;
+      }
+      await new Promise((r) => setTimeout(r, interval));
+    }
+    throw new Error(
+      `Mailpit waitForMessage timed out after ${timeout}ms. Filter: ${JSON.stringify(opts)}`,
+    );
+  }
+}

--- a/tests/Acceptance/playwright/globalSetup.ts
+++ b/tests/Acceptance/playwright/globalSetup.ts
@@ -1,0 +1,44 @@
+import { chromium, FullConfig } from '@playwright/test';
+
+const ADMIN_USER = process.env.ADMIN_USER ?? 'admin@example.com';
+const ADMIN_PASS = process.env.ADMIN_PASS ?? 'admin123';
+
+/**
+ * Pre-flight credential check. We do **not** persist storageState —
+ * OXID's admin session-token model means storageState alone isn't enough
+ * to skip the per-test login (see `fixtures/auth.ts` for rationale). This
+ * setup just fails fast with a clear error if admin credentials are wrong
+ * before any spec runs.
+ */
+export default async function globalSetup(config: FullConfig): Promise<void> {
+  const baseURL = config.projects[0]?.use.baseURL;
+  if (!baseURL) {
+    throw new Error('globalSetup: baseURL is not configured.');
+  }
+
+  const browser = await chromium.launch();
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await page.goto(`${baseURL}/admin/`, { waitUntil: 'domcontentloaded' });
+    await page.locator('#usr').fill(ADMIN_USER);
+    await page.locator('#pwd').fill(ADMIN_PASS);
+    await Promise.all([
+      page.waitForLoadState('domcontentloaded'),
+      page.locator('form#login input[type="submit"]').click(),
+    ]);
+
+    const stillOnLogin = await page.locator('#usr').count();
+    if (stillOnLogin > 0) {
+      throw new Error(
+        `globalSetup: admin login failed for '${ADMIN_USER}'. ` +
+          `The login form is still visible after submit. ` +
+          `Check ADMIN_USER / ADMIN_PASS env vars (or shop reachability at ${baseURL}).`,
+      );
+    }
+    await page.waitForSelector('frame[name="basefrm"]', { timeout: 10_000 });
+  } finally {
+    await browser.close();
+  }
+}

--- a/tests/Acceptance/playwright/helpers/config.ts
+++ b/tests/Acceptance/playwright/helpers/config.ts
@@ -1,0 +1,103 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { DbClient } from '../fixtures/db';
+
+/**
+ * Path to the host-mounted OXID file cache (matches the docker-compose
+ * bind mount). Override via OXID_TMP_DIR if testing against a
+ * differently-arranged install.
+ */
+const OXID_TMP_DIR =
+  process.env.OXID_TMP_DIR ?? path.join(__dirname, '..', '..', '..', '..', 'source', 'tmp');
+
+/**
+ * Clear the revocation anti-spam file cache. The default
+ * `NoopAntiSpamService` writes per-IP rate-limit counters to OXID's tmp
+ * cache (`oxc_o3rev_antispam_{f,s}_<hash>.txt`). One success locks the
+ * IP out for 5 minutes; one set of failures hits the threshold within a
+ * minute. Both make a multi-test browser suite unrunnable. Tests call
+ * this helper in `beforeEach` to start each scenario with a clean slate.
+ */
+export async function clearRevocationAntiSpamCache(): Promise<void> {
+  const dir = path.resolve(OXID_TMP_DIR);
+  let files: string[];
+  try {
+    files = await fs.readdir(dir);
+  } catch {
+    // tmp dir absent in this layout — nothing to clean.
+    return;
+  }
+  await Promise.all(
+    files
+      .filter((name) => /^oxc_o3rev_antispam_/.test(name))
+      .map((name) => fs.rm(path.join(dir, name), { force: true })),
+  );
+}
+
+// oxconfig.OXSHOPID is INT — owning shop ID. Single-shop CE uses 1.
+const OXSHOPID = 1;
+
+export type OxConfigType = 'bool' | 'str' | 'int' | 'arr' | 'aarr';
+
+export interface OxConfigEntry {
+  name: string;
+  type: OxConfigType;
+  value: string;
+}
+
+/**
+ * Read a single oxconfig entry. As of migration `Version20230322213324`
+ * (March 2023), OXVARVALUE is plain TEXT — no DECODE() needed.
+ */
+export async function readConfigVar(db: DbClient, name: string): Promise<string | null> {
+  const rows = await db.query<{ oxvarvalue: string }>(
+    `SELECT oxvarvalue FROM oxconfig WHERE oxshopid = ? AND oxvarname = ? LIMIT 1`,
+    [OXSHOPID, name],
+  );
+  return rows[0]?.oxvarvalue ?? null;
+}
+
+/**
+ * Set the four revocation oxconfig keys atomically — used by tests that
+ * need a known starting state. Pass undefined to leave a key untouched.
+ */
+export interface RevocationConfigInput {
+  blShowRevocationForm?: boolean;
+  blRevocationRequireLogin?: boolean;
+  blRevocationNotifyOperator?: boolean;
+  sRevocationOperatorEmail?: string;
+}
+
+export async function writeRevocationConfig(
+  db: DbClient,
+  input: RevocationConfigInput,
+): Promise<void> {
+  const entries: OxConfigEntry[] = [];
+  if (input.blShowRevocationForm !== undefined) {
+    entries.push({ name: 'blShowRevocationForm', type: 'bool', value: input.blShowRevocationForm ? '1' : '0' });
+  }
+  if (input.blRevocationRequireLogin !== undefined) {
+    entries.push({ name: 'blRevocationRequireLogin', type: 'bool', value: input.blRevocationRequireLogin ? '1' : '0' });
+  }
+  if (input.blRevocationNotifyOperator !== undefined) {
+    entries.push({ name: 'blRevocationNotifyOperator', type: 'bool', value: input.blRevocationNotifyOperator ? '1' : '0' });
+  }
+  if (input.sRevocationOperatorEmail !== undefined) {
+    entries.push({ name: 'sRevocationOperatorEmail', type: 'str', value: input.sRevocationOperatorEmail });
+  }
+
+  for (const entry of entries) {
+    await db.query(
+      `DELETE FROM oxconfig WHERE oxshopid = ? AND oxvarname = ?`,
+      [OXSHOPID, entry.name],
+    );
+    // oxconfig.OXID is CHAR(32); UUID() returns 36 chars w/ hyphens. Strip
+    // them — matches what UtilsObject::generateUID() produces. OXVARVALUE
+    // is plain TEXT post-2023 migration (Version20230322213324).
+    await db.query(
+      `INSERT INTO oxconfig (oxid, oxshopid, oxvarname, oxvartype, oxvarvalue)
+       VALUES (REPLACE(UUID(), '-', ''), ?, ?, ?, ?)`,
+      [OXSHOPID, entry.name, entry.type, entry.value],
+    );
+  }
+}

--- a/tests/Acceptance/playwright/helpers/urls.ts
+++ b/tests/Acceptance/playwright/helpers/urls.ts
@@ -1,0 +1,22 @@
+export const adminCl = (cl: string, params: Record<string, string> = {}): string => {
+  const search = new URLSearchParams({ cl, ...params });
+  return `/admin/index.php?${search.toString()}`;
+};
+
+export const storefrontCl = (cl: string, params: Record<string, string> = {}): string => {
+  const search = new URLSearchParams({ cl, ...params });
+  return `/index.php?${search.toString()}`;
+};
+
+export const URLS = {
+  adminLogin: '/admin/',
+  adminHome: '/admin/',
+  storefrontHome: '/',
+
+  adminRevocationList: adminCl('admin_revocation'),
+  adminRevocationConfig: adminCl('revocation_config'),
+  adminRevocationDetail: (oxid: string) => adminCl('revocation_main', { oxid }),
+
+  storefrontRevocation: storefrontCl('revocation'),
+  storefrontRevocationReceipt: storefrontCl('revocation', { fnc: 'receipt' }),
+} as const;

--- a/tests/Acceptance/playwright/package-lock.json
+++ b/tests/Acceptance/playwright/package-lock.json
@@ -1,0 +1,248 @@
+{
+  "name": "@o3-shop/playwright-tests",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@o3-shop/playwright-tests",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.50.0",
+        "@types/node": "^20.0.0",
+        "mysql2": "^3.11.0",
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/mysql2": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.3.tgz",
+      "integrity": "sha512-uWWxvZSRvRhtBdh2CdcuK83YcOfPdmEeEYB069bAmPnV93QApDGVPuvCQOLjlh7tYHEWdgQPrn6kosDxHBVLkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.2",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.2",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.4",
+        "named-placeholders": "^1.1.6",
+        "sql-escaper": "^1.3.3"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sql-escaper": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.3.tgz",
+      "integrity": "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/tests/Acceptance/playwright/package.json
+++ b/tests/Acceptance/playwright/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@o3-shop/playwright-tests",
+  "version": "0.0.0",
+  "private": true,
+  "description": "End-to-end browser tests for O3-Shop CE using Playwright + TypeScript.",
+  "scripts": {
+    "test": "playwright test",
+    "test:ui": "playwright test --ui",
+    "test:headed": "playwright test --headed",
+    "test:debug": "playwright test --debug",
+    "report": "playwright show-report",
+    "codegen": "playwright codegen http://localhost:8080",
+    "install-browsers": "playwright install chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.0",
+    "@types/node": "^20.0.0",
+    "mysql2": "^3.11.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/tests/Acceptance/playwright/pages/admin/BaseAdminPage.ts
+++ b/tests/Acceptance/playwright/pages/admin/BaseAdminPage.ts
@@ -1,0 +1,33 @@
+import { Page, Locator } from '@playwright/test';
+
+/**
+ * Base for every admin Page Object. The OXID admin uses a top frameset:
+ *
+ *   - frame `navigation` → child frame `adminnav` → menu DOM
+ *   - frame `basefrm`    → content DOM (forms, lists, detail views)
+ *
+ * Concrete page objects should reach into the right frame via the helpers
+ * here rather than dealing with frame-locator plumbing inline.
+ */
+export abstract class BaseAdminPage {
+  constructor(protected readonly page: Page) {}
+
+  /** Locator scoped to the admin content frame (`basefrm`). */
+  protected get content(): Locator {
+    return this.page.frameLocator('frame[name="basefrm"]').locator('body');
+  }
+
+  /** Locator scoped to the admin menu frame (`navigation > adminnav`). */
+  protected get menu(): Locator {
+    return this.page
+      .frameLocator('frame[name="navigation"]')
+      .frameLocator('frame[name="adminnav"]')
+      .locator('body');
+  }
+
+  /** Wait for the admin frameset to settle after navigation. */
+  async waitForReady(): Promise<void> {
+    await this.page.waitForLoadState('domcontentloaded');
+    await this.page.waitForSelector('frame[name="basefrm"]');
+  }
+}

--- a/tests/Acceptance/playwright/pages/admin/LoginPage.ts
+++ b/tests/Acceptance/playwright/pages/admin/LoginPage.ts
@@ -1,0 +1,25 @@
+import { Page } from '@playwright/test';
+import { URLS } from '../../helpers/urls';
+
+/**
+ * Admin login. In normal test runs the admin is already authenticated via
+ * `globalSetup.ts` + storageState — this Page Object is for tests that
+ * explicitly cover the login flow itself (or that intentionally start
+ * unauthenticated).
+ */
+export class AdminLoginPage {
+  constructor(private readonly page: Page) {}
+
+  async goto(): Promise<void> {
+    await this.page.goto(URLS.adminLogin, { waitUntil: 'domcontentloaded' });
+  }
+
+  async login(user: string, password: string): Promise<void> {
+    await this.page.locator('#usr').fill(user);
+    await this.page.locator('#pwd').fill(password);
+    await Promise.all([
+      this.page.waitForLoadState('domcontentloaded'),
+      this.page.locator('form#login input[type="submit"]').click(),
+    ]);
+  }
+}

--- a/tests/Acceptance/playwright/pages/admin/revocation/ConfigPage.ts
+++ b/tests/Acceptance/playwright/pages/admin/revocation/ConfigPage.ts
@@ -1,0 +1,95 @@
+import { Page, Locator, expect } from '@playwright/test';
+import { BaseAdminPage } from '../BaseAdminPage';
+
+/**
+ * POM for the admin "Revocations → Settings" form (cl=revocation_config).
+ *
+ * Navigating the top-level page to the controller URL renders the form
+ * markup directly (the OXID frameset only wraps the admin "home" view).
+ * Selectors are top-level — no frame plumbing.
+ */
+export class AdminRevocationConfigPage extends BaseAdminPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async goto(): Promise<void> {
+    const stoken = await this.extractStoken();
+    await this.page.goto(
+      `/admin/index.php?cl=revocation_config&stoken=${stoken}`,
+      { waitUntil: 'domcontentloaded' },
+    );
+  }
+
+  /**
+   * Read the stoken from the admin nav frame. The adminPage fixture
+   * leaves the page on the framed admin home, where every nav link
+   * carries a `stoken=` query param. We need it for any subsequent
+   * top-level admin navigation in the same session.
+   */
+  private async extractStoken(): Promise<string> {
+    const navFrame = this.page
+      .frameLocator('frame[name="navigation"]')
+      .frameLocator('frame[name="adminnav"]');
+    const link = await navFrame.locator('a[href*="stoken="]').first().getAttribute('href');
+    const match = link?.match(/stoken=([A-Za-z0-9]+)/);
+    if (!match) {
+      throw new Error('AdminRevocationConfigPage: could not extract stoken from admin nav.');
+    }
+    return match[1] ?? '';
+  }
+
+  get form(): Locator {
+    return this.page.locator('#myedit');
+  }
+
+  get showRevocationFormCheckbox(): Locator {
+    return this.page.locator('input[name="blShowRevocationForm"]');
+  }
+
+  get requireLoginCheckbox(): Locator {
+    return this.page.locator('input[name="blRevocationRequireLogin"]');
+  }
+
+  get notifyOperatorCheckbox(): Locator {
+    return this.page.locator('input[name="blRevocationNotifyOperator"]');
+  }
+
+  get operatorEmailInput(): Locator {
+    return this.page.locator('#sRevocationOperatorEmail');
+  }
+
+  get operatorEmailError(): Locator {
+    return this.page.locator('#o3rev_operator_email_err');
+  }
+
+  get missingAssetsBlock(): Locator {
+    return this.page.locator('.errorbox[role="alert"]');
+  }
+
+  get saveButton(): Locator {
+    return this.page.locator('form#myedit input[type="submit"]');
+  }
+
+  async setCheckbox(locator: Locator, checked: boolean): Promise<void> {
+    const isChecked = await locator.isChecked();
+    if (isChecked !== checked) {
+      await locator.click();
+    }
+  }
+
+  async submit(): Promise<void> {
+    // Bypass browser-side HTML5 validation. The operator email input is
+    // `type="email"` with no `novalidate` on the form, so a malformed
+    // value would trigger a browser tooltip and block submission —
+    // hiding the SERVER-SIDE cross-field rule we're trying to exercise.
+    // Calling the native HTMLFormElement.submit() skips constraint
+    // validation and event handlers entirely.
+    await this.form.evaluate((f) => (f as HTMLFormElement).submit());
+    await this.page.waitForLoadState('networkidle', { timeout: 15_000 });
+  }
+
+  async expectFormVisible(): Promise<void> {
+    await expect(this.form).toHaveCount(1);
+  }
+}

--- a/tests/Acceptance/playwright/pages/admin/revocation/DetailPage.ts
+++ b/tests/Acceptance/playwright/pages/admin/revocation/DetailPage.ts
@@ -1,0 +1,98 @@
+import { Page, Locator, expect } from '@playwright/test';
+import { BaseAdminPage } from '../BaseAdminPage';
+
+/**
+ * POM for the admin revocation detail view (cl=revocation_main).
+ *
+ * Like ConfigPage, we navigate top-level — `revocation_main.tpl` renders
+ * directly without the OXID frameset, so selectors are at page level.
+ */
+export class AdminRevocationDetailPage extends BaseAdminPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async goto(oxid: string): Promise<void> {
+    const stoken = await this.extractStoken();
+    await this.page.goto(
+      `/admin/index.php?cl=revocation_main&oxid=${encodeURIComponent(oxid)}&stoken=${stoken}`,
+      { waitUntil: 'domcontentloaded' },
+    );
+  }
+
+  private async extractStoken(): Promise<string> {
+    const navFrame = this.page
+      .frameLocator('frame[name="navigation"]')
+      .frameLocator('frame[name="adminnav"]');
+    const link = await navFrame.locator('a[href*="stoken="]').first().getAttribute('href');
+    const match = link?.match(/stoken=([A-Za-z0-9]+)/);
+    if (!match) {
+      throw new Error('AdminRevocationDetailPage: could not extract stoken from admin nav.');
+    }
+    return match[1] ?? '';
+  }
+
+  get editForm(): Locator {
+    return this.page.locator('form#myedit');
+  }
+
+  get oxidCell(): Locator {
+    // First <code> in the detail table holds the OXID.
+    return this.page.locator('form#myedit code').first();
+  }
+
+  get submittedCell(): Locator {
+    // Row 2 of the table — by position; relies on the canonical layout
+    // documented in revocation_main.tpl. If the layout changes, this
+    // selector needs updating in lockstep.
+    return this.page.locator('form#myedit table tr').nth(1).locator('td.edittext').nth(1);
+  }
+
+  get nameCell(): Locator {
+    return this.page.locator('form#myedit table tr').nth(2).locator('td.edittext').nth(1);
+  }
+
+  get orderIdentCell(): Locator {
+    return this.page.locator('form#myedit table tr').nth(3).locator('td.edittext').nth(1);
+  }
+
+  get emailLink(): Locator {
+    return this.page.locator('form#myedit a[href^="mailto:"]');
+  }
+
+  get freeTextCell(): Locator {
+    return this.page.locator('form#myedit pre').first();
+  }
+
+  /** Either the "sent" status or the "errorbox" badge. */
+  get statusCell(): Locator {
+    return this.page
+      .locator('form#myedit table tr')
+      .last()
+      .locator('td.edittext')
+      .last();
+  }
+
+  get sendFailedBadge(): Locator {
+    return this.statusCell.locator('span.errorbox');
+  }
+
+  get resendButton(): Locator {
+    return this.page.locator('form#myedit input[type="submit"][onClick*="resend"]');
+  }
+
+  get deleteButton(): Locator {
+    return this.page.locator('form#myedit input[type="button"][onClick*="deleteThis"]');
+  }
+
+  async clickResend(): Promise<void> {
+    await Promise.all([
+      this.page.waitForLoadState('domcontentloaded'),
+      this.resendButton.click(),
+    ]);
+  }
+
+  async expectDetailVisible(): Promise<void> {
+    await expect(this.editForm).toHaveCount(1);
+  }
+}

--- a/tests/Acceptance/playwright/pages/storefront/BaseStorefrontPage.ts
+++ b/tests/Acceptance/playwright/pages/storefront/BaseStorefrontPage.ts
@@ -1,0 +1,30 @@
+import { Page } from '@playwright/test';
+
+/**
+ * Base for every storefront Page Object. The storefront has no frames, so
+ * helpers are simpler than `BaseAdminPage`.
+ */
+export abstract class BaseStorefrontPage {
+  constructor(protected readonly page: Page) {}
+
+  async waitForReady(): Promise<void> {
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  /**
+   * Force OXID to create a session **before** the form GET that the test
+   * needs. OXID's storefront sessions are lazy — pure GETs don't start
+   * one, so `getHiddenSid()` renders no `stoken` input. Submitting such
+   * a form trips `checkSessionChallenge()`, which the controller surfaces
+   * as `O3_REVOCATION_VALIDATION_SESSION_EXPIRED`.
+   *
+   * A POST to any write action triggers session start. We navigate the
+   * page itself (rather than `page.request.post`) so the resulting
+   * cookies attach to the page's storage state cleanly — `request.post`
+   * sometimes leaves the page context one transition behind.
+   * `aid=__warmup__` never resolves, so the basket stays empty.
+   */
+  protected async warmupSession(): Promise<void> {
+    await this.page.request.post('/index.php?cl=start&fnc=tobasket&aid=__warmup__');
+  }
+}

--- a/tests/Acceptance/playwright/pages/storefront/checkout/PaymentPage.ts
+++ b/tests/Acceptance/playwright/pages/storefront/checkout/PaymentPage.ts
@@ -43,20 +43,20 @@ export class CheckoutPaymentPage extends BaseStorefrontPage {
     );
     await this.page.goto('/index.php?cl=user', { waitUntil: 'domcontentloaded' });
 
-    // Click "Continue without registration" (option=3 form).
+    // Click "Without registration" / guest checkout. In o3-theme the
+    // option semantics are inverted from standard OXID: `option=3` is
+    // "Open Account" (full registration, password required) and
+    // `option=1` is the no-password guest flow that creates a passwordless
+    // account record. We want the latter.
     await this.page
-      .locator('form input[name="option"][value="3"]')
+      .locator('form input[name="option"][value="1"]')
       .first()
       .evaluate((input) => (input as HTMLInputElement).form?.submit());
     await this.page.waitForLoadState('domcontentloaded');
 
-    // Fill the minimal billing address. The o3-theme user step's
-    // "continue without registration" form (option=3) actually creates
-    // a customer account on submit, so a password + confirm is also
-    // required even though the wording suggests guest checkout.
+    // Fill the minimal billing address. No password fields render on the
+    // option=1 path — this is the guest checkout.
     await this.page.locator('input[name="lgn_usr"]').first().fill(address.email);
-    await this.page.locator('input[name="lgn_pwd"]').first().fill('TestPassword2026!');
-    await this.page.locator('input[name="lgn_pwd2"]').first().fill('TestPassword2026!');
     await this.page.locator('input[name="invadr[oxuser__oxfname]"]').fill(address.firstName);
     await this.page.locator('input[name="invadr[oxuser__oxlname]"]').fill(address.lastName);
     await this.page.locator('input[name="invadr[oxuser__oxstreet]"]').fill(address.street);

--- a/tests/Acceptance/playwright/pages/storefront/checkout/PaymentPage.ts
+++ b/tests/Acceptance/playwright/pages/storefront/checkout/PaymentPage.ts
@@ -1,0 +1,140 @@
+import { Page, Locator, expect } from '@playwright/test';
+import { BaseStorefrontPage } from '../BaseStorefrontPage';
+
+export interface GuestCheckoutAddress {
+  email: string;
+  firstName: string;
+  lastName: string;
+  street: string;
+  streetNo: string;
+  zip: string;
+  city: string;
+  /** OXID country ID. Default: Germany (`a7c40f631fc920687.20179984`). */
+  countryId?: string;
+}
+
+const DEFAULT_COUNTRY_ID = 'a7c40f631fc920687.20179984'; // Germany
+
+/**
+ * POM for the storefront checkout payment page (cl=payment), with helpers
+ * to drive the checkout flow up to that step from a fresh session.
+ *
+ * Used by the issue-#116 regression test: bank-detail fields under the
+ * `oxiddebitnote` (Lastschrift) payment method must be disabled whenever
+ * a different payment method is selected, so unrelated submissions are
+ * not blocked by HTML5 `required` validation on hidden fields. The
+ * `payment-toggle.js` widget in o3-theme implements that behaviour.
+ */
+export class CheckoutPaymentPage extends BaseStorefrontPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Drive the checkout flow as a guest from a fresh session through to
+   * the payment step. Adds `productId × qty`, completes the user step
+   * with the supplied billing address, and lands on `cl=payment`.
+   */
+  async setupAndGoto(productId: string, address: GuestCheckoutAddress): Promise<void> {
+    // The /tobasket POST also doubles as our session warmup — see
+    // BaseStorefrontPage.warmupSession() rationale.
+    await this.page.request.post(
+      `/index.php?cl=start&fnc=tobasket&aid=${productId}&am=1`,
+    );
+    await this.page.goto('/index.php?cl=user', { waitUntil: 'domcontentloaded' });
+
+    // Click "Continue without registration" (option=3 form).
+    await this.page
+      .locator('form input[name="option"][value="3"]')
+      .first()
+      .evaluate((input) => (input as HTMLInputElement).form?.submit());
+    await this.page.waitForLoadState('domcontentloaded');
+
+    // Fill the minimal billing address. The o3-theme user step's
+    // "continue without registration" form (option=3) actually creates
+    // a customer account on submit, so a password + confirm is also
+    // required even though the wording suggests guest checkout.
+    await this.page.locator('input[name="lgn_usr"]').first().fill(address.email);
+    await this.page.locator('input[name="lgn_pwd"]').first().fill('TestPassword2026!');
+    await this.page.locator('input[name="lgn_pwd2"]').first().fill('TestPassword2026!');
+    await this.page.locator('input[name="invadr[oxuser__oxfname]"]').fill(address.firstName);
+    await this.page.locator('input[name="invadr[oxuser__oxlname]"]').fill(address.lastName);
+    await this.page.locator('input[name="invadr[oxuser__oxstreet]"]').fill(address.street);
+    await this.page.locator('input[name="invadr[oxuser__oxstreetnr]"]').fill(address.streetNo);
+    await this.page.locator('input[name="invadr[oxuser__oxzip]"]').fill(address.zip);
+    await this.page.locator('input[name="invadr[oxuser__oxcity]"]').fill(address.city);
+    await this.page
+      .locator('select[name="invadr[oxuser__oxcountryid]"]')
+      .selectOption(address.countryId ?? DEFAULT_COUNTRY_ID);
+
+    // Submit the address form to advance to the payment step. Bypass
+    // browser-side validation for the same reason as the revocation
+    // FormPage — we want to exercise server flow, not block on a
+    // browser tooltip when something goes wrong.
+    await this.page
+      .locator('form')
+      .filter({ has: this.page.locator('input[name="invadr[oxuser__oxfname]"]') })
+      .first()
+      .evaluate((f) => (f as HTMLFormElement).submit());
+    await this.page.waitForLoadState('networkidle', { timeout: 15_000 });
+
+    // After the address form submits, we may need to navigate explicitly
+    // to the payment step. Some flows land on a confirmation/order step
+    // instead — go to the payment URL deterministically.
+    if (!/cl=payment|\/zahlart\b/.test(this.page.url())) {
+      await this.page.goto('/index.php?cl=payment', { waitUntil: 'domcontentloaded' });
+    }
+    if (!/cl=payment|\/zahlart\b/.test(this.page.url())) {
+      const title = await this.page.title().catch(() => '<unavailable>');
+      const errors = await this.page
+        .locator('.alert-danger')
+        .allTextContents()
+        .catch(() => []);
+      throw new Error(
+        `setupAndGoto: expected to land on payment step, got url=${this.page.url()} title=${title} errors=${JSON.stringify(errors)}`,
+      );
+    }
+  }
+
+  // ── locators ────────────────────────────────────────────────────────
+
+  paymentRadio(paymentId: string): Locator {
+    return this.page.locator(`input[type="radio"][name="paymentid"][value="${paymentId}"]`);
+  }
+
+  /** All inputs/selects/textareas inside the debitnote .form-check label. */
+  get debitnoteFields(): Locator {
+    return this.page.locator(
+      '.form-check:has(input[type="radio"][value="oxiddebitnote"]) .form-check-label input, ' +
+        '.form-check:has(input[type="radio"][value="oxiddebitnote"]) .form-check-label select, ' +
+        '.form-check:has(input[type="radio"][value="oxiddebitnote"]) .form-check-label textarea',
+    );
+  }
+
+  /** Specifically the four bank-detail inputs (excludes the radio itself). */
+  get debitnoteBankInputs(): Locator {
+    return this.page.locator(
+      '.form-check:has(input[type="radio"][value="oxiddebitnote"]) .form-check-label input[name^="dynvalue"]',
+    );
+  }
+
+  async selectPayment(paymentId: string): Promise<void> {
+    await this.paymentRadio(paymentId).check();
+  }
+
+  async expectDebitnoteBankFieldsDisabled(): Promise<void> {
+    const count = await this.debitnoteBankInputs.count();
+    expect(count, 'expected oxiddebitnote bank inputs to exist').toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(this.debitnoteBankInputs.nth(i)).toBeDisabled();
+    }
+  }
+
+  async expectDebitnoteBankFieldsEnabled(): Promise<void> {
+    const count = await this.debitnoteBankInputs.count();
+    expect(count, 'expected oxiddebitnote bank inputs to exist').toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(this.debitnoteBankInputs.nth(i)).toBeEnabled();
+    }
+  }
+}

--- a/tests/Acceptance/playwright/pages/storefront/revocation/FormPage.ts
+++ b/tests/Acceptance/playwright/pages/storefront/revocation/FormPage.ts
@@ -1,0 +1,92 @@
+import { Page, Locator, expect } from '@playwright/test';
+import { BaseStorefrontPage } from '../BaseStorefrontPage';
+import { URLS } from '../../../helpers/urls';
+
+export interface RevocationFormInput {
+  name?: string;
+  orderIdent?: string;
+  email?: string;
+  freeText?: string;
+}
+
+/**
+ * Page Object for the customer-facing §356a revocation form (cl=revocation).
+ *
+ * Selectors are anchored to the IDs declared in
+ * `source/Application/views/wave/tpl/page/revocation/revocation.tpl`.
+ */
+export class StorefrontRevocationFormPage extends BaseStorefrontPage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async goto(): Promise<void> {
+    await this.warmupSession();
+    await this.page.goto(URLS.storefrontRevocation, { waitUntil: 'domcontentloaded' });
+  }
+
+  get form(): Locator {
+    return this.page.locator('#o3-revocation-form');
+  }
+
+  get nameInput(): Locator {
+    return this.page.locator('#o3rev_name');
+  }
+
+  get orderIdentInput(): Locator {
+    return this.page.locator('#o3rev_orderident');
+  }
+
+  get emailInput(): Locator {
+    return this.page.locator('#o3rev_email');
+  }
+
+  get freeTextInput(): Locator {
+    return this.page.locator('#o3rev_freetext');
+  }
+
+  get submitButton(): Locator {
+    return this.page.locator('button.o3-revocation-submit');
+  }
+
+  /** Per-field error message bound via aria-describedby. */
+  fieldError(field: 'name' | 'orderident' | 'email'): Locator {
+    return this.page.locator(`#o3rev_${field}_err`);
+  }
+
+  /** Form-level alert (CSRF / spam rejection). */
+  get formError(): Locator {
+    return this.page.locator('form#o3-revocation-form ~ * .alert-danger[role="alert"]')
+      .or(this.page.locator('form#o3-revocation-form .alert-danger[role="alert"]'));
+  }
+
+  async fill(input: RevocationFormInput): Promise<void> {
+    if (input.name !== undefined) await this.nameInput.fill(input.name);
+    if (input.orderIdent !== undefined) await this.orderIdentInput.fill(input.orderIdent);
+    if (input.email !== undefined) await this.emailInput.fill(input.email);
+    if (input.freeText !== undefined) await this.freeTextInput.fill(input.freeText);
+  }
+
+  async submit(): Promise<void> {
+    // Bypass jqBootstrapValidation. The form template wires
+    // jqBootstrapValidation onto every input; clicking the submit
+    // button would let it preventDefault for required-but-empty fields,
+    // hiding the server-side validation paths from us. We test SERVER-SIDE
+    // validation here — call the native HTMLFormElement.submit() directly.
+    await this.form.evaluate((f) => (f as HTMLFormElement).submit());
+    await this.page.waitForLoadState('networkidle', { timeout: 15_000 });
+  }
+
+  async fillAndSubmit(input: RevocationFormInput): Promise<void> {
+    await this.fill(input);
+    await this.submit();
+  }
+
+  async expectOnReceiptPage(): Promise<void> {
+    await expect(this.page).toHaveURL(/fnc=receipt/);
+  }
+
+  async expectStillOnFormPage(): Promise<void> {
+    await expect(this.form).toHaveCount(1);
+  }
+}

--- a/tests/Acceptance/playwright/playwright.config.ts
+++ b/tests/Acceptance/playwright/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const SHOP_URL = process.env.SHOP_URL ?? 'http://localhost:8080';
+
+export default defineConfig({
+  testDir: './tests',
+  outputDir: './test-results',
+  globalSetup: require.resolve('./globalSetup.ts'),
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'playwright-report', open: 'never' }],
+  ],
+  use: {
+    baseURL: SHOP_URL,
+    actionTimeout: 10_000,
+    navigationTimeout: 15_000,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});
+
+export { SHOP_URL };

--- a/tests/Acceptance/playwright/tests/admin/revocation/config.spec.ts
+++ b/tests/Acceptance/playwright/tests/admin/revocation/config.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from '../../../fixtures';
+import { AdminRevocationConfigPage } from '../../../pages/admin/revocation/ConfigPage';
+import { writeRevocationConfig, readConfigVar } from '../../../helpers/config';
+
+const KNOWN_OPERATOR_EMAIL = 'operator-baseline@example.test';
+
+test.describe('admin revocation config (cl=revocation_config)', () => {
+  test('P0 loads current oxconfig values into the form on first render', async ({
+    adminPage,
+    db,
+  }) => {
+    await writeRevocationConfig(db, {
+      blShowRevocationForm: true,
+      blRevocationRequireLogin: true,
+      blRevocationNotifyOperator: true,
+      sRevocationOperatorEmail: KNOWN_OPERATOR_EMAIL,
+    });
+
+    const config = new AdminRevocationConfigPage(adminPage);
+    await config.goto();
+    await config.expectFormVisible();
+
+    await expect(config.showRevocationFormCheckbox).toBeChecked();
+    await expect(config.requireLoginCheckbox).toBeChecked();
+    await expect(config.notifyOperatorCheckbox).toBeChecked();
+    await expect(config.operatorEmailInput).toHaveValue(KNOWN_OPERATOR_EMAIL);
+  });
+
+  test('P0 saves all four fields atomically when valid', async ({ adminPage, db }) => {
+    // Start from a known empty-ish state so the save is observable.
+    await writeRevocationConfig(db, {
+      blShowRevocationForm: false,
+      blRevocationRequireLogin: false,
+      blRevocationNotifyOperator: false,
+      sRevocationOperatorEmail: '',
+    });
+
+    const config = new AdminRevocationConfigPage(adminPage);
+    await config.goto();
+    await config.setCheckbox(config.showRevocationFormCheckbox, true);
+    await config.setCheckbox(config.requireLoginCheckbox, true);
+    await config.setCheckbox(config.notifyOperatorCheckbox, true);
+    await config.operatorEmailInput.fill('atomic-save@example.test');
+    await config.submit();
+
+    expect(await readConfigVar(db, 'blShowRevocationForm')).toBe('1');
+    expect(await readConfigVar(db, 'blRevocationRequireLogin')).toBe('1');
+    expect(await readConfigVar(db, 'blRevocationNotifyOperator')).toBe('1');
+    expect(await readConfigVar(db, 'sRevocationOperatorEmail')).toBe('atomic-save@example.test');
+  });
+
+  test('P0 cross-field rule: rejects save when notify-operator=1 and operator email is empty', async ({
+    adminPage,
+    db,
+  }) => {
+    // Snapshot baseline: known values that should NOT change after the
+    // rejected save (all-or-nothing invariant).
+    await writeRevocationConfig(db, {
+      blShowRevocationForm: false,
+      blRevocationRequireLogin: false,
+      blRevocationNotifyOperator: false,
+      sRevocationOperatorEmail: KNOWN_OPERATOR_EMAIL,
+    });
+
+    const config = new AdminRevocationConfigPage(adminPage);
+    await config.goto();
+    await config.setCheckbox(config.notifyOperatorCheckbox, true);
+    await config.operatorEmailInput.fill('');
+    await config.submit();
+
+    // Form re-renders with the cross-field error visible.
+    await expect(config.operatorEmailError).toBeVisible();
+
+    // All-or-nothing: NONE of the four oxconfig values changed.
+    expect(await readConfigVar(db, 'blShowRevocationForm')).not.toBe('1');
+    expect(await readConfigVar(db, 'blRevocationNotifyOperator')).not.toBe('1');
+    expect(await readConfigVar(db, 'sRevocationOperatorEmail')).toBe(KNOWN_OPERATOR_EMAIL);
+  });
+
+  test('P0 cross-field rule: rejects save when operator email is malformed', async ({
+    adminPage,
+    db,
+  }) => {
+    await writeRevocationConfig(db, {
+      blShowRevocationForm: false,
+      blRevocationNotifyOperator: false,
+      sRevocationOperatorEmail: KNOWN_OPERATOR_EMAIL,
+    });
+
+    const config = new AdminRevocationConfigPage(adminPage);
+    await config.goto();
+    await config.setCheckbox(config.notifyOperatorCheckbox, true);
+    await config.operatorEmailInput.fill('not-an-email');
+    await config.submit();
+
+    await expect(config.operatorEmailError).toBeVisible();
+    expect(await readConfigVar(db, 'sRevocationOperatorEmail')).toBe(KNOWN_OPERATOR_EMAIL);
+    expect(await readConfigVar(db, 'blRevocationNotifyOperator')).not.toBe('1');
+  });
+
+  test('P0 preserves submitted values on rejection (form-input-preservation)', async ({
+    adminPage,
+    db,
+  }) => {
+    await writeRevocationConfig(db, {
+      blShowRevocationForm: false,
+      blRevocationRequireLogin: false,
+      blRevocationNotifyOperator: false,
+      sRevocationOperatorEmail: KNOWN_OPERATOR_EMAIL,
+    });
+
+    const config = new AdminRevocationConfigPage(adminPage);
+    await config.goto();
+    // Submit a state that triggers cross-field rejection. The user's
+    // submitted toggles + email string must be what we see on re-render
+    // (not the values still in oxconfig).
+    await config.setCheckbox(config.showRevocationFormCheckbox, true);
+    await config.setCheckbox(config.notifyOperatorCheckbox, true);
+    await config.operatorEmailInput.fill('typo@@example.test');
+    await config.submit();
+
+    await expect(config.operatorEmailError).toBeVisible();
+    await expect(config.showRevocationFormCheckbox).toBeChecked(); // user toggled this on
+    await expect(config.notifyOperatorCheckbox).toBeChecked(); // user toggled this on
+    await expect(config.operatorEmailInput).toHaveValue('typo@@example.test');
+  });
+});

--- a/tests/Acceptance/playwright/tests/admin/revocation/detail.spec.ts
+++ b/tests/Acceptance/playwright/tests/admin/revocation/detail.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from '../../../fixtures';
+import { AdminRevocationDetailPage } from '../../../pages/admin/revocation/DetailPage';
+import { writeRevocationConfig } from '../../../helpers/config';
+
+const SEED_NAME = 'Detail-View Tester';
+const SEED_EMAIL = 'detail-tester@example.test';
+const SEED_FREETEXT = 'Erste Zeile.\nZweite Zeile.';
+
+test.describe('admin revocation detail (cl=revocation_main)', () => {
+  // The resend test requires emails to actually go out; ensure operator
+  // notification stays off so we only assert customer-side delivery.
+  test.beforeEach(async ({ db }) => {
+    await writeRevocationConfig(db, {
+      blShowRevocationForm: true,
+      blRevocationRequireLogin: false,
+      blRevocationNotifyOperator: false,
+      sRevocationOperatorEmail: '',
+    });
+  });
+
+  test('P0 renders all six fields of a stored submission', async ({ adminPage, db }) => {
+    const orderIdent = `ORD-DETAIL-${Date.now()}`;
+    const oxid = await db.seedRevocation({
+      name: SEED_NAME,
+      orderIdent,
+      email: SEED_EMAIL,
+      freeText: SEED_FREETEXT,
+    });
+
+    try {
+      const detail = new AdminRevocationDetailPage(adminPage);
+      await detail.goto(oxid);
+      await detail.expectDetailVisible();
+
+      await expect(detail.oxidCell).toContainText(oxid);
+      // Submitted: just confirm a non-empty value renders (formatting
+      // is the |oxformdate filter — locale-dependent).
+      await expect(detail.submittedCell).not.toBeEmpty();
+      await expect(detail.nameCell).toContainText(SEED_NAME);
+      await expect(detail.orderIdentCell).toContainText(orderIdent);
+      await expect(detail.emailLink).toHaveAttribute('href', `mailto:${SEED_EMAIL}`);
+      await expect(detail.freeTextCell).toContainText('Erste Zeile.');
+      await expect(detail.freeTextCell).toContainText('Zweite Zeile.');
+    } finally {
+      await db.deleteRevocation(oxid);
+    }
+  });
+
+  test('P0 resend button re-sends the customer confirmation email', async ({
+    adminPage,
+    db,
+    mailpit,
+  }) => {
+    const orderIdent = `ORD-RESEND-${Date.now()}`;
+    const oxid = await db.seedRevocation({
+      name: SEED_NAME,
+      orderIdent,
+      email: SEED_EMAIL,
+      sendFailed: true,
+    });
+
+    try {
+      const detail = new AdminRevocationDetailPage(adminPage);
+      await detail.goto(oxid);
+      await detail.clickResend();
+
+      // Mailpit gets a fresh customer-facing message.
+      await mailpit.waitForMessage({ to: SEED_EMAIL, timeoutMs: 8000 });
+
+      // OXSENDFAILED should be cleared after a successful resend.
+      const flags = await db.readRevocationFlags(oxid);
+      expect(flags?.sendFailed).toBe(0);
+    } finally {
+      await db.deleteRevocation(oxid);
+    }
+  });
+
+  test('P1 OXSENDFAILED banner is visible when send failed flag is set', async ({
+    adminPage,
+    db,
+  }) => {
+    const orderIdent = `ORD-FAIL-${Date.now()}`;
+    const oxid = await db.seedRevocation({
+      name: SEED_NAME,
+      orderIdent,
+      email: SEED_EMAIL,
+      sendFailed: true,
+    });
+
+    try {
+      const detail = new AdminRevocationDetailPage(adminPage);
+      await detail.goto(oxid);
+      await expect(detail.sendFailedBadge).toBeVisible();
+    } finally {
+      await db.deleteRevocation(oxid);
+    }
+  });
+
+  test('P1 customer email renders as a clickable mailto link', async ({ adminPage, db }) => {
+    const orderIdent = `ORD-MAILTO-${Date.now()}`;
+    const oxid = await db.seedRevocation({
+      name: SEED_NAME,
+      orderIdent,
+      email: SEED_EMAIL,
+    });
+
+    try {
+      const detail = new AdminRevocationDetailPage(adminPage);
+      await detail.goto(oxid);
+      await expect(detail.emailLink).toBeVisible();
+      const href = await detail.emailLink.getAttribute('href');
+      expect(href).toBe(`mailto:${SEED_EMAIL}`);
+    } finally {
+      await db.deleteRevocation(oxid);
+    }
+  });
+});

--- a/tests/Acceptance/playwright/tests/smoke.spec.ts
+++ b/tests/Acceptance/playwright/tests/smoke.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '../fixtures';
+import { URLS } from '../helpers/urls';
+
+/**
+ * Pipeline-validation tests: prove the whole stack runs end-to-end before
+ * any feature specs are written.
+ *
+ * - storefront responds with HTTP 200 and serves an OXID page
+ * - the adminPage fixture is authenticated (storageState from globalSetup)
+ * - the Mailpit and DB fixtures are reachable
+ *
+ * If any of these fail, every other spec will fail downstream — fix here
+ * first.
+ */
+
+test.describe('smoke', () => {
+  test('storefront homepage loads', async ({ storefrontPage }) => {
+    const response = await storefrontPage.goto(URLS.storefrontHome);
+    expect(response?.ok()).toBe(true);
+    await expect(storefrontPage).toHaveTitle(/.+/);
+  });
+
+  test('adminPage fixture lands on the framed admin', async ({ adminPage }) => {
+    // adminPage logs in fresh per-test (see fixtures/auth.ts) and is
+    // pre-positioned on the framed admin home. The fixture itself waits
+    // for `basefrm`, so reaching this test body already proves auth.
+    await expect(adminPage.locator('frame[name="basefrm"]')).toHaveCount(1);
+    await expect(adminPage.locator('#usr')).toHaveCount(0);
+  });
+
+  test('Mailpit REST API is reachable and inbox starts empty', async ({ mailpit }) => {
+    const messages = await mailpit.listMessages();
+    expect(Array.isArray(messages)).toBe(true);
+    expect(messages.length).toBe(0);
+  });
+
+  test('MySQL is reachable and oxconfig table exists', async ({ db }) => {
+    const rows = await db.query<{ c: number }>(`SELECT COUNT(*) AS c FROM oxconfig`);
+    expect(rows[0]?.c).toBeGreaterThan(0);
+  });
+});

--- a/tests/Acceptance/playwright/tests/storefront/checkout/payment-toggle.spec.ts
+++ b/tests/Acceptance/playwright/tests/storefront/checkout/payment-toggle.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '../../../fixtures';
+import { CheckoutPaymentPage } from '../../../pages/storefront/checkout/PaymentPage';
+
+const DEMO_PRODUCT_ID = '01c9499c21914ae7de1b2412ea4b019f'; // "Go Home Pinguin"
+
+const guestAddress = (suffix: string) => ({
+  email: `guest-${suffix}-${Date.now()}@example.test`,
+  firstName: 'Erika',
+  lastName: 'Mustermann',
+  street: 'Musterstraße',
+  streetNo: '1',
+  zip: '12345',
+  city: 'Musterstadt',
+});
+
+test.describe('issue #116 — payment-method radio toggles oxiddebitnote bank fields', () => {
+  test('P0 bank-detail fields are disabled when a different payment method is selected', async ({
+    storefrontPage,
+  }) => {
+    const checkout = new CheckoutPaymentPage(storefrontPage);
+    await checkout.setupAndGoto(DEMO_PRODUCT_ID, guestAddress('disabled'));
+
+    // Pick something other than debitnote. Invoice is always available
+    // in the o3-shop demo data.
+    await checkout.selectPayment('oxidinvoice');
+    await checkout.expectDebitnoteBankFieldsDisabled();
+  });
+
+  test('P0 bank-detail fields are enabled when oxiddebitnote is selected', async ({
+    storefrontPage,
+  }) => {
+    const checkout = new CheckoutPaymentPage(storefrontPage);
+    await checkout.setupAndGoto(DEMO_PRODUCT_ID, guestAddress('enabled'));
+
+    await checkout.selectPayment('oxiddebitnote');
+    await checkout.expectDebitnoteBankFieldsEnabled();
+  });
+
+  test('P0 toggling away from oxiddebitnote re-disables the bank fields', async ({
+    storefrontPage,
+  }) => {
+    const checkout = new CheckoutPaymentPage(storefrontPage);
+    await checkout.setupAndGoto(DEMO_PRODUCT_ID, guestAddress('toggle'));
+
+    await checkout.selectPayment('oxiddebitnote');
+    await checkout.expectDebitnoteBankFieldsEnabled();
+
+    await checkout.selectPayment('oxidinvoice');
+    await checkout.expectDebitnoteBankFieldsDisabled();
+  });
+});

--- a/tests/Acceptance/playwright/tests/storefront/revocation/form.spec.ts
+++ b/tests/Acceptance/playwright/tests/storefront/revocation/form.spec.ts
@@ -1,0 +1,214 @@
+import { test, expect } from '../../../fixtures';
+import { StorefrontRevocationFormPage } from '../../../pages/storefront/revocation/FormPage';
+import { writeRevocationConfig, clearRevocationAntiSpamCache } from '../../../helpers/config';
+import { URLS } from '../../../helpers/urls';
+
+const VALID_NAME = 'Erika Mustermann';
+const VALID_ORDER = 'ORD-2026-04321';
+const CUSTOMER_EMAIL = 'erika.mustermann@example.test';
+const OPERATOR_EMAIL = 'revocation-ops@example.test';
+
+test.describe('storefront revocation form (cl=revocation)', () => {
+  test.beforeEach(async ({ db }) => {
+    // Baseline: feature on, anonymous access, no operator notification.
+    // Individual tests override what they need.
+    await writeRevocationConfig(db, {
+      blShowRevocationForm: true,
+      blRevocationRequireLogin: false,
+      blRevocationNotifyOperator: false,
+      sRevocationOperatorEmail: '',
+    });
+    // Reset the anti-spam IP rate limit so successive tests don't trip
+    // the 5-minute post-success lockout in NoopAntiSpamService.
+    await clearRevocationAntiSpamCache();
+  });
+
+  test('P0 submits successfully and shows the receipt page', async ({ storefrontPage, db }) => {
+    const form = new StorefrontRevocationFormPage(storefrontPage);
+    await form.goto();
+    await form.fillAndSubmit({
+      name: VALID_NAME,
+      orderIdent: VALID_ORDER,
+      email: CUSTOMER_EMAIL,
+      freeText: 'Ich widerrufe meinen Vertrag.',
+    });
+
+    await form.expectOnReceiptPage();
+
+    const oxid = await db.findRevocationByOrderIdent(VALID_ORDER);
+    expect(oxid).not.toBeNull();
+    await db.deleteRevocation(oxid!);
+  });
+
+  test('P0 returns 404 when the feature is disabled', async ({ storefrontPage, db }) => {
+    await writeRevocationConfig(db, { blShowRevocationForm: false });
+
+    const response = await storefrontPage.goto(URLS.storefrontRevocation);
+    // OXID's handlePageNotFoundError emits a 404 page; either the HTTP
+    // status is 404, or the response body is the OXID 404 template.
+    // Accept both — different stack configurations route differently.
+    const status = response?.status() ?? 0;
+    if (status === 404) {
+      expect(status).toBe(404);
+    } else {
+      const title = await storefrontPage.title();
+      expect(title.toLowerCase()).toMatch(/not found|fehler|404/);
+    }
+
+    const form = new StorefrontRevocationFormPage(storefrontPage);
+    await expect(form.form).toHaveCount(0);
+  });
+
+  test('P0 redirects anonymous users to login when blRevocationRequireLogin=1', async ({
+    storefrontPage,
+    db,
+  }) => {
+    await writeRevocationConfig(db, { blRevocationRequireLogin: true });
+
+    await storefrontPage.goto(URLS.storefrontRevocation, { waitUntil: 'domcontentloaded' });
+
+    // Controller redirects to ?cl=account&sourcecl=revocation for anonymous
+    // visitors. Final URL must reflect that.
+    expect(storefrontPage.url()).toMatch(/cl=account/);
+    expect(storefrontPage.url()).toMatch(/sourcecl=revocation/);
+  });
+
+  test('P0 rejects empty required fields and preserves entered values', async ({
+    storefrontPage,
+  }) => {
+    const form = new StorefrontRevocationFormPage(storefrontPage);
+    await form.goto();
+    // Leave name empty; fill the other two with values that should be
+    // preserved across the rejection.
+    await form.fillAndSubmit({
+      name: '',
+      orderIdent: VALID_ORDER,
+      email: CUSTOMER_EMAIL,
+      freeText: 'Optional note.',
+    });
+
+    await form.expectStillOnFormPage();
+    await expect(form.fieldError('name')).toBeVisible();
+
+    // form-input-preservation: the values the user typed must still be
+    // there, except the empty one.
+    await expect(form.orderIdentInput).toHaveValue(VALID_ORDER);
+    await expect(form.emailInput).toHaveValue(CUSTOMER_EMAIL);
+    await expect(form.freeTextInput).toHaveValue('Optional note.');
+  });
+
+  test('P0 rejects invalid email format and preserves inputs', async ({ storefrontPage }) => {
+    const form = new StorefrontRevocationFormPage(storefrontPage);
+    await form.goto();
+    await form.fillAndSubmit({
+      name: VALID_NAME,
+      orderIdent: VALID_ORDER,
+      email: 'not-an-email',
+    });
+
+    await form.expectStillOnFormPage();
+    await expect(form.fieldError('email')).toBeVisible();
+
+    await expect(form.nameInput).toHaveValue(VALID_NAME);
+    await expect(form.orderIdentInput).toHaveValue(VALID_ORDER);
+    await expect(form.emailInput).toHaveValue('not-an-email');
+  });
+
+  test('P1 dispatches confirmation email to the customer on success', async ({
+    storefrontPage,
+    db,
+    mailpit,
+  }) => {
+    const form = new StorefrontRevocationFormPage(storefrontPage);
+    await form.goto();
+
+    const orderIdent = `${VALID_ORDER}-EMAIL-${Date.now()}`;
+    await form.fillAndSubmit({
+      name: VALID_NAME,
+      orderIdent,
+      email: CUSTOMER_EMAIL,
+    });
+    await form.expectOnReceiptPage();
+
+    const message = await mailpit.waitForMessage({ to: CUSTOMER_EMAIL, timeoutMs: 8000 });
+    expect(message.To.some((t) => t.Address.toLowerCase() === CUSTOMER_EMAIL)).toBe(true);
+
+    const oxid = await db.findRevocationByOrderIdent(orderIdent);
+    if (oxid) await db.deleteRevocation(oxid);
+  });
+
+  test('P1 dispatches operator notification when blRevocationNotifyOperator=1', async ({
+    storefrontPage,
+    db,
+    mailpit,
+  }) => {
+    await writeRevocationConfig(db, {
+      blRevocationNotifyOperator: true,
+      sRevocationOperatorEmail: OPERATOR_EMAIL,
+    });
+
+    const form = new StorefrontRevocationFormPage(storefrontPage);
+    await form.goto();
+    const orderIdent = `${VALID_ORDER}-OP-${Date.now()}`;
+    await form.fillAndSubmit({
+      name: VALID_NAME,
+      orderIdent,
+      email: CUSTOMER_EMAIL,
+    });
+    await form.expectOnReceiptPage();
+
+    // Both customer + operator emails should arrive.
+    await mailpit.waitForMessage({ to: CUSTOMER_EMAIL, timeoutMs: 8000 });
+    await mailpit.waitForMessage({ to: OPERATOR_EMAIL, timeoutMs: 8000 });
+
+    const oxid = await db.findRevocationByOrderIdent(orderIdent);
+    if (oxid) await db.deleteRevocation(oxid);
+  });
+
+  test('P1 accepts long UTF-8 + emoji in the free-text field', async ({ storefrontPage, db }) => {
+    const form = new StorefrontRevocationFormPage(storefrontPage);
+    await form.goto();
+    const orderIdent = `${VALID_ORDER}-UTF8-${Date.now()}`;
+    const longText = ('Käufer-Notiz ❤️ → ' + 'A'.repeat(2000) + ' 🎉').slice(0, 2500);
+    await form.fillAndSubmit({
+      name: 'Müller',
+      orderIdent,
+      email: CUSTOMER_EMAIL,
+      freeText: longText,
+    });
+    await form.expectOnReceiptPage();
+
+    const oxid = await db.findRevocationByOrderIdent(orderIdent);
+    expect(oxid).not.toBeNull();
+    await db.deleteRevocation(oxid!);
+  });
+
+  test('P2 back-button after success does not resubmit the form', async ({
+    storefrontPage,
+    db,
+  }) => {
+    const form = new StorefrontRevocationFormPage(storefrontPage);
+    await form.goto();
+    const orderIdent = `${VALID_ORDER}-BACK-${Date.now()}`;
+    await form.fillAndSubmit({
+      name: VALID_NAME,
+      orderIdent,
+      email: CUSTOMER_EMAIL,
+    });
+    await form.expectOnReceiptPage();
+
+    // The 303 from submit() means a back-navigation goes to the FORM
+    // (GET), not the POST. Confirm only one row exists for this orderIdent.
+    await storefrontPage.goBack();
+    await storefrontPage.waitForLoadState('domcontentloaded');
+
+    const rows = await db.query<{ c: number }>(
+      `SELECT COUNT(*) AS c FROM o3revocation WHERE OXORDERIDENT = ?`,
+      [orderIdent],
+    );
+    expect(rows[0]?.c).toBe(1);
+
+    const oxid = await db.findRevocationByOrderIdent(orderIdent);
+    if (oxid) await db.deleteRevocation(oxid);
+  });
+});

--- a/tests/Acceptance/playwright/tsconfig.json
+++ b/tests/Acceptance/playwright/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@fixtures/*": ["fixtures/*"],
+      "@helpers/*": ["helpers/*"],
+      "@pages/*": ["pages/*"]
+    }
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "test-results", "playwright-report"]
+}


### PR DESCRIPTION
## Summary

- Net-new Playwright + TypeScript E2E test infrastructure under `tests/Acceptance/playwright/`, parallel to the existing Codeception/Selenium suite (Codeception to be retired once Playwright coverage is sufficient).
- 22 tests covering the three §356a BGB revocation surfaces (storefront form, admin config, admin detail).
- 3 tests pinning the o3-theme `payment-toggle.js` fix for issue #116 (direct-debit bank fields toggling with payment-method selection).
- `./docker.sh playwright` entrypoint (auto-installs deps + browser on first run) and `.gitattributes export-ignore` so the Node/TS suite is excluded from composer dist tarballs.

**Total**: 25 Playwright tests, all green, ~34 s runtime.

## Why parallel infra

The existing `tests/Acceptance/` Codeception/Selenium suite is the long-term casualty here, but introducing Playwright next to it (rather than rewriting Codeception in place) lets the two coexist while we migrate. Playwright lives at `tests/Acceptance/playwright/` so all browser-test concerns stay under one parent directory.

## Specific gotchas worked through and documented inline

1. **Storefront sessions are lazy.** Pure GETs don't start a session, so `getHiddenSid()` emits no `stoken` and the next form POST trips `checkSessionChallenge()`. `BaseStorefrontPage.warmupSession()` does a `tobasket` POST first to force session start.
2. **`type="email"` + jqBootstrapValidation block `submitButton.click()`.** Both the storefront revocation form and the admin config form had JS-side validation (jqBootstrapValidation on storefront, native HTML5 on the admin operator-email input) that prevented `click()` from reaching the server when fields were empty/malformed, hiding the server-side validation paths. Both POMs use native `HTMLFormElement.submit()` to bypass constraint validation — server-side validation is what these tests exercise; client-side belongs in separate tests.
3. **Anti-spam locks out repeated test runs.** `NoopAntiSpamService` writes per-IP rate-limit counters to `source/tmp/`; one successful submission triggers a 5-minute lockout on the IP. `clearRevocationAntiSpamCache()` purges the `oxc_o3rev_antispam_*.txt` files in `beforeEach`.
4. **Schema gotchas.** `oxconfig.OXID` is `CHAR(32)` not 36 (strip hyphens from `UUID()`), `OXSHOPID` is `INT` not the string `"oxbaseshop"`, and since the 2023 migration `OXVARVALUE` is plain `TEXT` (no `ENCODE`/`DECODE`). `o3revocation` requires `OXLANG` (NOT NULL).
5. **Admin sessions can't be storage-state cached.** Shop emits a `force_admin_sid` URL param at login plus per-request `stoken`s; cookie-only restoration gets bounced back to login. So the admin auth fixture does a per-test login (~1.5–2 s overhead each) — same as the existing Codeception suite.
6. **o3-theme's "continue without registration" (option=3) is misleading.** It creates a real customer account and requires `lgn_pwd` + `lgn_pwd2` to be filled. The CheckoutPaymentPage helper supplies a 17-char password.

## Files added / changed

```
.gitattributes                                  # export-ignore the playwright dir
docker.sh                                       # +playwright subcommand
tests/Acceptance/playwright/                    # whole new directory
  package.json + lock + tsconfig + .gitignore
  README.md                                     # how to run + conventions
  playwright.config.ts + globalSetup.ts
  fixtures/{auth, db, mailpit, index}.ts        # test fixtures
  helpers/{urls, config}.ts                     # URL builders + oxconfig helpers
  pages/                                        # Page Objects, mirroring surfaces
    admin/{BaseAdminPage, LoginPage, revocation/{ConfigPage, DetailPage}}.ts
    storefront/{BaseStorefrontPage, revocation/FormPage, checkout/PaymentPage}.ts
  tests/                                        # specs
    smoke.spec.ts                               # 4 pipeline-validation tests
    storefront/revocation/form.spec.ts          # 9 tests (P0×6, P1×2, P2×1)
    storefront/checkout/payment-toggle.spec.ts  # 3 tests (issue #116)
    admin/revocation/config.spec.ts             # 5 P0 tests
    admin/revocation/detail.spec.ts             # 4 tests (P0×2, P1×2)
```

## Test plan

- [ ] `./docker.sh start` (shop + Mailpit + MySQL up)
- [ ] `./docker.sh playwright` runs the full suite — expect 25 / 25 green
- [ ] `./docker.sh playwright tests/storefront/checkout/` runs only the issue-#116 spec
- [ ] `cd tests/Acceptance/playwright && npm run test:ui` for interactive debugging
- [ ] Confirm Mailpit inbox is reset between tests (no message bleed-through)
- [ ] Confirm Codeception suite still runs unchanged (the new dir is isolated)

