### PR TITLE
fix: SeoEncoder PHP 8 TypeError on null aSEOReservedWords (#94)

### DIFF
--- a/source/Core/SeoEncoder.php
+++ b/source/Core/SeoEncoder.php
@@ -969,6 +969,14 @@ class SeoEncoder extends \OxidEsales\Eshop\Core\Base
      */
     public function setReservedWords($aReservedWords)
     {
+        // PHP 7 silently swallowed array_merge(array, null); PHP 8 raises a
+        // fatal TypeError. aSEOReservedWords config is allowed to be NULL
+        // (default seed is missing on some installs — see o3-shop/o3-shop#94),
+        // so guard against non-array input rather than crashing the whole
+        // frontend and backend.
+        if (!is_array($aReservedWords)) {
+            return;
+        }
         self::$_aReservedWords = array_merge(self::$_aReservedWords, $aReservedWords);
     }
 

--- a/tests/Unit/Core/SeoEncoderTest.php
+++ b/tests/Unit/Core/SeoEncoderTest.php
@@ -230,6 +230,42 @@ class SeoEncoderTest extends \OxidTestCase
     }
 
     /**
+     * Regression guard for o3-shop/o3-shop#94.
+     *
+     * On PHP 7 array_merge(array, null) silently returned the first array.
+     * On PHP 8 it raises TypeError, taking down every page that constructs
+     * a SeoEncoder once aSEOReservedWords config is NULL — i.e. the entire
+     * frontend and backend in #94. setReservedWords(null) must therefore
+     * be a tolerated no-op, not a fatal.
+     */
+    public function testSetReservedWordsWithNullDoesNotCrash()
+    {
+        $oEncoder = oxNew(\OxidEsales\Eshop\Core\SeoEncoder::class);
+
+        $oEncoder->setReservedWords(null);
+
+        $this->assertTrue(
+            true,
+            'setReservedWords(null) must be a no-op, not a TypeError'
+        );
+    }
+
+    /**
+     * Companion to testSetReservedWordsWithNullDoesNotCrash:
+     * pin the integration path #94 actually crashed on. When the
+     * shop is configured with aSEOReservedWords = NULL,
+     * SeoEncoder::__construct() must not throw.
+     */
+    public function testConstructorTolerantOfNullSeoReservedWordsConfig()
+    {
+        $this->getConfig()->setConfigParam('aSEOReservedWords', null);
+
+        $oEncoder = oxNew(\OxidEsales\Eshop\Core\SeoEncoder::class);
+
+        $this->assertInstanceOf(\OxidEsales\Eshop\Core\SeoEncoder::class, $oEncoder);
+    }
+
+    /**
      * Test for #0001664
      *
      * @return null


### PR DESCRIPTION
## Summary

When \`aSEOReservedWords\` config is NULL, \`SeoEncoder::__construct()\` calls \`setReservedWords(null)\`, which on PHP 7 was silently swallowed by \`array_merge\` but on PHP 8 raises a fatal \`TypeError\`. This crashed **every storefront and admin page** that constructs a \`SeoEncoder\`, taking the whole shop offline (issue #94).

The fix guards \`setReservedWords()\` against non-array input so a missing default is tolerated rather than fatal — same root-cause analysis already documented in the issue thread.

## Changes

- \`source/Core/SeoEncoder.php\` — \`is_array()\` guard before the \`array_merge\`. Comment references #94 and the PHP 7→8 behaviour change.
- \`tests/Unit/Core/SeoEncoderTest.php\` — two regression tests pinning the failure mode:
  - \`testSetReservedWordsWithNullDoesNotCrash\` — direct setter null-safety
  - \`testConstructorTolerantOfNullSeoReservedWordsConfig\` — pins the actual \`__construct\` integration path #94 hit (mocking config to return \`null\`)

## TDD evidence

Without the fix, both new tests fail with the exact signature seen in #94's production log:

\`\`\`
TypeError: array_merge(): Argument #2 must be of type array, null given
/var/www/html/source/Core/SeoEncoder.php:972
\`\`\`

With the fix, both tests pass and the full unit suite stays green (8464 / 15274).

## Out of scope (separate concerns)

- **Why does \`aSEOReservedWords\` come back NULL at all?** There's supposed to be a default; either \`ShopSeo::save()\` writes the key as NULL, or the seeded default isn't loading. Worth its own ticket — but doesn't block the visible-crash fix.
- **\`oxconfig\` table missing** in some entries of #94's log — that's a database-level / install-state issue, orthogonal to this TypeError.

## Test plan

- [x] \`./docker.sh test --fast tests/Unit/Core/SeoEncoderTest.php --filter '/(testSetReservedWordsWithNull|testConstructorTolerantOfNullSeoReservedWordsConfig)/'\` — red before fix (matching #94's stack), green after.
- [x] \`./docker.sh test --fast tests/Unit/Core/SeoEncoderTest.php\` — full SeoEncoderTest 71/71 green.
- [x] \`./docker.sh test-all\` — full unit suite green: **8464 tests / 15274 assertions, 0 failures**.

Closes o3-shop/o3-shop#94

🤖 Generated with [Claude Code](https://claude.com/claude-code)