### PR TITLE
build: exclude AI / dev tooling from composer dist (#119)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
+# AI / dev-tooling configuration that has no place in the composer dist.
 AGENTS.md export-ignore
+CLAUDE.md export-ignore
+.claude/** export-ignore
+openspec/** export-ignore
+docs/superpowers/** export-ignore


### PR DESCRIPTION
Closes #119.

## Summary

- Add `export-ignore` patterns in `.gitattributes` for the dev-tooling content that has no place in a customer install: Claude Code config (`.claude/`, `CLAUDE.md`), the OpenSpec definitions (`openspec/`), and the Claude superpowers plans/specs (`docs/superpowers/`). `AGENTS.md` was already covered.

## Why

`git archive` (which is what Composer uses for `--prefer-dist` and Packagist uses for source archives) honours `.gitattributes` `export-ignore`. Right now those directories ship inside every dist tarball — bloat and noise that's irrelevant to anyone consuming the package.

## Files affected

```
.gitattributes
```

Diff:

```diff
+# AI / dev-tooling configuration that has no place in the composer dist.
 AGENTS.md export-ignore
+CLAUDE.md export-ignore
+.claude/** export-ignore
+openspec/** export-ignore
+docs/superpowers/** export-ignore
```

## Verification

`git check-attr export-ignore` resolves correctly per file:

| Path | Resolved |
|---|---|
| `AGENTS.md` | set ✓ |
| `CLAUDE.md` | set ✓ |
| `.claude/memory/MEMORY.md` | set ✓ |
| `.claude/hooks/load-memory.py` | set ✓ |
| `openspec/config.yaml` | set ✓ |
| `openspec/changes/add-electronic-revocation/proposal.md` | set ✓ |
| `docs/superpowers/plans/2026-03-31-claude-code-setup.md` | set ✓ |
| `README.md` | unspecified (will ship) ✓ |
| `CHANGELOG.md` | unspecified (will ship) ✓ |
| `backwards-compatibility-test.md` | unspecified (will ship) ✓ |
| `composer.json` | unspecified (will ship) ✓ |
| `source/Core/Config.php` | unspecified (will ship) ✓ |

Real `git archive HEAD | tar -t` confirms only empty directory entries remain for `.claude/` and `openspec/` (a tar artifact — no actual files inside), `docs/superpowers/` is gone entirely, and customer-facing files (README, CHANGELOG, source/, composer.json, backwards-compatibility-test.md) are all still present.

Total archive entries before fix: ~4720+ (estimate); after fix: 4638.

## Test plan

- [ ] `git checkout 119-exclude-ai-tooling-from-dist`
- [ ] `git archive --format=tar HEAD | tar -t | grep -E '^(\.claude|CLAUDE\.md|AGENTS\.md|openspec/|docs/superpowers)'` → expect only the empty `.claude/` and `openspec/` directory entries; no `CLAUDE.md`, no `AGENTS.md`, no `docs/superpowers/...`, no actual files under `.claude/` or `openspec/`.
- [ ] `git archive --format=tar HEAD | tar -t | grep -E '^(README\.md|CHANGELOG\.md|composer\.json)$'` → all three present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)