### PR TITLE
fix: route internal BC-shim call sites through `_method()` (#107)

### DIFF
--- a/bin/apply-internal-shim-call-site-sweep.php
+++ b/bin/apply-internal-shim-call-site-sweep.php
@@ -37,6 +37,14 @@
 
 declare(strict_types=1);
 
+// composer.json supports php ^7.4 || ^8.0; str_starts_with is PHP 8.0+.
+if (!function_exists('str_starts_with')) {
+    function str_starts_with(string $haystack, string $needle): bool
+    {
+        return $needle === '' || strncmp($haystack, $needle, strlen($needle)) === 0;
+    }
+}
+
 exit(main($argv));
 
 function main(array $argv): int

--- a/bin/apply-internal-shim-call-site-sweep.php
+++ b/bin/apply-internal-shim-call-site-sweep.php
@@ -1,0 +1,353 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * This file is part of O3-Shop.
+ *
+ * O3-Shop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * Phase 2 rewriter for #107 internal call-site sweep.
+ *
+ * Reads the findings file produced by find-internal-shim-call-sites.php, then
+ * for each entry rewrites `$this->method(` → `$this->_method(` at the exact
+ * token location identified by the detector. Tokenizer-based so string and
+ * comment occurrences of the same name are never touched.
+ *
+ * Optionally restrict to a directory prefix — `--prefix=source/Application/Controller/Admin/`
+ * applies only to findings whose file starts with that prefix. Useful for
+ * batched per-directory commits per the gate's batching decision.
+ *
+ * Usage:
+ *   apply-internal-shim-call-site-sweep.php [--findings=<path>] [--prefix=<repo-relative-prefix>]
+ *                                            [--dry-run] [--quiet]
+ *   apply-internal-shim-call-site-sweep.php --help | -h
+ *
+ * Defaults (resolved against the repo root):
+ *   --findings  openspec/changes/fix-internal-shim-call-sites/findings.json
+ *   no --prefix means: apply to all findings
+ *
+ * Exit codes:
+ *   0  rewrites applied (or dry-run completed)
+ *   2  usage error
+ *   3  findings file missing or malformed
+ *   4  rewrite verification mismatch (a finding's expected token did not match the file)
+ */
+
+declare(strict_types=1);
+
+exit(main($argv));
+
+function main(array $argv): int
+{
+    $opts = parse_args($argv);
+    if ($opts['help']) {
+        echo usage_text();
+        return 0;
+    }
+
+    $repoRoot = resolve_repo_root(__DIR__);
+    $findingsPath = resolve_path($repoRoot, $opts['findings']);
+
+    if (!is_file($findingsPath)) {
+        fwrite(STDERR, "error: findings file not found: $findingsPath\n");
+        return 3;
+    }
+    $findings = json_decode((string) file_get_contents($findingsPath), true);
+    if (!is_array($findings)) {
+        fwrite(STDERR, "error: findings file is not a JSON array: $findingsPath\n");
+        return 3;
+    }
+
+    // Load exclusions and skip any finding that matches an exclusion entry
+    // (the durable allow-list of intentional non-underscore call sites).
+    $exclusionsPath = resolve_path($repoRoot, $opts['exclusions']);
+    $excludedKeys = [];
+    if (is_file($exclusionsPath)) {
+        $exDecoded = json_decode((string) file_get_contents($exclusionsPath), true);
+        if (is_array($exDecoded) && isset($exDecoded['exclusions']) && is_array($exDecoded['exclusions'])) {
+            foreach ($exDecoded['exclusions'] as $e) {
+                if (isset($e['file'], $e['line'], $e['method'])) {
+                    $excludedKeys[$e['file'] . '|' . $e['line'] . '|' . $e['method']] = true;
+                }
+            }
+        }
+    }
+
+    $prefix = $opts['prefix'];
+    $filePattern = $opts['filePattern'];
+    $byFile = [];
+    foreach ($findings as $f) {
+        if (!is_array($f) || !isset($f['file'], $f['line'], $f['method'])) {
+            continue;
+        }
+        if ($prefix !== '' && !str_starts_with($f['file'], $prefix)) {
+            continue;
+        }
+        if ($filePattern !== '' && !preg_match($filePattern, $f['file'])) {
+            continue;
+        }
+        $key = $f['file'] . '|' . $f['line'] . '|' . $f['method'];
+        if (isset($excludedKeys[$key])) {
+            continue;
+        }
+        $byFile[$f['file']][] = ['line' => (int) $f['line'], 'method' => (string) $f['method']];
+    }
+
+    if ($byFile === []) {
+        if (!$opts['quiet']) {
+            $hint = $prefix === '' ? '' : " (with prefix \"$prefix\")";
+            echo "No findings to apply$hint.\n";
+        }
+        return 0;
+    }
+
+    $totalRewritten = 0;
+    $filesTouched = 0;
+    foreach ($byFile as $relFile => $sites) {
+        $absFile = resolve_path($repoRoot, $relFile);
+        $rewrites = rewrite_file($absFile, $sites, $opts['dryRun']);
+        if ($rewrites === null) {
+            return 4;
+        }
+        if ($rewrites > 0) {
+            $totalRewritten += $rewrites;
+            $filesTouched++;
+            if (!$opts['quiet']) {
+                printf("  %s: %d rewrite%s\n", $relFile, $rewrites, $rewrites === 1 ? '' : 's');
+            }
+        }
+    }
+
+    if (!$opts['quiet']) {
+        printf(
+            "%s: %d rewrite%s across %d file%s.\n",
+            $opts['dryRun'] ? 'Dry run' : 'Applied',
+            $totalRewritten,
+            $totalRewritten === 1 ? '' : 's',
+            $filesTouched,
+            $filesTouched === 1 ? '' : 's'
+        );
+    }
+
+    return 0;
+}
+
+function parse_args(array $argv): array
+{
+    $opts = [
+        'help' => false,
+        'dryRun' => false,
+        'quiet' => false,
+        'findings' => 'openspec/changes/fix-internal-shim-call-sites/findings.json',
+        'exclusions' => 'tests/Unit/BackwardsCompatibility/internal-shim-call-sites-exclusions.json',
+        'prefix' => '',
+        'filePattern' => '',
+    ];
+    foreach (array_slice($argv, 1) as $arg) {
+        if ($arg === '--help' || $arg === '-h') {
+            $opts['help'] = true;
+            continue;
+        }
+        if ($arg === '--dry-run') {
+            $opts['dryRun'] = true;
+            continue;
+        }
+        if ($arg === '--quiet') {
+            $opts['quiet'] = true;
+            continue;
+        }
+        if (str_starts_with($arg, '--findings=')) {
+            $opts['findings'] = substr($arg, strlen('--findings='));
+            continue;
+        }
+        if (str_starts_with($arg, '--prefix=')) {
+            $opts['prefix'] = substr($arg, strlen('--prefix='));
+            continue;
+        }
+        if (str_starts_with($arg, '--file-pattern=')) {
+            $opts['filePattern'] = substr($arg, strlen('--file-pattern='));
+            continue;
+        }
+        if (str_starts_with($arg, '--exclusions=')) {
+            $opts['exclusions'] = substr($arg, strlen('--exclusions='));
+            continue;
+        }
+        fwrite(STDERR, "error: unknown argument: $arg (try --help)\n");
+        exit(2);
+    }
+    return $opts;
+}
+
+function usage_text(): string
+{
+    return <<<TXT
+apply-internal-shim-call-site-sweep.php — Phase 2 rewriter for #107.
+
+Reads findings.json and for each entry rewrites `\$this->method(` to
+`\$this->_method(` at the exact token location. Tokenizer-based; never
+touches string or comment occurrences.
+
+Usage:
+  bin/apply-internal-shim-call-site-sweep.php [--findings=<path>] [--prefix=<dir>]
+                                              [--dry-run] [--quiet]
+  bin/apply-internal-shim-call-site-sweep.php --help | -h
+
+Options:
+  --findings      Path to findings JSON
+                  (default: openspec/changes/fix-internal-shim-call-sites/findings.json)
+  --exclusions    Path to exclusions JSON (durable allow-list)
+                  (default: tests/Unit/BackwardsCompatibility/internal-shim-call-sites-exclusions.json)
+  --prefix        Limit rewrites to findings whose file starts with this prefix
+                  (e.g. source/Application/Controller/Admin/). No default: applies to all.
+  --file-pattern  Limit rewrites to findings whose file matches this regex
+                  (e.g. '~Ajax\.php$~' for *Ajax.php files only). No default.
+  --dry-run       Verify findings without writing files; print the would-be summary.
+  --quiet         Suppress per-file progress output.
+
+TXT;
+}
+
+function resolve_repo_root(string $startDir): string
+{
+    $cmd = sprintf('git -C %s rev-parse --show-toplevel 2>/dev/null', escapeshellarg($startDir));
+    $root = trim((string) shell_exec($cmd));
+    if ($root === '' || !is_dir($root)) {
+        fwrite(STDERR, "error: cannot resolve repo root from $startDir\n");
+        exit(3);
+    }
+    return $root;
+}
+
+function resolve_path(string $repoRoot, string $path): string
+{
+    if ($path !== '' && $path[0] === '/') {
+        return $path;
+    }
+    return rtrim($repoRoot, '/') . '/' . ltrim($path, '/');
+}
+
+/**
+ * Rewrite a single file. Returns the number of rewrites applied,
+ * or null on a verification mismatch (means findings.json is stale
+ * relative to the file).
+ *
+ * @param list<array{line:int,method:string}> $sites
+ */
+function rewrite_file(string $absPath, array $sites, bool $dryRun): ?int
+{
+    if (!is_file($absPath)) {
+        fwrite(STDERR, "error: source file missing: $absPath\n");
+        return null;
+    }
+    $code = file_get_contents($absPath);
+    if ($code === false) {
+        fwrite(STDERR, "error: cannot read $absPath\n");
+        return null;
+    }
+    $tokens = token_get_all($code);
+    $count = count($tokens);
+
+    // Build (line => list of method names to rewrite on that line)
+    $byLine = [];
+    foreach ($sites as $s) {
+        $byLine[$s['line']][] = $s['method'];
+    }
+
+    // Find each `$this->method(` token sequence; if its (line, method) is
+    // in the requested set, mark that T_STRING for replacement.
+    $replacements = []; // list of [token-index, original-name, new-name]
+    for ($i = 0; $i < $count; $i++) {
+        $tok = $tokens[$i];
+        if (!is_array($tok) || $tok[0] !== T_VARIABLE || $tok[1] !== '$this') {
+            continue;
+        }
+        $j = next_significant($tokens, $i);
+        if ($j === null || !is_array($tokens[$j]) || $tokens[$j][0] !== T_OBJECT_OPERATOR) {
+            continue;
+        }
+        $k = next_significant($tokens, $j);
+        if ($k === null || !is_array($tokens[$k]) || $tokens[$k][0] !== T_STRING) {
+            continue;
+        }
+        $l = next_significant($tokens, $k);
+        if ($l === null || $tokens[$l] !== '(') {
+            continue;
+        }
+        $line = $tokens[$k][2];
+        $name = $tokens[$k][1];
+        if (!isset($byLine[$line])) {
+            continue;
+        }
+        $needles = $byLine[$line];
+        $idx = array_search($name, $needles, true);
+        if ($idx === false) {
+            continue;
+        }
+        // Consume one needle so a duplicate (same method on same line) does
+        // not match twice for one finding.
+        unset($byLine[$line][$idx]);
+        $byLine[$line] = array_values($byLine[$line]);
+        if ($byLine[$line] === []) {
+            unset($byLine[$line]);
+        }
+        $replacements[] = [$k, $name, '_' . $name];
+    }
+
+    // Verify: every finding for this file should have matched a token.
+    if ($byLine !== []) {
+        $missed = [];
+        foreach ($byLine as $line => $names) {
+            foreach ($names as $n) {
+                $missed[] = "{$line}:{$n}";
+            }
+        }
+        fwrite(
+            STDERR,
+            sprintf(
+                "error: verification mismatch in %s: %d finding%s did not match a token (stale findings?). Missing: %s\n",
+                $absPath,
+                count($missed),
+                count($missed) === 1 ? '' : 's',
+                implode(', ', $missed)
+            )
+        );
+        return null;
+    }
+
+    if ($replacements === [] || $dryRun) {
+        return count($replacements);
+    }
+
+    // Apply replacements by mutating the tokens array, then re-emit.
+    foreach ($replacements as [$idx, , $newName]) {
+        $tok = $tokens[$idx];
+        // Token shape: [T_STRING, "name", line]
+        $tokens[$idx] = [$tok[0], $newName, $tok[2]];
+    }
+
+    $rebuilt = '';
+    foreach ($tokens as $tok) {
+        $rebuilt .= is_array($tok) ? $tok[1] : $tok;
+    }
+
+    if (file_put_contents($absPath, $rebuilt) === false) {
+        fwrite(STDERR, "error: failed to write $absPath\n");
+        return null;
+    }
+    return count($replacements);
+}
+
+function next_significant(array $tokens, int $i): ?int
+{
+    $count = count($tokens);
+    for ($j = $i + 1; $j < $count; $j++) {
+        $tok = $tokens[$j];
+        if (is_array($tok) && in_array($tok[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+            continue;
+        }
+        return $j;
+    }
+    return null;
+}

--- a/bin/apply-shim-phpdoc-transitional-rewrite.php
+++ b/bin/apply-shim-phpdoc-transitional-rewrite.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Phase 2 Batch 4 — rewrite the PHPDoc blocks of every BC-shim pair from
+ * the original PR #104 wording to the new transitional framing.
+ *
+ * The original wording told modules NOT to override _method() ("new code …
+ * MUST NOT call or override _method()"). After #107's call-site sweep,
+ * internal code now dispatches direct to _method(), so module overrides
+ * of _method() are the path that wins. The new wording reflects that AND
+ * flags it as transitional, pointing #108 (template-method refactor) as
+ * the long-term direction that re-inverts the contract.
+ *
+ * Mechanical text replace. Two patterns:
+ *
+ * @deprecated block on _method():
+ *   OLD: "Use METHOD() instead. This underscore-prefixed name is retained only
+ *         for backward compatibility with module subclasses that already override
+ *         it; new code, including new modules, MUST NOT call or override _METHOD()."
+ *   NEW: "Transitional during #107. Modules SHOULD override _METHOD()
+ *         for now — internal call paths route through it. The longer-term
+ *         direction (issue #108) is a template-method refactor that
+ *         promotes METHOD() to the canonical override target and retires
+ *         _METHOD(); until then, _METHOD() is the safe override target.
+ *         Plan extension work with both stages in mind."
+ *
+ * @internal block on method():
+ *   OLD: "If your override does not fully replace the behavior, call parent::METHOD()
+ *         (not the deprecated _METHOD()) so downstream overrides in the class chain
+ *         are preserved. Template-method refactor tracked in o3-shop/o3-shop#108."
+ *   NEW: "Public delegate during the #107 transition. Module subclasses
+ *         SHOULD override _METHOD(), not this — internal call paths
+ *         bypass this name. Issue #108 will eventually invert this and
+ *         make METHOD() the canonical override target."
+ *
+ * Usage:
+ *   apply-shim-phpdoc-transitional-rewrite.php [--dry-run]
+ *
+ * Walks source/ and applies the two regex replacements per file.
+ */
+
+declare(strict_types=1);
+
+exit(main($argv));
+
+function main(array $argv): int
+{
+    $dryRun = in_array('--dry-run', $argv, true);
+    $repoRoot = trim((string) shell_exec('git -C ' . escapeshellarg(__DIR__) . ' rev-parse --show-toplevel 2>/dev/null'));
+    $sourceRoot = $repoRoot . '/source';
+
+    $deprecatedReplacements = 0;
+    $internalReplacements = 0;
+    $filesTouched = 0;
+
+    $iter = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($sourceRoot, FilesystemIterator::SKIP_DOTS));
+    foreach ($iter as $info) {
+        if (!$info->isFile() || $info->getExtension() !== 'php') {
+            continue;
+        }
+        $path = $info->getPathname();
+        $rel = ltrim(substr($path, strlen($repoRoot)), '/');
+        $code = file_get_contents($path);
+        if ($code === false) {
+            continue;
+        }
+        $original = $code;
+
+        // 1) @deprecated block rewrite. Pattern matches the canonical PR #104 wording.
+        $code = preg_replace_callback(
+            '/^([ \t]*\*) @deprecated Use ([a-zA-Z][a-zA-Z0-9_]*)\(\) instead\. This underscore-prefixed name is retained only\n\1\s+for backward compatibility with module subclasses that already override\n\1\s+it; new code, including new modules, MUST NOT call or override _\2\(\)\.$/m',
+            function (array $m): string {
+                $star = $m[1];
+                $bare = $m[2];
+                $under = '_' . $bare;
+                $indent = $star . ' ';
+                $contIndent = preg_replace('/\* $/', ' *  ', $indent);
+                return implode("\n", [
+                    "{$indent}@deprecated Transitional during #107. Modules SHOULD override {$under}()",
+                    "{$contIndent}           for now — internal call paths route through it. The",
+                    "{$contIndent}           longer-term direction (issue #108) is a template-method",
+                    "{$contIndent}           refactor that promotes {$bare}() to the canonical override",
+                    "{$contIndent}           target and retires {$under}(); until then, {$under}() is the",
+                    "{$contIndent}           safe override target. Plan extension work with both stages",
+                    "{$contIndent}           in mind.",
+                ]);
+            },
+            $code,
+            -1,
+            $deprecatedCount
+        );
+        $deprecatedReplacements += $deprecatedCount;
+
+        // 2) @internal block rewrite.
+        $code = preg_replace_callback(
+            '/^([ \t]*\*) @internal If your override does not fully replace the behavior, call parent::([a-zA-Z][a-zA-Z0-9_]*)\(\)\n\1\s+\(not the deprecated _\2\(\)\) so downstream overrides in the class chain\n\1\s+are preserved\. Template-method refactor tracked in o3-shop\/o3-shop#108\.$/m',
+            function (array $m): string {
+                $star = $m[1];
+                $bare = $m[2];
+                $under = '_' . $bare;
+                $indent = $star . ' ';
+                $contIndent = preg_replace('/\* $/', ' *  ', $indent);
+                return implode("\n", [
+                    "{$indent}@internal Public delegate during the #107 transition. Module subclasses",
+                    "{$contIndent}         SHOULD override {$under}(), not this — internal call paths",
+                    "{$contIndent}         bypass this name. Issue #108 will eventually invert this and",
+                    "{$contIndent}         make {$bare}() the canonical override target.",
+                ]);
+            },
+            $code,
+            -1,
+            $internalCount
+        );
+        $internalReplacements += $internalCount;
+
+        if ($code !== $original) {
+            $filesTouched++;
+            if (!$dryRun) {
+                file_put_contents($path, $code);
+            }
+            printf("  %s: %d @deprecated, %d @internal\n", $rel, $deprecatedCount, $internalCount);
+        }
+    }
+
+    printf(
+        "%s: %d @deprecated + %d @internal block rewrites across %d files.\n",
+        $dryRun ? 'Dry run' : 'Applied',
+        $deprecatedReplacements,
+        $internalReplacements,
+        $filesTouched
+    );
+    return 0;
+}

--- a/bin/apply-test-mock-name-sweep.php
+++ b/bin/apply-test-mock-name-sweep.php
@@ -1,0 +1,490 @@
+<?php
+
+/**
+ * Companion to apply-internal-shim-call-site-sweep.php — updates test
+ * mock-string targets when the corresponding production call sites were
+ * rewritten from $this->method( to $this->_method(.
+ *
+ * Tokenizer-based: looks for getMock() / createMock() / createPartialMock()
+ * invocations and rewrites string literals inside their method-name array
+ * argument when the bare name has its underscore counterpart in the swept
+ * set. Other occurrences of the same string are left alone.
+ *
+ * Usage:
+ *   apply-test-mock-name-sweep.php [--findings=<path>] [--exclusions=<path>]
+ *                                   [--prefix=<dir>] [--file-pattern=<regex>]
+ *                                   [--tests-root=<dir>] [--dry-run] [--quiet]
+ *
+ * Defaults:
+ *   --findings    openspec/changes/fix-internal-shim-call-sites/findings.json
+ *   --exclusions  tests/Unit/BackwardsCompatibility/internal-shim-call-sites-exclusions.json
+ *   --tests-root  tests/Unit/
+ *   --prefix      (none — applies to whole tests root)
+ */
+
+declare(strict_types=1);
+
+exit(main($argv));
+
+function main(array $argv): int
+{
+    $opts = parse_args($argv);
+    if ($opts['help']) {
+        echo usage_text();
+        return 0;
+    }
+
+    $repoRoot = resolve_repo_root(__DIR__);
+    $findingsPath = resolve_path($repoRoot, $opts['findings']);
+    $exclusionsPath = resolve_path($repoRoot, $opts['exclusions']);
+    $testsRoot = resolve_path($repoRoot, $opts['testsRoot']);
+
+    $findings = load_findings_subset($findingsPath, $exclusionsPath, $opts['prefix'], $opts['filePattern']);
+    if ($findings === []) {
+        if (!$opts['quiet']) {
+            echo "No in-scope findings under prefix/pattern; nothing to do.\n";
+        }
+        return 0;
+    }
+
+    // Build per-class swept-name sets. A test mock 'method' is rewritten
+    // only when the mocked class matches one of these and the method
+    // appears in its swept set. A class is keyed by its short name (for
+    // matching against `Class::class` in tests, which references the
+    // unified `\OxidEsales\Eshop\...` namespace), and we accept the FQCN
+    // suffix match.
+    /** @var array<string, array<string,bool>> $sweptByClass */
+    $sweptByClass = [];
+    foreach ($findings as $f) {
+        $sweptByClass[$f['class']][$f['method']] = true;
+    }
+    if (!$opts['quiet']) {
+        printf("Swept classes in batch: %d (across %d findings)\n", count($sweptByClass), count($findings));
+    }
+
+    // Walk every .php under testsRoot and rewrite mock string targets.
+    $touched = 0;
+    $rewrites = 0;
+    $iter = new \RecursiveIteratorIterator(
+        new \RecursiveDirectoryIterator($testsRoot, \FilesystemIterator::SKIP_DOTS)
+    );
+    foreach ($iter as $info) {
+        if (!$info->isFile() || $info->getExtension() !== 'php') {
+            continue;
+        }
+        $path = $info->getPathname();
+        $code = file_get_contents($path);
+        if ($code === false) {
+            continue;
+        }
+        [$newCode, $count] = rewrite_mocks_in_file($code, $sweptByClass);
+        if ($count > 0) {
+            $rewrites += $count;
+            $touched++;
+            $rel = ltrim(substr($path, strlen($repoRoot)), '/');
+            if (!$opts['quiet']) {
+                printf("  %s: %d mock rewrite%s\n", $rel, $count, $count === 1 ? '' : 's');
+            }
+            if (!$opts['dryRun']) {
+                file_put_contents($path, $newCode);
+            }
+        }
+    }
+
+    if (!$opts['quiet']) {
+        printf(
+            "%s: %d mock rewrite%s across %d test file%s.\n",
+            $opts['dryRun'] ? 'Dry run' : 'Applied',
+            $rewrites,
+            $rewrites === 1 ? '' : 's',
+            $touched,
+            $touched === 1 ? '' : 's'
+        );
+    }
+    return 0;
+}
+
+function parse_args(array $argv): array
+{
+    $opts = [
+        'help' => false,
+        'dryRun' => false,
+        'quiet' => false,
+        'findings' => 'openspec/changes/fix-internal-shim-call-sites/findings.json',
+        'exclusions' => 'tests/Unit/BackwardsCompatibility/internal-shim-call-sites-exclusions.json',
+        'testsRoot' => 'tests/Unit/',
+        'prefix' => '',
+        'filePattern' => '',
+    ];
+    foreach (array_slice($argv, 1) as $arg) {
+        if ($arg === '--help' || $arg === '-h') {
+            $opts['help'] = true;
+            continue;
+        }
+        if ($arg === '--dry-run') {
+            $opts['dryRun'] = true;
+            continue;
+        }
+        if ($arg === '--quiet') {
+            $opts['quiet'] = true;
+            continue;
+        }
+        if (str_starts_with($arg, '--findings=')) {
+            $opts['findings'] = substr($arg, strlen('--findings='));
+            continue;
+        }
+        if (str_starts_with($arg, '--exclusions=')) {
+            $opts['exclusions'] = substr($arg, strlen('--exclusions='));
+            continue;
+        }
+        if (str_starts_with($arg, '--tests-root=')) {
+            $opts['testsRoot'] = substr($arg, strlen('--tests-root='));
+            continue;
+        }
+        if (str_starts_with($arg, '--prefix=')) {
+            $opts['prefix'] = substr($arg, strlen('--prefix='));
+            continue;
+        }
+        if (str_starts_with($arg, '--file-pattern=')) {
+            $opts['filePattern'] = substr($arg, strlen('--file-pattern='));
+            continue;
+        }
+        fwrite(STDERR, "error: unknown argument: $arg (try --help)\n");
+        exit(2);
+    }
+    return $opts;
+}
+
+function usage_text(): string
+{
+    return <<<TXT
+apply-test-mock-name-sweep.php — update getMock() string targets to match
+the production call-site sweep done by apply-internal-shim-call-site-sweep.php.
+
+When production code is rewritten from \$this->method( to \$this->_method(,
+unit tests that mock 'method' must also flip to '_method', otherwise the
+mock no longer intercepts the call. This script does that update,
+constrained to the same batch (--prefix / --file-pattern as the sweep).
+
+Tokenizer-based: only string literals inside getMock / createMock /
+createPartialMock array arguments are touched.
+
+TXT;
+}
+
+function resolve_repo_root(string $startDir): string
+{
+    $cmd = sprintf('git -C %s rev-parse --show-toplevel 2>/dev/null', escapeshellarg($startDir));
+    $root = trim((string) shell_exec($cmd));
+    if ($root === '' || !is_dir($root)) {
+        fwrite(STDERR, "error: cannot resolve repo root from $startDir\n");
+        exit(3);
+    }
+    return $root;
+}
+
+function resolve_path(string $repoRoot, string $path): string
+{
+    if ($path !== '' && $path[0] === '/') {
+        return $path;
+    }
+    return rtrim($repoRoot, '/') . '/' . ltrim($path, '/');
+}
+
+/**
+ * @return list<array{file:string, line:int, method:string}>
+ */
+function load_findings_subset(string $findingsPath, string $exclusionsPath, string $prefix, string $filePattern): array
+{
+    $findings = json_decode((string) file_get_contents($findingsPath), true);
+    if (!is_array($findings)) {
+        return [];
+    }
+
+    $excluded = [];
+    if (is_file($exclusionsPath)) {
+        $exDecoded = json_decode((string) file_get_contents($exclusionsPath), true);
+        if (is_array($exDecoded) && isset($exDecoded['exclusions']) && is_array($exDecoded['exclusions'])) {
+            foreach ($exDecoded['exclusions'] as $e) {
+                if (isset($e['file'], $e['line'], $e['method'])) {
+                    $excluded[$e['file'] . '|' . $e['line'] . '|' . $e['method']] = true;
+                }
+            }
+        }
+    }
+
+    $out = [];
+    foreach ($findings as $f) {
+        if (!is_array($f) || !isset($f['file'], $f['line'], $f['method'])) {
+            continue;
+        }
+        if ($prefix !== '' && !str_starts_with($f['file'], $prefix)) {
+            continue;
+        }
+        if ($filePattern !== '' && !preg_match($filePattern, $f['file'])) {
+            continue;
+        }
+        $key = $f['file'] . '|' . $f['line'] . '|' . $f['method'];
+        if (isset($excluded[$key])) {
+            continue;
+        }
+        $out[] = $f;
+    }
+    return $out;
+}
+
+/**
+ * Two-pass rewrite per file:
+ * 1. Walk tokens; for each getMock/createMock/createPartialMock call whose
+ *    first arg is a swept class, collect the set of swept method names
+ *    that appear as string literals in that call (the mock array).
+ * 2. With the union of all such names for this file, rewrite every
+ *    matching string literal `'name'` / `"name"` to its underscore form
+ *    throughout the file. This catches both the array entry and the
+ *    chained `->method('name')` references.
+ *
+ * @param array<string, array<string,bool>> $sweptByClass FQCN => method-set
+ * @return array{0:string, 1:int}
+ */
+function rewrite_mocks_in_file(string $code, array $sweptByClass): array
+{
+    $tokens = token_get_all($code);
+    $count = count($tokens);
+
+    $mockMethods = ['getMock' => true, 'createMock' => true, 'createPartialMock' => true];
+
+    // Lookup keyed by short class name (tests usually reference classes
+    // via `Class::class`, which yields the short name).
+    $sweptByShort = [];
+    foreach ($sweptByClass as $fqcn => $methods) {
+        $parts = explode('\\', $fqcn);
+        $short = end($parts);
+        if (isset($sweptByShort[$short])) {
+            $sweptByShort[$short] = $sweptByShort[$short] + $methods;
+        } else {
+            $sweptByShort[$short] = $methods;
+        }
+    }
+
+    // Pass 1: discover which method names this file mocks-on-swept-class.
+    $namesToRewrite = [];
+    for ($i = 0; $i < $count; $i++) {
+        $tok = $tokens[$i];
+        if (!is_array($tok) || $tok[0] !== T_STRING || !isset($mockMethods[$tok[1]])) {
+            continue;
+        }
+        $j = next_significant($tokens, $i);
+        if ($j === null || $tokens[$j] !== '(') {
+            continue;
+        }
+
+        $shortName = read_first_arg_class($tokens, $j + 1);
+        if ($shortName === null) {
+            continue;
+        }
+        $sweptForThisClass = $sweptByShort[$shortName] ?? null;
+        if ($sweptForThisClass === null) {
+            continue;
+        }
+
+        // Walk through the call args collecting string literals inside
+        // array contexts; mark any whose unquoted value is in swept set.
+        $parenDepth = 1;
+        $bracketDepth = 0;
+        $inArrayArg = false;
+        $k = $j + 1;
+        while ($k < $count && $parenDepth > 0) {
+            $tk = $tokens[$k];
+            if (is_array($tk)) {
+                if ($tk[0] === T_ARRAY) {
+                    $inArrayArg = true;
+                } elseif ($tk[0] === T_CONSTANT_ENCAPSED_STRING && ($inArrayArg || $bracketDepth > 0)) {
+                    $unquoted = unquote_literal($tk[1]);
+                    if ($unquoted !== null && isset($sweptForThisClass[$unquoted])) {
+                        $namesToRewrite[$unquoted] = true;
+                    }
+                }
+            } else {
+                if ($tk === '(') {
+                    $parenDepth++;
+                } elseif ($tk === ')') {
+                    $parenDepth--;
+                    if ($parenDepth === 0) {
+                        break;
+                    } if ($inArrayArg && $bracketDepth === 0) {
+                        $inArrayArg = false;
+                    }
+                } elseif ($tk === '[') {
+                    $bracketDepth++;
+                } elseif ($tk === ']') {
+                    $bracketDepth--;
+                }
+            }
+            $k++;
+        }
+    }
+
+    if ($namesToRewrite === []) {
+        return [$code, 0];
+    }
+
+    // Pass 2: rewrite every matching string literal in the file. Tokens
+    // already loaded; just scan once more.
+    $rewrites = 0;
+    for ($i = 0; $i < $count; $i++) {
+        $tok = $tokens[$i];
+        if (!is_array($tok) || $tok[0] !== T_CONSTANT_ENCAPSED_STRING) {
+            continue;
+        }
+        $unquoted = unquote_literal($tok[1]);
+        if ($unquoted === null || !isset($namesToRewrite[$unquoted])) {
+            continue;
+        }
+        $newLiteral = requote_literal($tok[1], '_' . $unquoted);
+        $tokens[$i] = [$tok[0], $newLiteral, $tok[2]];
+        $rewrites++;
+    }
+
+    if ($rewrites === 0) {
+        return [$code, 0];
+    }
+
+    $rebuilt = '';
+    foreach ($tokens as $tok) {
+        $rebuilt .= is_array($tok) ? $tok[1] : $tok;
+    }
+    return [$rebuilt, $rewrites];
+}
+
+/**
+ * Read the first argument of a getMock-like call starting at the given
+ * index (just inside the opening paren). Return the short class name if
+ * the first arg is a `Class::class` reference or a string literal with a
+ * class name; otherwise null.
+ */
+function read_first_arg_class(array $tokens, int $start): ?string
+{
+    $count = count($tokens);
+    // Read tokens up to the first comma, ignoring whitespace/comments.
+    $segment = [];
+    $depth = 0;
+    for ($i = $start; $i < $count; $i++) {
+        $tk = $tokens[$i];
+        if (is_array($tk)) {
+            if (in_array($tk[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+            $segment[] = $tk;
+        } else {
+            if ($tk === '(') {
+                $depth++;
+                $segment[] = $tk;
+            } elseif ($tk === ')') {
+                if ($depth === 0) {
+                    break;
+                } $depth--;
+                $segment[] = $tk;
+            } elseif ($tk === ',' && $depth === 0) {
+                break;
+            } else {
+                $segment[] = $tk;
+            }
+        }
+    }
+    // Look for `Class::class`: T_STRING/qualified name followed by ::class
+    $name = '';
+    foreach ($segment as $tok) {
+        if (!is_array($tok)) {
+            continue;
+        }
+        $id = $tok[0];
+        if ($id === T_STRING) {
+            $name .= $tok[1];
+            continue;
+        }
+        if ($id === T_NS_SEPARATOR) {
+            $name .= '\\';
+            continue;
+        }
+        if (defined('T_NAME_QUALIFIED') && $id === T_NAME_QUALIFIED) {
+            $name .= $tok[1];
+            continue;
+        }
+        if (defined('T_NAME_FULLY_QUALIFIED') && $id === T_NAME_FULLY_QUALIFIED) {
+            $name .= ltrim($tok[1], '\\');
+            continue;
+        }
+        if ($id === T_DOUBLE_COLON || $id === T_CLASS_C) {
+            continue;
+        }
+        if ($id === T_CONSTANT_ENCAPSED_STRING) {
+            $unq = unquote_string_with_namespace($tok[1]);
+            if ($unq !== null) {
+                $name = $unq;
+            }
+            continue;
+        }
+    }
+    if ($name === '') {
+        return null;
+    }
+    $parts = explode('\\', trim($name, '\\'));
+    return end($parts) ?: null;
+}
+
+function unquote_string_with_namespace(string $literal): ?string
+{
+    if (strlen($literal) < 2) {
+        return null;
+    }
+    $first = $literal[0];
+    if ($first !== "'" && $first !== '"') {
+        return null;
+    }
+    $inner = substr($literal, 1, -1);
+    if (preg_match('/^[\\\\A-Za-z_][\\\\A-Za-z0-9_]*$/', $inner)) {
+        return $inner;
+    }
+    return null;
+}
+
+function unquote_literal(string $literal): ?string
+{
+    if (strlen($literal) < 2) {
+        return null;
+    }
+    $first = $literal[0];
+    $last = $literal[strlen($literal) - 1];
+    if ($first !== $last) {
+        return null;
+    }
+    if ($first !== "'" && $first !== '"') {
+        return null;
+    }
+    $inner = substr($literal, 1, -1);
+    // Reject anything with escapes or quotes inside; we only care about
+    // simple identifier-like literals.
+    if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $inner)) {
+        return $inner;
+    }
+    return null;
+}
+
+function requote_literal(string $literal, string $newInner): string
+{
+    $first = $literal[0];
+    return $first . $newInner . $first;
+}
+
+function next_significant(array $tokens, int $i): ?int
+{
+    $count = count($tokens);
+    for ($j = $i + 1; $j < $count; $j++) {
+        $tok = $tokens[$j];
+        if (is_array($tok) && in_array($tok[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+            continue;
+        }
+        return $j;
+    }
+    return null;
+}

--- a/bin/apply-test-mock-name-sweep.php
+++ b/bin/apply-test-mock-name-sweep.php
@@ -24,6 +24,14 @@
 
 declare(strict_types=1);
 
+// composer.json supports php ^7.4 || ^8.0; str_starts_with is PHP 8.0+.
+if (!function_exists('str_starts_with')) {
+    function str_starts_with(string $haystack, string $needle): bool
+    {
+        return $needle === '' || strncmp($haystack, $needle, strlen($needle)) === 0;
+    }
+}
+
 exit(main($argv));
 
 function main(array $argv): int

--- a/bin/find-internal-shim-call-sites.php
+++ b/bin/find-internal-shim-call-sites.php
@@ -1,0 +1,712 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * This file is part of O3-Shop.
+ *
+ * O3-Shop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * Internal call-site detector for BC-shim methods.
+ *
+ * For every (Class, _method) entry in the pinned inventory at
+ * tests/Unit/BackwardsCompatibility/underscore-method-snapshot.json, find every
+ * `$this->method(` call site in source/ where the declaring class also has both
+ * `_method()` and `method()` declared (the BC-shim pair is in effect locally).
+ * Emits deterministic JSON `{file, line, class, method}` per match, sorted by
+ * (file, line), to the findings path.
+ *
+ * Companion to InheritanceContractTest: that test enforces structural BC
+ * (overrides of `_method()` are dispatched through the public surface). This
+ * script enforces the call-site convention (internal code uses
+ * `$this->_method()` not `$this->method()`). See o3-shop/o3-shop#107.
+ *
+ * Usage:
+ *   find-internal-shim-call-sites.php [--inventory=<path>] [--source-root=<path>]
+ *                                     [--output=<path>] [--quiet]
+ *   find-internal-shim-call-sites.php --help | -h
+ *
+ * Defaults (resolved against the repo root, not the caller's cwd):
+ *   --inventory   tests/Unit/BackwardsCompatibility/underscore-method-snapshot.json
+ *   --source-root source/
+ *   --output      openspec/changes/fix-internal-shim-call-sites/findings.json
+ *
+ * Exit codes:
+ *   0  detector ran cleanly (regardless of whether findings is empty)
+ *   2  usage error
+ *   3  inventory or source-root not found
+ */
+
+declare(strict_types=1);
+
+exit(main($argv));
+
+function main(array $argv): int
+{
+    $opts = parse_args($argv);
+    if ($opts['help']) {
+        echo usage_text();
+        return 0;
+    }
+
+    // Resolve the repo root for both path resolution and producing
+    // repo-relative file paths in the findings output. Order of precedence:
+    //   1. Explicit --repo-root (the test harness passes this so the
+    //      detector works inside the Docker container without needing git).
+    //   2. `git rev-parse --show-toplevel` from this script's directory
+    //      (the normal CLI case).
+    $repoRoot = $opts['repoRoot'] !== ''
+        ? rtrim($opts['repoRoot'], '/')
+        : resolve_repo_root(__DIR__);
+    $inventoryPath = resolve_path($repoRoot, $opts['inventory']);
+    $sourceRoot = resolve_path($repoRoot, $opts['sourceRoot']);
+    $outputPath = resolve_path($repoRoot, $opts['output']);
+
+    if (!is_dir($sourceRoot)) {
+        fwrite(STDERR, "error: source root not found: $sourceRoot\n");
+        return 3;
+    }
+
+    [$classMethods, $callSites, $classExtends] = scan_source_tree($sourceRoot, $repoRoot);
+
+    // Inventory file is parsed but only used as informational; the detector
+    // relies on current-source shim pairs as the operational definition.
+    // Reason: the official baseline generator under-counts (missed
+    // `_getAll`/`_addFilter` on ListComponentAjax, etc.). For a call-site
+    // convention sweep, "this class currently has both names defined" is the
+    // right oracle.
+    if ($inventoryPath !== '' && !is_file($inventoryPath)) {
+        fwrite(STDERR, "error: inventory not found: $inventoryPath\n");
+        return 3;
+    }
+
+    $findings = filter_findings($callSites, $classMethods, $classExtends);
+
+    write_findings($outputPath, $findings);
+
+    if (!$opts['quiet']) {
+        printf(
+            "Scanned %d classes, %d call sites; %d findings written to %s\n",
+            count($classMethods),
+            count($callSites),
+            count($findings),
+            $outputPath
+        );
+    }
+
+    return 0;
+}
+
+function parse_args(array $argv): array
+{
+    $opts = [
+        'help' => false,
+        'quiet' => false,
+        'repoRoot' => '',
+        'inventory' => 'tests/Unit/BackwardsCompatibility/underscore-method-snapshot.json',
+        'sourceRoot' => 'source/',
+        'output' => 'openspec/changes/fix-internal-shim-call-sites/findings.json',
+    ];
+
+    foreach (array_slice($argv, 1) as $arg) {
+        if ($arg === '--help' || $arg === '-h') {
+            $opts['help'] = true;
+            continue;
+        }
+        if ($arg === '--quiet') {
+            $opts['quiet'] = true;
+            continue;
+        }
+        if (str_starts_with($arg, '--repo-root=')) {
+            $opts['repoRoot'] = substr($arg, strlen('--repo-root='));
+            continue;
+        }
+        if (str_starts_with($arg, '--inventory=')) {
+            $opts['inventory'] = substr($arg, strlen('--inventory='));
+            continue;
+        }
+        if (str_starts_with($arg, '--source-root=')) {
+            $opts['sourceRoot'] = substr($arg, strlen('--source-root='));
+            continue;
+        }
+        if (str_starts_with($arg, '--output=')) {
+            $opts['output'] = substr($arg, strlen('--output='));
+            continue;
+        }
+        fwrite(STDERR, "error: unknown argument: $arg (try --help)\n");
+        exit(2);
+    }
+
+    return $opts;
+}
+
+function usage_text(): string
+{
+    return <<<TXT
+find-internal-shim-call-sites.php — detect convention violations of #107.
+
+Walks source/ and reports every `\$this->method(` call site where `method` is
+the non-underscore counterpart of an inventory `_method` entry AND the class
+declaring the call also declares both `_method()` and `method()`.
+
+Usage:
+  bin/find-internal-shim-call-sites.php [--inventory=<path>] [--source-root=<path>]
+                                        [--output=<path>] [--quiet]
+  bin/find-internal-shim-call-sites.php --help | -h
+
+Defaults (resolved against the repo root):
+  --inventory    tests/Unit/BackwardsCompatibility/underscore-method-snapshot.json
+  --source-root  source/
+  --output       openspec/changes/fix-internal-shim-call-sites/findings.json
+
+Example (from anywhere):
+  /Users/foo/o3/shop-ce/bin/find-internal-shim-call-sites.php
+
+See openspec/changes/fix-internal-shim-call-sites/design.md for the full design.
+
+TXT;
+}
+
+function resolve_repo_root(string $startDir): string
+{
+    $cmd = sprintf('git -C %s rev-parse --show-toplevel 2>/dev/null', escapeshellarg($startDir));
+    $root = trim((string) shell_exec($cmd));
+    if ($root === '' || !is_dir($root)) {
+        fwrite(STDERR, "error: cannot resolve repo root from $startDir (not a git work tree?)\n");
+        exit(3);
+    }
+    return $root;
+}
+
+function is_absolute(string $path): bool
+{
+    return $path !== '' && $path[0] === '/';
+}
+
+function resolve_path(string $repoRoot, string $path): string
+{
+    if (is_absolute($path)) {
+        return $path;
+    }
+    return rtrim($repoRoot, '/') . '/' . ltrim($path, '/');
+}
+
+/**
+ * @return array<string,bool> set keyed by underscore-prefixed method names
+ */
+function load_inventory_method_names(string $path): array
+{
+    $json = file_get_contents($path);
+    if ($json === false) {
+        fwrite(STDERR, "error: cannot read inventory: $path\n");
+        exit(3);
+    }
+    $entries = json_decode($json, true);
+    if (!is_array($entries)) {
+        fwrite(STDERR, "error: inventory is not a JSON array: $path\n");
+        exit(3);
+    }
+    $set = [];
+    foreach ($entries as $entry) {
+        if (!is_array($entry) || !isset($entry['method']) || !is_string($entry['method'])) {
+            continue;
+        }
+        $name = $entry['method'];
+        if ($name !== '' && $name[0] === '_' && (strlen($name) < 2 || $name[1] !== '_')) {
+            $set[$name] = true;
+        }
+    }
+    return $set;
+}
+
+/**
+ * @return array{
+ *   0: array<string, array<string,bool>>,  // FQCN => set of declared method names
+ *   1: list<array{file:string,line:int,class:string,method:string}>,
+ *   2: array<string,string>                // FQCN => parent FQCN
+ * }
+ */
+function scan_source_tree(string $sourceRoot, string $repoRoot): array
+{
+    $classMethods = [];
+    $callSites = [];
+    $classExtends = [];
+
+    $iter = new \RecursiveIteratorIterator(
+        new \RecursiveDirectoryIterator($sourceRoot, \FilesystemIterator::SKIP_DOTS)
+    );
+
+    /** @var \SplFileInfo $fileInfo */
+    foreach ($iter as $fileInfo) {
+        if (!$fileInfo->isFile() || $fileInfo->getExtension() !== 'php') {
+            continue;
+        }
+        $filePath = $fileInfo->getPathname();
+        $relPath = ltrim(substr($filePath, strlen($repoRoot)), '/');
+        $code = file_get_contents($filePath);
+        if ($code === false) {
+            continue;
+        }
+        scan_file($code, $relPath, $classMethods, $callSites, $classExtends);
+    }
+
+    return [$classMethods, $callSites, $classExtends];
+}
+
+/**
+ * @param-out array<string, array<string,bool>> $classMethods
+ * @param-out list<array{file:string,line:int,class:string,method:string}> $callSites
+ * @param-out array<string,string> $classExtends FQCN => parent FQCN
+ */
+function scan_file(
+    string $code,
+    string $relPath,
+    array &$classMethods,
+    array &$callSites,
+    array &$classExtends
+): void {
+    $tokens = token_get_all($code);
+    $count = count($tokens);
+    $namespace = '';
+    $useMap = []; // alias => FQCN
+    $currentClass = null;
+    $braceDepth = 0;
+    $classBraceDepth = null;
+
+    for ($i = 0; $i < $count; $i++) {
+        $tok = $tokens[$i];
+
+        if (is_array($tok) && $tok[0] === T_NAMESPACE) {
+            $namespace = read_namespace($tokens, $i);
+            $useMap = []; // namespace boundary resets use aliases
+            continue;
+        }
+
+        // `use Foo\Bar;` and `use Foo\Bar as Baz;`
+        if (is_array($tok) && $tok[0] === T_USE && $currentClass === null) {
+            collect_use_aliases($tokens, $i, $useMap);
+            continue;
+        }
+
+        if (is_array($tok) && ($tok[0] === T_CLASS || $tok[0] === T_TRAIT)) {
+            if ($tok[0] === T_CLASS) {
+                $prev = previous_significant($tokens, $i);
+                if ($prev !== null && is_array($tokens[$prev]) && $tokens[$prev][0] === T_NEW) {
+                    continue;
+                }
+            }
+            $name = read_class_name($tokens, $i);
+            if ($name === null) {
+                continue;
+            }
+            $currentClass = $namespace !== '' ? $namespace . '\\' . $name : $name;
+            $classMethods[$currentClass] ??= [];
+            $classBraceDepth = $braceDepth;
+            // Look for `extends ParentClass` after the class name
+            if ($tok[0] === T_CLASS) {
+                $parentFqcn = read_extends($tokens, $i, $namespace, $useMap);
+                if ($parentFqcn !== null) {
+                    $classExtends[$currentClass] = $parentFqcn;
+                }
+            }
+            continue;
+        }
+
+        if ($currentClass !== null && is_array($tok) && $tok[0] === T_FUNCTION) {
+            $j = next_significant($tokens, $i);
+            if ($j !== null && is_array($tokens[$j]) && $tokens[$j][0] === T_STRING) {
+                $methodName = $tokens[$j][1];
+                $classMethods[$currentClass][$methodName] = true;
+            }
+            continue;
+        }
+
+        if ($currentClass !== null && is_array($tok) && $tok[0] === T_VARIABLE && $tok[1] === '$this') {
+            $j = next_significant($tokens, $i);
+            if ($j === null || !is_array($tokens[$j]) || $tokens[$j][0] !== T_OBJECT_OPERATOR) {
+                continue;
+            }
+            $k = next_significant($tokens, $j);
+            if ($k === null || !is_array($tokens[$k]) || $tokens[$k][0] !== T_STRING) {
+                continue;
+            }
+            $l = next_significant($tokens, $k);
+            if ($l === null || $tokens[$l] !== '(') {
+                continue;
+            }
+            $callSites[] = [
+                'file' => $relPath,
+                'line' => $tokens[$k][2],
+                'class' => $currentClass,
+                'method' => $tokens[$k][1],
+            ];
+            continue;
+        }
+
+        if (is_array($tok)) {
+            // String interpolation `{$var}` and `${var}` — the opening is an
+            // array token (T_CURLY_OPEN / T_DOLLAR_OPEN_CURLY_BRACES) but the
+            // matching close is a literal `}` char. Count the open here so
+            // the literal `}` doesn't unbalance the class brace depth.
+            if (
+                $tok[0] === T_CURLY_OPEN
+                || (defined('T_DOLLAR_OPEN_CURLY_BRACES') && $tok[0] === T_DOLLAR_OPEN_CURLY_BRACES)
+            ) {
+                $braceDepth++;
+            }
+            continue;
+        }
+
+        if ($tok === '{') {
+            $braceDepth++;
+            continue;
+        }
+        if ($tok === '}') {
+            $braceDepth--;
+            if ($currentClass !== null && $classBraceDepth !== null && $braceDepth === $classBraceDepth) {
+                $currentClass = null;
+                $classBraceDepth = null;
+            }
+            continue;
+        }
+    }
+}
+
+/**
+ * Read a single `use Foo\Bar [as Baz];` statement starting at $i pointing at T_USE.
+ * Adds an entry alias => FQCN to $useMap. Skips function/const uses and grouped uses.
+ *
+ * @param-out array<string,string> $useMap
+ */
+function collect_use_aliases(array $tokens, int $i, array &$useMap): void
+{
+    $count = count($tokens);
+    // Skip `function` / `const` modifiers
+    $j = next_significant($tokens, $i);
+    if ($j === null) {
+        return;
+    }
+    if (is_array($tokens[$j]) && in_array($tokens[$j][0], [T_FUNCTION, T_CONST], true)) {
+        return;
+    }
+
+    $fqcn = '';
+    $alias = '';
+    $sawAs = false;
+    for ($k = $j; $k < $count; $k++) {
+        $tok = $tokens[$k];
+        if (is_array($tok)) {
+            $id = $tok[0];
+            if (in_array($id, [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+            if ($id === T_AS) {
+                $sawAs = true;
+                continue;
+            }
+            if ($id === T_STRING) {
+                if ($sawAs) {
+                    $alias = $tok[1];
+                } else {
+                    $fqcn .= $tok[1];
+                }
+                continue;
+            }
+            if ($id === T_NS_SEPARATOR) {
+                $fqcn .= '\\';
+                continue;
+            }
+            if (defined('T_NAME_QUALIFIED') && $id === T_NAME_QUALIFIED) {
+                $fqcn .= $tok[1];
+                continue;
+            }
+            if (defined('T_NAME_FULLY_QUALIFIED') && $id === T_NAME_FULLY_QUALIFIED) {
+                $fqcn .= ltrim($tok[1], '\\');
+                continue;
+            }
+            // Anything else (e.g. `{` for grouped uses) — bail. Grouped uses
+            // are uncommon in this codebase; skip rather than parse them.
+            return;
+        }
+        if ($tok === ';' || $tok === ',') {
+            break;
+        }
+        if ($tok === '{') {
+            // Grouped use — skip.
+            return;
+        }
+    }
+
+    $fqcn = ltrim($fqcn, '\\');
+    if ($fqcn === '') {
+        return;
+    }
+    if ($alias === '') {
+        $parts = explode('\\', $fqcn);
+        $alias = end($parts);
+    }
+    $useMap[$alias] = $fqcn;
+}
+
+/**
+ * Read `extends ParentClass` after a class declaration, returning the parent FQCN.
+ */
+function read_extends(array $tokens, int $classTokenIndex, string $namespace, array $useMap): ?string
+{
+    $count = count($tokens);
+    $extendsAt = null;
+    // Walk forward until '{' (class body) or end
+    for ($i = $classTokenIndex + 1; $i < $count; $i++) {
+        $tok = $tokens[$i];
+        if (is_array($tok) && $tok[0] === T_EXTENDS) {
+            $extendsAt = $i;
+            break;
+        }
+        if ($tok === '{') {
+            return null;
+        }
+    }
+    if ($extendsAt === null) {
+        return null;
+    }
+    // Read the next type name token
+    $name = '';
+    $isFullyQualified = false;
+    for ($i = $extendsAt + 1; $i < $count; $i++) {
+        $tok = $tokens[$i];
+        if (is_array($tok)) {
+            $id = $tok[0];
+            if (in_array($id, [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+            if ($id === T_STRING) {
+                $name .= $tok[1];
+                continue;
+            }
+            if ($id === T_NS_SEPARATOR) {
+                if ($name === '') {
+                    $isFullyQualified = true;
+                }
+                $name .= '\\';
+                continue;
+            }
+            if (defined('T_NAME_QUALIFIED') && $id === T_NAME_QUALIFIED) {
+                $name .= $tok[1];
+                continue;
+            }
+            if (defined('T_NAME_FULLY_QUALIFIED') && $id === T_NAME_FULLY_QUALIFIED) {
+                $isFullyQualified = true;
+                $name .= ltrim($tok[1], '\\');
+                continue;
+            }
+            // Anything else means we hit `implements` or `{`
+            break;
+        }
+        if ($tok === '{' || $tok === ',') {
+            break;
+        }
+    }
+    $name = trim($name, '\\');
+    if ($name === '') {
+        return null;
+    }
+    return resolve_name_to_fqcn($name, $isFullyQualified, $namespace, $useMap);
+}
+
+function resolve_name_to_fqcn(string $name, bool $isFullyQualified, string $namespace, array $useMap): string
+{
+    if ($isFullyQualified) {
+        return $name;
+    }
+    $parts = explode('\\', $name);
+    $head = $parts[0];
+    if (isset($useMap[$head])) {
+        $rest = array_slice($parts, 1);
+        return ltrim($useMap[$head] . ($rest === [] ? '' : '\\' . implode('\\', $rest)), '\\');
+    }
+    if ($namespace !== '') {
+        return $namespace . '\\' . $name;
+    }
+    return $name;
+}
+
+function read_namespace(array $tokens, int $i): string
+{
+    $count = count($tokens);
+    $name = '';
+    for ($j = $i + 1; $j < $count; $j++) {
+        $tok = $tokens[$j];
+        if (is_array($tok)) {
+            if (in_array($tok[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+            if ($tok[0] === T_STRING || $tok[0] === T_NS_SEPARATOR) {
+                $name .= $tok[1];
+                continue;
+            }
+            // T_NAME_QUALIFIED on PHP 8+
+            if (defined('T_NAME_QUALIFIED') && $tok[0] === T_NAME_QUALIFIED) {
+                $name .= $tok[1];
+                continue;
+            }
+            if (defined('T_NAME_FULLY_QUALIFIED') && $tok[0] === T_NAME_FULLY_QUALIFIED) {
+                $name .= ltrim($tok[1], '\\');
+                continue;
+            }
+        }
+        break;
+    }
+    return $name;
+}
+
+function read_class_name(array $tokens, int $i): ?string
+{
+    $j = next_significant($tokens, $i);
+    if ($j === null || !is_array($tokens[$j]) || $tokens[$j][0] !== T_STRING) {
+        return null;
+    }
+    return $tokens[$j][1];
+}
+
+function next_significant(array $tokens, int $i): ?int
+{
+    $count = count($tokens);
+    for ($j = $i + 1; $j < $count; $j++) {
+        $tok = $tokens[$j];
+        if (is_array($tok) && in_array($tok[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+            continue;
+        }
+        return $j;
+    }
+    return null;
+}
+
+function previous_significant(array $tokens, int $i): ?int
+{
+    for ($j = $i - 1; $j >= 0; $j--) {
+        $tok = $tokens[$j];
+        if (is_array($tok) && in_array($tok[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+            continue;
+        }
+        return $j;
+    }
+    return null;
+}
+
+/**
+ * @param list<array{file:string,line:int,class:string,method:string}> $callSites
+ * @param array<string, array<string,bool>> $classMethods
+ * @param array<string,string> $classExtends
+ * @return list<array{file:string,line:int,class:string,method:string}>
+ */
+function filter_findings(
+    array $callSites,
+    array $classMethods,
+    array $classExtends
+): array {
+    $findings = [];
+    $resolvedCache = [];
+    foreach ($callSites as $site) {
+        $method = $site['method'];
+        if ($method === '' || $method[0] === '_') {
+            continue;
+        }
+        $underscoreName = '_' . $method;
+        $class = $site['class'];
+        if (!isset($classMethods[$class])) {
+            continue;
+        }
+        $resolved = $resolvedCache[$class] ??= resolve_inherited_methods($class, $classMethods, $classExtends);
+        // A call site is a violation iff the class chain has both the
+        // underscore form and the non-underscore form defined — i.e. a
+        // BC-shim pair is live for this class.
+        if (!isset($resolved[$method]) || !isset($resolved[$underscoreName])) {
+            continue;
+        }
+        $findings[] = $site;
+    }
+
+    usort($findings, function (array $a, array $b): int {
+        $cmp = strcmp($a['file'], $b['file']);
+        if ($cmp !== 0) {
+            return $cmp;
+        }
+        return $a['line'] <=> $b['line'];
+    });
+
+    return $findings;
+}
+
+/**
+ * Walk the `extends` chain and return the union of method names declared on
+ * the class and any of its in-scope ancestors.
+ *
+ * Handles the OXID virtual namespace: source files use'd parents as
+ * `OxidEsales\Eshop\...` (the unified runtime alias) but the concrete classes
+ * are declared under `OxidEsales\EshopCommunity\...`. When a parent FQCN
+ * doesn't resolve directly, we retry under the concrete prefix.
+ *
+ * @param array<string, array<string,bool>> $classMethods
+ * @param array<string,string> $classExtends
+ * @return array<string,bool>
+ */
+function resolve_inherited_methods(string $class, array $classMethods, array $classExtends): array
+{
+    $methods = $classMethods[$class] ?? [];
+    $seen = [$class => true];
+    $current = $class;
+    while (isset($classExtends[$current])) {
+        $parent = canonicalize_fqcn($classExtends[$current], $classMethods);
+        if (isset($seen[$parent])) {
+            break;
+        }
+        $seen[$parent] = true;
+        if (isset($classMethods[$parent])) {
+            $methods += $classMethods[$parent];
+        } else {
+            break; // Parent not in source/ scope — stop walking.
+        }
+        $current = $parent;
+    }
+    return $methods;
+}
+
+/**
+ * Translate an extends-resolved FQCN to the concrete `OxidEsales\EshopCommunity\...`
+ * form when the source file used'd the virtual `OxidEsales\Eshop\...` alias.
+ *
+ * @param array<string, array<string,bool>> $classMethods
+ */
+function canonicalize_fqcn(string $fqcn, array $classMethods): string
+{
+    if (isset($classMethods[$fqcn])) {
+        return $fqcn;
+    }
+    if (str_starts_with($fqcn, 'OxidEsales\\Eshop\\')) {
+        $concrete = 'OxidEsales\\EshopCommunity\\' . substr($fqcn, strlen('OxidEsales\\Eshop\\'));
+        if (isset($classMethods[$concrete])) {
+            return $concrete;
+        }
+    }
+    return $fqcn;
+}
+
+function write_findings(string $path, array $findings): void
+{
+    $dir = dirname($path);
+    if (!is_dir($dir)) {
+        @mkdir($dir, 0755, true);
+    }
+    $json = json_encode($findings, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+    if ($json === false) {
+        fwrite(STDERR, "error: failed to encode findings JSON\n");
+        exit(3);
+    }
+    $tmp = $path . '.tmp';
+    if (file_put_contents($tmp, $json) === false) {
+        fwrite(STDERR, "error: failed to write $tmp\n");
+        exit(3);
+    }
+    rename($tmp, $path);
+}

--- a/bin/find-internal-shim-call-sites.php
+++ b/bin/find-internal-shim-call-sites.php
@@ -40,6 +40,14 @@
 
 declare(strict_types=1);
 
+// composer.json supports php ^7.4 || ^8.0; str_starts_with is PHP 8.0+.
+if (!function_exists('str_starts_with')) {
+    function str_starts_with(string $haystack, string $needle): bool
+    {
+        return $needle === '' || strncmp($haystack, $needle, strlen($needle)) === 0;
+    }
+}
+
 exit(main($argv));
 
 function main(array $argv): int

--- a/openspec/changes/fix-internal-shim-call-sites/design.md
+++ b/openspec/changes/fix-internal-shim-call-sites/design.md
@@ -1,0 +1,109 @@
+## Context
+
+The bug (see `proposal.md`) is residual call-site drift left over from `e4e180cc`'s rename. PR #104 fixed the structural shim direction across ~225 entries and restored a small set of internal call sites in `ListComponentAjax` (the parent class). The subclasses were not swept. `InheritanceContractTest` is silent on this because its assertion is structural — it calls `method()` on a synthetic subclass overriding `_method()` and confirms the override fires; the test doesn't audit which name internal code uses to reach the override.
+
+Relevant facts about the codebase:
+- PHP 7.4+ / 8.0, PSR-4 autoload under `OxidEsales\EshopCommunity\` → `./source`; tests under `OxidEsales\EshopCommunity\Tests\` → `./tests`.
+- The pinned baseline inventory at `tests/Unit/BackwardsCompatibility/underscore-method-snapshot.json` is the authoritative list of `_method()` names. It is the input to this change's detector.
+- `bin/verify-underscore-method-body-equivalence.php` is the existing tokenizer-based sibling tool; the new detector mirrors its idioms.
+- The shop's "virtual" namespace layer is irrelevant for this change — the detector operates on source files lexically, not at runtime through the class loader.
+
+Stakeholders: same as PR #104. Core devs maintaining `b-1.6.0`; module authors writing `_method()` overrides (now the only override style honored on swept call paths).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Produce a deterministic, machine-readable list of every `$this->method(` call site in `source/` where `method` is the non-underscore counterpart of an inventory `_method` and the declaring class still has both names defined.
+- Ship a PHPUnit test that runs that detector and asserts the list is empty.
+- After the verification gate closes, remediate every listed call site by single-token rewrite to `$this->_method(`. Update affected test mocks. Update affected shim-pair PHPDocs to flag the transitional framing.
+
+**Timing assumption:** Phase 1 and Phase 2 land in the same work session, same as PR #104.
+
+**Non-Goals:**
+- Detecting `parent::method(` call sites. Those are intentional — `parent::method()` is the documented way for subclass overrides to call up the chain (see the existing `@internal` PHPDoc).
+- Detecting `static::method(` or `self::method(`. Out of scope for this pass; can be a follow-up if drift surfaces.
+- Detecting calls outside `source/` (tests, bin, vendor). Inventory scope is `source/` only by precedent.
+- The structural template-method refactor that resolves the BC-anchor / new-name tension. That is #108.
+- Removing `_method()` shims or renaming the canonical override target. Both stay during the transition.
+
+## Decisions
+
+### D1 — Detector input is the pinned baseline inventory
+
+The detector reads `tests/Unit/BackwardsCompatibility/underscore-method-snapshot.json` and treats every entry's `method` (with its leading underscore) as an in-scope name. The non-underscore counterpart is the search target. Rationale: the inventory is already the single source of truth for "which `_method()` names matter" and is reused by `InheritanceContractTest` and `verify-underscore-method-body-equivalence.php`. Reusing it keeps a consistent boundary across the three tools.
+
+### D2 — Detector matches `$this->method(` calls only
+
+Matched token sequence (using PHP's built-in tokenizer):
+```
+T_VARIABLE("$this") T_OBJECT_OPERATOR("->") T_STRING("method") "("
+```
+Only `$this->method(` is matched. `parent::method(`, `static::method(`, `self::method(`, and `$other->method(` are all out of scope. The detector reports `(file, line, declaring_class, method)` per match.
+
+Rationale: the convention being enforced is "internal calls go direct to the BC anchor." `parent::method()` is intentional (the `@internal` hint says so). Other forms are either obviously wrong (cross-instance method calls on shimmed methods are extremely rare and probably not relevant) or already covered by the structural test.
+
+### D3 — Pair-presence check before reporting
+
+A `$this->method(` call is reported only if the class declaring the call site has, in the **current** source tree, both `_method()` and `method()` defined (either directly or via inheritance from a class also in scope of the BC-shim layer). Rationale: if the class never had the shim pair (e.g. the inventory's `method` was removed entirely, or the class was added post-baseline and uses a non-shim method), `$this->method(` is just a normal method call and not a convention violation.
+
+Implementation: build a class-method map from a single tokenizer pass over `source/`, then filter the call-site matches against it. Single pass for performance and determinism.
+
+### D4 — Findings file shape
+
+```json
+[
+  {
+    "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+    "line": 190,
+    "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+    "method": "getQuery"
+  },
+  …
+]
+```
+
+Sorted deterministically by `(file, line)`. Path is repo-relative. The `class` is the FQCN at the call site (concrete `EshopCommunity\` namespace; the unified namespace is irrelevant for this lexical analysis). The `method` is the non-underscore form (the actual call as written).
+
+Output written to `openspec/changes/fix-internal-shim-call-sites/findings.json`. Same convention as the parent change.
+
+### D5 — Test runs the detector in-process; CI red until Phase 2
+
+`InternalShimCallSitesTest` instantiates the detector class and asserts the returned list is empty. No shell-out. Rationale: same as `InheritanceContractTest` — keeps the test self-contained and fast.
+
+Between Phase 1 landing and Phase 2 closing, the new test will be red. Acceptable because Phases 1 and 2 land in the same session.
+
+### D6 — Remediation transform
+
+For each approved finding `(file, line, class, method)`:
+1. In `file`, find the **single** `$this->method(` token sequence on `line` (the detector pinpoints exactly one).
+2. Replace `T_STRING("method")` with `T_STRING("_method")`. Single token substitution.
+3. No reformat. No re-indentation. No changes to surrounding code.
+
+This preserves diff hygiene — every line in the diff is a single-token change, easy to review.
+
+### D7 — PHPDoc rewrite (gate-conditional)
+
+If the gate approves the PHPDoc rewrite, every shim pair touched in Phase 2 (or every shim pair from PR #104, depending on the gate decision) gets:
+- `_method()` PHPDoc: `@deprecated` block rewritten to flag transitional state, name `method()` as the eventual successor (per #108), advise modules to override `_method()` *for now*, with a "plan extension work with both stages in mind" note.
+- `method()` PHPDoc: `@internal` block rewritten to clarify it's the public delegate during the transition, that internal call paths bypass it after this sweep, and that #108 will eventually invert this.
+
+The three load-bearing clauses on each must be preserved across PHPDoc-style variations: transitional framing, `_method()` is the safe override target now, `method()` is the long-term canonical target per #108.
+
+### D8 — Test-mock updates ride with the production rewrite
+
+Per file: after rewriting `$this->method(` → `$this->_method(` in production, run the file's targeted unit test. If the test mocks the production-name method, update the mock to the underscore name. Same pattern `c4eb488` applied to `AjaxListComponentTest`. Mock-string updates are tracked in the same commit as the production rewrite — never split.
+
+### D9 — Equivalence check unchanged
+
+`bin/verify-underscore-method-body-equivalence.php` already verifies that `_method()` bodies match baseline. This change does not move bodies — it only edits call sites and PHPDoc. The equivalence tool stays green throughout.
+
+## Risks / Trade-offs
+
+- **Risk:** the detector misses a call form (e.g. dynamic `$this->{$name}(...)`) or false-flags a non-shim method that happens to share a name. Mitigation: hand-spot-check the findings file against grep output before the gate; the AdminAjax trio's count is known (~143). False-positive rate at the gate.
+- **Risk:** PHPDoc rewrite mass-touches files outside the call-site batch. Mitigation: limit PHPDoc rewrites to classes appearing in the findings, unless the gate explicitly approves the broader rewrite. Smaller scope = smaller blast radius for review.
+- **Trade-off:** committing to BC-anchor-only narrows the override surface. Module authors who built large `method()` overrides on the new name will silently lose dispatch on swept call paths. Mitigation: explicit PHPDoc rewrite that calls this out, and the PR body that flags the design choice. #108 inverts it later.
+
+## Open Questions
+
+- Whether to land Phases 1 and 2 in one PR or two. Same question as PR #104; default: one PR per directory batch, but a single large PR is acceptable if review bandwidth allows. Decided at the gate.
+- Whether the new test should additionally enforce the `parent::method(...)` form for `parent::` calls (currently out of scope). Probably yes for completeness, but defer to a follow-up — this PR's scope is `$this->` only.

--- a/openspec/changes/fix-internal-shim-call-sites/findings.json
+++ b/openspec/changes/fix-internal-shim-call-sites/findings.json
@@ -1,0 +1,2144 @@
+[
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 116,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "setListLocatorData"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 132,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "loadIdsInList"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 135,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "findActPageNumber"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 139,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "getProductPos"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 146,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "makeLink"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 146,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "getPageNumber"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 151,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "makeLink"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 152,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "makeLink"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 176,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "setVendorLocatorData"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 201,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "findActPageNumber"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 210,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "getProductPos"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 215,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "makeLink"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 215,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "getPageNumber"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 220,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "makeLink"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 221,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "makeLink"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 237,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "setManufacturerLocatorData"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 262,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "findActPageNumber"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 271,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "getProductPos"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 278,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "makeLink"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 278,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "getPageNumber"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 283,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "makeLink"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 284,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "makeLink"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 308,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "setSearchLocatorData"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 342,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "findActPageNumber"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 361,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "getProductPos"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 363,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "getPageNumber"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 365,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "makeLink"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 368,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "makeLink"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 369,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "makeLink"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 398,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "findActPageNumber"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 411,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "getProductPos"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 419,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "makeLink"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 419,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "getPageNumber"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 421,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "makeLink"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 430,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "makeLink"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 431,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "makeLink"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 457,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "loadIdsInList"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 505,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "makeLink"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 538,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "findActPageNumber"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 579,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "getPageNumber"
+    },
+    {
+        "file": "source/Application/Component/Locator.php",
+        "line": 610,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+        "method": "getProductPos"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsArticleAjax.php",
+        "line": 78,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsArticleAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsArticleAjax.php",
+        "line": 79,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsArticleAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsArticleAjax.php",
+        "line": 143,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsArticleAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsGroupsAjax.php",
+        "line": 72,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsGroupsAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsGroupsAjax.php",
+        "line": 120,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsGroupsAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsGroupsAjax.php",
+        "line": 142,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsGroupsAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsGroupsAjax.php",
+        "line": 143,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsGroupsAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+        "line": 93,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+        "line": 94,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+        "line": 167,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+        "line": 245,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+        "method": "getOxRssFeed"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+        "line": 248,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+        "line": 270,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+        "method": "getOxRssFeed"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+        "line": 273,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+        "line": 274,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+        "line": 279,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+        "line": 317,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+        "line": 361,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+        "line": 366,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+        "method": "getData"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+        "line": 377,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+        "method": "getOxRssFeed"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsOrderAjax.php",
+        "line": 65,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsOrderAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsOrderAjax.php",
+        "line": 165,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsOrderAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ActionsOrderAjax.php",
+        "line": 170,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsOrderAjax",
+        "method": "getData"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminController.php",
+        "line": 201,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminController",
+        "method": "authorize"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminController.php",
+        "line": 342,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminController",
+        "method": "setupNavigation"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminController.php",
+        "line": 408,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminController",
+        "method": "getMaxUploadFileInfo"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminController.php",
+        "line": 429,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminController",
+        "method": "getMaxUploadFileInfo"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminController.php",
+        "line": 477,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminController",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminController.php",
+        "line": 543,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminController",
+        "method": "allowAdminEdit"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminController.php",
+        "line": 570,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminController",
+        "method": "getCountryByCode"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminController.php",
+        "line": 621,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminController",
+        "method": "authorize"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminDetailsController.php",
+        "line": 219,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminDetailsController",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminDetailsController.php",
+        "line": 228,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminDetailsController",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminDetailsController.php",
+        "line": 237,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminDetailsController",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminListController.php",
+        "line": 296,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminListController.php",
+        "line": 707,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+        "method": "changeselect"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminListController.php",
+        "line": 750,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+        "method": "convertToDBDate"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminListController.php",
+        "line": 775,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+        "method": "convertToDBDate"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminListController.php",
+        "line": 795,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+        "method": "convertTime"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminListController.php",
+        "line": 797,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+        "method": "convertDate"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminListController.php",
+        "line": 804,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+        "method": "convertDate"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminListController.php",
+        "line": 821,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+        "method": "convertDate"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminListController.php",
+        "line": 872,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+        "method": "convertTime"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminListController.php",
+        "line": 923,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+        "method": "setListNavigationParams"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminListController.php",
+        "line": 1017,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+        "method": "setupNavigation"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminListController.php",
+        "line": 1090,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+        "method": "changeselect"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminRightsMainAjax.php",
+        "line": 77,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminRightsMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminRightsMainAjax.php",
+        "line": 125,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminRightsMainAjax",
+        "method": "getActionIds"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminRightsMainAjax.php",
+        "line": 128,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminRightsMainAjax",
+        "method": "addFilter"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminRightsMainAjax.php",
+        "line": 128,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminRightsMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminRightsMainAjax.php",
+        "line": 141,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminRightsMainAjax",
+        "method": "getActionIds"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminRightsMainAjax.php",
+        "line": 146,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminRightsMainAjax",
+        "method": "getAll"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminRightsMainAjax.php",
+        "line": 146,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminRightsMainAjax",
+        "method": "addFilter"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AdminRightsMainAjax.php",
+        "line": 146,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminRightsMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleAccessoriesAjax.php",
+        "line": 165,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAccessoriesAjax",
+        "method": "getSorting"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleAttributeAjax.php",
+        "line": 76,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAttributeAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleAttributeAjax.php",
+        "line": 77,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAttributeAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleAttributeAjax.php",
+        "line": 117,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAttributeAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleAttributeAjax.php",
+        "line": 118,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAttributeAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleAttributeAjax.php",
+        "line": 138,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAttributeAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleAttributeAjax.php",
+        "line": 139,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAttributeAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleAttributeAjax.php",
+        "line": 164,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAttributeAjax",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleAttributeAjax.php",
+        "line": 179,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAttributeAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleBundleAjax.php",
+        "line": 76,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleBundleAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleBundleAjax.php",
+        "line": 77,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleBundleAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleBundleAjax.php",
+        "line": 142,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleBundleAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleCrosssellingAjax.php",
+        "line": 87,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleCrosssellingAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleCrosssellingAjax.php",
+        "line": 88,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleCrosssellingAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleCrosssellingAjax.php",
+        "line": 172,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleCrosssellingAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleCrosssellingAjax.php",
+        "line": 191,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleCrosssellingAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleCrosssellingAjax.php",
+        "line": 192,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleCrosssellingAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+        "line": 74,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+        "line": 75,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+        "line": 193,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+        "line": 194,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+        "line": 211,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+        "line": 227,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+        "line": 231,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+        "line": 232,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+        "line": 261,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+        "line": 276,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+        "method": "updateOxTime"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+        "line": 289,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+        "line": 327,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleMain.php",
+        "line": 428,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleMain.php",
+        "line": 531,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+        "method": "copyAttributes"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleMain.php",
+        "line": 576,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+        "method": "copyFiles"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleMain.php",
+        "line": 622,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+        "method": "copySelectlists"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleMain.php",
+        "line": 669,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+        "method": "copyCrossseling"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleMain.php",
+        "line": 716,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+        "method": "copyAccessoires"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleMain.php",
+        "line": 761,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+        "method": "copyStaffelpreis"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleMain.php",
+        "line": 800,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+        "method": "copyArtExtends"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleMain.php",
+        "line": 849,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+        "method": "formJumpList"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleMain.php",
+        "line": 864,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+        "method": "getTitle"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleMain.php",
+        "line": 869,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+        "method": "getTitle"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleMain.php",
+        "line": 874,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+        "method": "getTitle"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleMain.php",
+        "line": 881,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+        "method": "getTitle"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleMain.php",
+        "line": 886,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+        "method": "getTitle"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleMain.php",
+        "line": 905,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+        "method": "getTitle"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleReview.php",
+        "line": 177,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleReview",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleSelectionAjax.php",
+        "line": 73,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSelectionAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleSelectionAjax.php",
+        "line": 74,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSelectionAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleSelectionAjax.php",
+        "line": 129,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSelectionAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleSelectionAjax.php",
+        "line": 154,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSelectionAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleSelectionAjax.php",
+        "line": 155,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSelectionAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleSeo.php",
+        "line": 154,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSeo",
+        "method": "getVendorList"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleSeo.php",
+        "line": 158,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSeo",
+        "method": "getManufacturerList"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleSeo.php",
+        "line": 249,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSeo",
+        "method": "getVendorList"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleSeo.php",
+        "line": 283,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSeo",
+        "method": "getManufacturerList"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleSeo.php",
+        "line": 385,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSeo",
+        "method": "getAltSeoEntryId"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleSeo.php",
+        "line": 406,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSeo",
+        "method": "getType"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleSeo.php",
+        "line": 441,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSeo",
+        "method": "getEncoder"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleSeo.php",
+        "line": 466,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSeo",
+        "method": "getEncoder"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleStock.php",
+        "line": 156,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleStock",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleStock.php",
+        "line": 250,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleStock",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleVariant.php",
+        "line": 285,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleVariant",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleVariant.php",
+        "line": 303,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleVariant",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleVariant.php",
+        "line": 318,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleVariant",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ArticleVariant.php",
+        "line": 347,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleVariant",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AttributeCategoryAjax.php",
+        "line": 83,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeCategoryAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AttributeCategoryAjax.php",
+        "line": 135,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeCategoryAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AttributeCategoryAjax.php",
+        "line": 143,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeCategoryAjax",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AttributeCategoryAjax.php",
+        "line": 159,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeCategoryAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AttributeCategoryAjax.php",
+        "line": 160,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeCategoryAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AttributeCategoryAjax.php",
+        "line": 185,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeCategoryAjax",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AttributeMainAjax.php",
+        "line": 90,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AttributeMainAjax.php",
+        "line": 91,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AttributeMainAjax.php",
+        "line": 92,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AttributeMainAjax.php",
+        "line": 163,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AttributeMainAjax.php",
+        "line": 200,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AttributeMainAjax.php",
+        "line": 202,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AttributeMainAjax.php",
+        "line": 221,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AttributeMainAjax.php",
+        "line": 222,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AttributeOrderAjax.php",
+        "line": 63,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeOrderAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AttributeOrderAjax.php",
+        "line": 160,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeOrderAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/AttributeOrderAjax.php",
+        "line": 165,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeOrderAjax",
+        "method": "getData"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+        "line": 88,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+        "line": 89,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+        "line": 152,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+        "line": 196,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+        "line": 200,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+        "line": 204,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+        "line": 254,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+        "method": "updateOxTime"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+        "line": 267,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+        "line": 315,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+        "line": 316,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+        "line": 82,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+        "line": 83,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+        "line": 144,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+        "line": 189,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+        "line": 190,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+        "line": 230,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+        "line": 231,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+        "line": 262,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+        "line": 266,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategorySeo.php",
+        "line": 53,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategorySeo",
+        "method": "getEncoder"
+    },
+    {
+        "file": "source/Application/Controller/Admin/CategorySeo.php",
+        "line": 157,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategorySeo",
+        "method": "getEncoder"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ContentSeo.php",
+        "line": 109,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ContentSeo",
+        "method": "getEncoder"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryArticlesAjax.php",
+        "line": 89,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryArticlesAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryArticlesAjax.php",
+        "line": 90,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryArticlesAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryArticlesAjax.php",
+        "line": 162,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryArticlesAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryArticlesAjax.php",
+        "line": 180,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryArticlesAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryArticlesAjax.php",
+        "line": 181,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryArticlesAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryCategoriesAjax.php",
+        "line": 74,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryCategoriesAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryCategoriesAjax.php",
+        "line": 131,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryCategoriesAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryCategoriesAjax.php",
+        "line": 150,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryCategoriesAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryCategoriesAjax.php",
+        "line": 151,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryCategoriesAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryGroupsAjax.php",
+        "line": 74,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryGroupsAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryGroupsAjax.php",
+        "line": 123,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryGroupsAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryGroupsAjax.php",
+        "line": 142,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryGroupsAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryGroupsAjax.php",
+        "line": 143,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryGroupsAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryMainAjax.php",
+        "line": 74,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryMainAjax.php",
+        "line": 123,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryMainAjax.php",
+        "line": 141,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryMainAjax.php",
+        "line": 142,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetCountryAjax.php",
+        "line": 78,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetCountryAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetCountryAjax.php",
+        "line": 125,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetCountryAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetCountryAjax.php",
+        "line": 144,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetCountryAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetCountryAjax.php",
+        "line": 145,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetCountryAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetGroupsAjax.php",
+        "line": 74,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetGroupsAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetGroupsAjax.php",
+        "line": 120,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetGroupsAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetGroupsAjax.php",
+        "line": 139,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetGroupsAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetGroupsAjax.php",
+        "line": 140,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetGroupsAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetMainAjax.php",
+        "line": 77,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetMainAjax.php",
+        "line": 118,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetMainAjax.php",
+        "line": 138,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetMainAjax.php",
+        "line": 139,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetPaymentAjax.php",
+        "line": 77,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetPaymentAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetPaymentAjax.php",
+        "line": 118,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetPaymentAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetPaymentAjax.php",
+        "line": 138,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetPaymentAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetPaymentAjax.php",
+        "line": 139,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetPaymentAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetUsersAjax.php",
+        "line": 91,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetUsersAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetUsersAjax.php",
+        "line": 145,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetUsersAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetUsersAjax.php",
+        "line": 163,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetUsersAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliverySetUsersAjax.php",
+        "line": 164,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetUsersAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryUsersAjax.php",
+        "line": 87,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryUsersAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryUsersAjax.php",
+        "line": 141,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryUsersAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryUsersAjax.php",
+        "line": 159,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryUsersAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DeliveryUsersAjax.php",
+        "line": 160,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryUsersAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountArticlesAjax.php",
+        "line": 92,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountArticlesAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountArticlesAjax.php",
+        "line": 93,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountArticlesAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountArticlesAjax.php",
+        "line": 155,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountArticlesAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountArticlesAjax.php",
+        "line": 174,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountArticlesAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountArticlesAjax.php",
+        "line": 175,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountArticlesAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountCategoriesAjax.php",
+        "line": 82,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountCategoriesAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountCategoriesAjax.php",
+        "line": 135,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountCategoriesAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountCategoriesAjax.php",
+        "line": 154,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountCategoriesAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountCategoriesAjax.php",
+        "line": 155,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountCategoriesAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountGroupsAjax.php",
+        "line": 75,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountGroupsAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountGroupsAjax.php",
+        "line": 122,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountGroupsAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountGroupsAjax.php",
+        "line": 141,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountGroupsAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountGroupsAjax.php",
+        "line": 142,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountGroupsAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountItemAjax.php",
+        "line": 79,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountItemAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountItemAjax.php",
+        "line": 80,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountItemAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountItemAjax.php",
+        "line": 81,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountItemAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountItemAjax.php",
+        "line": 220,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountItemAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountItemAjax.php",
+        "line": 241,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountItemAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountMainAjax.php",
+        "line": 73,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountMainAjax.php",
+        "line": 117,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountMainAjax.php",
+        "line": 135,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountMainAjax.php",
+        "line": 136,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountUsersAjax.php",
+        "line": 87,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountUsersAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountUsersAjax.php",
+        "line": 142,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountUsersAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountUsersAjax.php",
+        "line": 160,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountUsersAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DiscountUsersAjax.php",
+        "line": 161,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountUsersAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 223,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "getHeapTableName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 485,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "findDeepestCatPath"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 498,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "getHeapTableName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 503,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "generateTableCharSet"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 506,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "createHeapTable"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 511,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "getCatAdd"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 512,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "insertArticles"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 543,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "getHeapTableName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 545,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "setCampaignDetailLink"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 587,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "unHtmlEntities"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 613,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "getHeapTableName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 639,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "generateTableCharSet"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 683,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "createHeapTable"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 720,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "getCatAdd"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 764,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "insertArticles"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 833,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "removeParentArticles"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 877,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "setSessionParams"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 936,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "loadRootCats"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 1002,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "findDeepestCatPath"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 1021,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "loadRootCats"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 1061,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "initArticle"
+    },
+    {
+        "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+        "line": 1113,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+        "method": "setCampaignDetailLink"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+        "line": 283,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+        "method": "getData"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+        "line": 529,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+        "line": 659,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+        "method": "getSortDir"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+        "line": 756,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+        "line": 880,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+        "method": "getSortDir"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+        "line": 906,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+        "method": "getStartIndex"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+        "line": 930,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+        "method": "getTotalCount"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+        "line": 996,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+        "method": "outputResponse"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+        "line": 1017,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+        "method": "output"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+        "line": 1040,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+        "line": 1068,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+        "method": "getData"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+        "line": 1086,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+        "method": "getStartIndex"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+        "line": 1088,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+        "method": "getSortDir"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+        "line": 1098,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+        "method": "getTotalCount"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ManufacturerMainAjax.php",
+        "line": 87,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ManufacturerMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ManufacturerMainAjax.php",
+        "line": 88,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ManufacturerMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ManufacturerMainAjax.php",
+        "line": 147,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ManufacturerMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ManufacturerMainAjax.php",
+        "line": 183,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ManufacturerMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ManufacturerMainAjax.php",
+        "line": 184,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ManufacturerMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ManufacturerMainAjax.php",
+        "line": 222,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ManufacturerMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ManufacturerMainAjax.php",
+        "line": 223,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ManufacturerMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ManufacturerSeo.php",
+        "line": 153,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ManufacturerSeo",
+        "method": "getEncoder"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ModuleConfiguration.php",
+        "line": 197,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ModuleConfiguration",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationController.php",
+        "line": 123,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationController",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 119,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "addLinks"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 157,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "loadFromFile"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 275,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "sessionizeLocalUrls"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 285,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "getAdminUrl"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 307,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "checkRights"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 325,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "hasRights"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 333,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "hasRights"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 349,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "checkGroups"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 367,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "hasGroup"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 375,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "hasGroup"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 393,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "checkDemoShopDenials"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 444,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "copyAttributes"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 471,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "mergeNodes"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 520,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "merge"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 612,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "getMenuFiles"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 688,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "processCachedFile"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 711,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "getInitialDom"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 724,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "getMenuFiles"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 763,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "processCachedFile"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 785,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "getInitialDom"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 899,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "getAdminUrl"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 930,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "hasRights"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 955,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "hasGroup"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NavigationTree.php",
+        "line": 979,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+        "method": "getInitialDom"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NewsMainAjax.php",
+        "line": 72,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NewsMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NewsMainAjax.php",
+        "line": 116,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NewsMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NewsMainAjax.php",
+        "line": 133,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NewsMainAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NewsMainAjax.php",
+        "line": 134,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NewsMainAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NewsletterSelectionAjax.php",
+        "line": 70,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NewsletterSelectionAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NewsletterSelectionAjax.php",
+        "line": 116,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NewsletterSelectionAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NewsletterSelectionAjax.php",
+        "line": 133,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NewsletterSelectionAjax",
+        "method": "getViewName"
+    },
+    {
+        "file": "source/Application/Controller/Admin/NewsletterSelectionAjax.php",
+        "line": 134,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NewsletterSelectionAjax",
+        "method": "getQuery"
+    },
+    {
+        "file": "source/Application/Controller/Admin/OrderList.php",
+        "line": 111,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\OrderList",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ShopConfiguration.php",
+        "line": 185,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ShopConfiguration",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Controller/Admin/ThemeMain.php",
+        "line": 114,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ThemeMain",
+        "method": "resetContentCache"
+    },
+    {
+        "file": "source/Application/Model/Article.php",
+        "line": 996,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+        "method": "getPrice"
+    },
+    {
+        "file": "source/Application/Model/Article.php",
+        "line": 1037,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+        "method": "getVarMinPrice"
+    },
+    {
+        "file": "source/Application/Model/Article.php",
+        "line": 1735,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+        "method": "getPrice"
+    },
+    {
+        "file": "source/Application/Model/Article.php",
+        "line": 2069,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+        "method": "getPrice"
+    },
+    {
+        "file": "source/Application/Model/Article.php",
+        "line": 2114,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+        "method": "getVarMinPrice"
+    },
+    {
+        "file": "source/Application/Model/Article.php",
+        "line": 2117,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+        "method": "getPrice"
+    },
+    {
+        "file": "source/Application/Model/Article.php",
+        "line": 3187,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+        "method": "getPrice"
+    },
+    {
+        "file": "source/Application/Model/Article.php",
+        "line": 3219,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+        "method": "getPrice"
+    },
+    {
+        "file": "source/Application/Model/Article.php",
+        "line": 4526,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+        "method": "getAmountPriceList"
+    },
+    {
+        "file": "source/Application/Model/Basket.php",
+        "line": 3039,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Basket",
+        "method": "addedNewItem"
+    },
+    {
+        "file": "source/Application/Model/Content.php",
+        "line": 513,
+        "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Content",
+        "method": "getFieldData"
+    }
+]

--- a/openspec/changes/fix-internal-shim-call-sites/proposal.md
+++ b/openspec/changes/fix-internal-shim-call-sites/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+PR [#104](https://github.com/o3-shop/shop-ce/pull/104) (commit `45e71ae`) closed the **structural** half of issue [#107](https://github.com/o3-shop/o3-shop/issues/107): for every `(Class, _method)` entry from baseline `ebe86dc08875034d5a3d0533b7cbdede7cc6abff`, the implementation body was moved back to `_method()` and `method()` was rewritten as a one-line delegate `return $this->_method(...)`. The runtime `InheritanceContractTest` proves that calling the public `method()` correctly dispatches to a subclass override of `_method()`; `findings.json` for that change is empty.
+
+PR #104 also restored a small set of internal call sites in the parent class `ListComponentAjax` (notably `processRequest` line 257: `$sQAdd = $this->_getQuery();`). It missed the **subclasses**. A direct grep across `source/` finds 60+ `$this->getQuery(`, 52+ `$this->addFilter(`, 31+ `$this->getAll(` call sites — all in `ListComponentAjax` descendants, all inherited from `e4e180cc`'s rename, none restored. Ralf's reopen comment on #107 flags this:
+
+> We found a few more remaining pieces: `$this->getQuery()` is called internally on still quite some places — even after this fix. Needs to be reverted, too.
+
+The same shape of drift almost certainly affects other entries in the 677-row baseline inventory. This change finishes the baseline restoration in the subclasses and adds an automated guard that prevents the same drift from recurring.
+
+This is **not a correctness fix** — `InheritanceContractTest` already proves the public-surface dispatch contract holds. Both `$this->method()` and `$this->_method()` reach a module's `_method()` override via virtual dispatch (the public-name path takes one extra hop through the delegate). It is a **convention sweep** that pins `_method()` (the BC anchor) as the canonical override target during the transition period before #108's template-method refactor.
+
+## Trade-off this commits to
+
+Internal calls on the BC anchor narrow dispatch to `_method()` overrides only. Module overrides of the new public `method()` are bypassed by any internal path that has been swept. This is a deliberate design choice — the codebase commits to BC anchor (`_method()`) as the canonical override target during the transition. The current PHPDocs say the opposite (`@deprecated … new code MUST NOT call or override _method()`). They MUST be updated to flag this as transitional and point at #108 as the long-term inversion target. Without that framing, module authors reading "MUST override `_method()`" would commit to a name slated for removal and migrate twice.
+
+## What Changes
+
+### Phase 1 — Detection
+- Add a tokenizer-based detector script `bin/find-internal-shim-call-sites.php` that, given the existing pinned inventory at `tests/Unit/BackwardsCompatibility/underscore-method-snapshot.json`, walks every `.php` under `source/`, finds each `$this->method(` where `method` is the non-underscore counterpart of an inventory `_method` entry **and** the class declaring the call site still has both `_method()` and `method()` defined. Emits deterministic JSON `{file, line, class, method}`.
+- Add a PHPUnit test `tests/Unit/BackwardsCompatibility/InternalShimCallSitesTest.php` that runs the detector logic and asserts the findings list is empty. Mirrors `InheritanceContractTest`'s shape so it slots into the existing CI gate. Docblock cross-references `InheritanceContractTest` and explains the division of labour: structural BC vs. call-site convention.
+- Produce `openspec/changes/fix-internal-shim-call-sites/findings.json` with the current set of violations.
+
+### Verification gate
+- The findings list is reviewed and signed off before any production code is touched. Phase 2 does not start until this gate passes. Three decisions to record:
+  1. Sweep scope: full inventory or AdminAjax trio first?
+  2. PHPDoc rewrite scope: every shim pair touched in Phase 2, or all 225 from PR #104?
+  3. Batching: one PR or per-directory?
+
+### Phase 2 — Remediation
+- For every approved finding, rewrite `$this->method(` → `$this->_method(`. Token-aware, single-token substitution, no reformat.
+- Update PHPDoc on each affected shim pair (per gate decision): `@deprecated`/`@internal` blocks rewritten to flag the transitional state and reference #108 as the long-term inversion target.
+- Update tests that mock the public name to mock the underscore name (same pattern `c4eb488` applied to `AjaxListComponentTest`).
+- After each batch, run targeted unit tests then the full unit suite to catch cross-cutting regressions.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `legacy-method-inheritance-contract`: extend with a **call-site-form requirement** for parent classes that hold a BC-shim pair. The structural dispatch contract (Phase 1 of `fix-underscore-method-inheritance`) remains unchanged; this change adds the convention layer that pins which name internal code SHOULD use.
+
+### New Capabilities
+<!-- None: the convention layer extends an existing capability. -->
+
+## Impact
+
+- **Production code (Phase 2):** Every approved call-site rewrite is a single-token substitution. PHPDoc rewrites are localised to shim-pair PHPDoc blocks; no signature changes.
+- **Production code (Phase 1):** None.
+- **Tests:** New PHPUnit test that runs the detector against the current source tree. Plus mock-string updates in tests that mock the public name of a swept method.
+- **Tooling:** `bin/find-internal-shim-call-sites.php` (new). Lives alongside the existing `bin/verify-underscore-method-body-equivalence.php`.
+- **CI gating:** Between Phase 1 landing and the verification gate closing, the new test will be red. Either skipped-with-annotation until Phase 2 lands, or both phases land in the same PR — gate decision.
+- **Extenders / modules:** Behaviorally neutral for modules that override `_method()`. Module overrides of the new public `method()` lose dispatch on swept call paths — by design, per the trade-off above.
+- **Dependencies:** None new. Reuses the existing PHPUnit setup, PHP Reflection, and the pinned baseline inventory.
+- **Docs:** PHPDoc on every swept shim pair gets the transitional-framing rewrite. A short note in the upgrade/migration section pointing extenders at the call-site rule, added alongside Phase 2.

--- a/openspec/changes/fix-internal-shim-call-sites/specs/legacy-method-inheritance-contract/spec.md
+++ b/openspec/changes/fix-internal-shim-call-sites/specs/legacy-method-inheritance-contract/spec.md
@@ -1,0 +1,114 @@
+## ADDED Requirements
+
+### Requirement: Internal call sites of BC-shim methods use the underscore form
+
+For every `(class, _methodName)` entry in the baseline inventory whose class declares both `_methodName()` and a sibling `methodName()` in the current codebase, every internal call expressed as `$this->methodName(...)` inside any file under `source/` SHALL be written as `$this->_methodName(...)` instead. This pins `_methodName()` (the BC anchor) as the canonical override target for the duration of the BC-shim transition.
+
+`parent::methodName(...)`, `static::methodName(...)`, and `self::methodName(...)` are out of scope for this requirement — `parent::` calls are intentional per the existing `@internal` PHPDoc directive, and the other forms are not produced by the BC-shim pattern.
+
+#### Scenario: Internal call site uses the underscore form
+
+- **WHEN** a class in `source/` declares both `_methodName()` and `methodName()` per the BC-shim pattern
+- **AND** any method body in the class chain expresses an internal call as `$this->methodName(...)`
+- **THEN** the call SHALL be written as `$this->_methodName(...)` instead
+
+#### Scenario: `parent::` calls are exempt
+
+- **WHEN** a subclass override of `methodName()` calls `parent::methodName(...)` to delegate up the chain
+- **THEN** the call is exempt from this requirement and remains unchanged
+
+#### Scenario: Classes without the shim pair are exempt
+
+- **WHEN** a class does not declare both `_methodName()` and `methodName()`
+- **THEN** any `$this->methodName(...)` call in that class is not subject to this requirement
+
+### Requirement: Convention-enforcement test for internal call sites
+
+The system SHALL include a PHPUnit test that, driven by the pinned baseline inventory, statically scans `source/` for `$this->methodName(...)` call sites that violate the call-site form requirement and asserts the violation list is empty. The test runs in the normal `tests/Unit/` suite alongside `InheritanceContractTest`.
+
+The test MUST distinguish itself from `InheritanceContractTest`:
+- `InheritanceContractTest` enforces structural BC: a subclass override of `_methodName()` is dispatched through every public entry point.
+- This new test enforces call-site convention: internal code uses `$this->_methodName(...)` rather than `$this->methodName(...)`.
+
+#### Scenario: Test fails when an internal call site uses the non-underscore form
+
+- **WHEN** any file under `source/` contains `$this->methodName(...)` for a `methodName` that is the non-underscore counterpart of an inventory `_methodName` entry, in a class declaring both names
+- **THEN** the test fails and records the `(file, line, class, method)` of the violation
+
+#### Scenario: Test passes when no violations exist
+
+- **WHEN** every internal call site of a BC-shim method uses the underscore form
+- **THEN** the test passes and emits no findings file (or emits an empty array)
+
+### Requirement: Reproducible call-site detector script
+
+The system SHALL provide a tokenizer-based detector script at `bin/find-internal-shim-call-sites.php` that produces the call-site findings list. The script MUST:
+- Accept `--inventory=<path>`, `--source-root=<path>`, `--output=<path>`, `--help`, `-h`
+- Resolve the repo root by running `git -C __DIR__ rev-parse --show-toplevel` and resolve all default paths against it (caller `cwd`-independent)
+- Default `--inventory` to `tests/Unit/BackwardsCompatibility/underscore-method-snapshot.json`
+- Default `--source-root` to `source/`
+- Default `--output` to `openspec/changes/fix-internal-shim-call-sites/findings.json`
+- Tokenize each `.php` file under the source root with PHP's built-in `token_get_all()` and emit `(file, line, declaring_class, method)` for every `$this->method(` call site that satisfies the pair-presence check
+- Sort findings deterministically by `(file, line)` and serialize as pretty-printed JSON with a trailing newline
+- Write atomically to the resolved output path
+- Print a usage summary on `--help`/`-h` with no side effects (no source walking, no output written, no `chdir`)
+
+#### Scenario: Default invocation produces the canonical findings file
+
+- **WHEN** the script is invoked with no arguments
+- **THEN** the script reads the default inventory, walks the default source root, and writes findings to the default output path
+
+#### Scenario: `--help` is non-side-effecting
+
+- **WHEN** the script is invoked with `--help` or `-h` (with or without additional flags)
+- **THEN** the script writes a usage summary to stdout and exits 0
+- **AND** no source walking happens, no output file is written, and the caller's `cwd` is unchanged
+
+#### Scenario: Path resolution is `cwd`-independent
+
+- **WHEN** the script is invoked from outside the repository root
+- **THEN** all default paths resolve against the repo root via `git rev-parse --show-toplevel`, not against the caller's `cwd`
+
+### Requirement: Findings file shape
+
+When the call-site detector emits findings, the system SHALL write a machine-readable findings list as JSON to `openspec/changes/fix-internal-shim-call-sites/findings.json`. Each entry MUST include:
+- `file`: repo-relative source path
+- `line`: integer line number of the call site
+- `class`: concrete FQCN at the call site under `OxidEsales\EshopCommunity\...`
+- `method`: the non-underscore method name as written in the call
+
+Findings entries SHALL be sorted deterministically by `(file, line)`.
+
+#### Scenario: Findings are emitted on a non-empty run
+
+- **WHEN** the detector identifies one or more call-site violations
+- **THEN** a valid JSON file exists at the findings path with one entry per violation, deterministically sorted
+
+#### Scenario: Findings file is empty after a clean run
+
+- **WHEN** the detector identifies zero violations
+- **THEN** the findings file is either absent or contains an empty JSON array
+
+### Requirement: PHPDoc transitional framing on remediated shim pairs
+
+When remediation rewrites a class's internal call sites for an inventory entry, the PHPDoc blocks of `_methodName()` and `methodName()` SHALL be updated to flag the BC-shim pair as a **transitional** state and reference [o3-shop/o3-shop#108](https://github.com/o3-shop/o3-shop/issues/108) as the long-term inversion target. Three load-bearing clauses must be present in substance across PHPDoc-style variations:
+
+For `_methodName()`:
+- `@deprecated` tag identifying this as transitional
+- The instruction that modules SHOULD override `_methodName()` for now (since internal call paths route through it)
+- A pointer to #108 as the eventual inversion target that promotes `methodName()` to canonical
+
+For `methodName()`:
+- `@internal` annotation explaining this is a public delegate during the transition
+- The note that internal call paths bypass this name after the sweep
+- A pointer to #108 as the eventual inversion target
+
+#### Scenario: Transitional framing is present on every remediated pair
+
+- **WHEN** a class is touched by Phase 2 remediation
+- **THEN** the PHPDoc of `_methodName()` contains a transitional `@deprecated` block referencing #108, and the PHPDoc of `methodName()` contains the `@internal` block referencing #108
+
+#### Scenario: Existing PHPDoc style is preserved
+
+- **WHEN** the file uses a PHPDoc style that differs from the canonical template
+- **THEN** the wording adapts to match the local style, while the three load-bearing clauses remain in substance

--- a/openspec/changes/fix-internal-shim-call-sites/tasks.md
+++ b/openspec/changes/fix-internal-shim-call-sites/tasks.md
@@ -1,0 +1,45 @@
+## 1. Phase 1 — Detector script
+
+- [ ] 1.1 Create `bin/find-internal-shim-call-sites.php`: CLI skeleton, accepts `--inventory=<path>`, `--source-root=<path>`, `--output=<path>`, `--help`, `-h`; default inventory `tests/Unit/BackwardsCompatibility/underscore-method-snapshot.json`, default source root `source/`, default output `openspec/changes/fix-internal-shim-call-sites/findings.json`
+- [ ] 1.2 Implement `--help` / `-h` handler: print synopsis, options with defaults, one example invocation; exit 0; no side effects; takes precedence over all other flags
+- [ ] 1.3 Resolve repo root via `git -C __DIR__ rev-parse --show-toplevel`; resolve all default paths against it (caller cwd-independent)
+- [ ] 1.4 Load + parse the inventory file; build a set of `_method` names (with leading underscore)
+- [ ] 1.5 Walk every `.php` file under the source root via `RecursiveDirectoryIterator`; for each file, tokenize once with `token_get_all()` and accumulate (a) per-class method declarations and (b) `$this->method(` call sites with their `(file, line, declaring_class, method)`
+- [ ] 1.6 Filter call sites: keep only those where `method` is the non-underscore counterpart of an inventory `_method` AND the declaring class has both `_method()` and `method()` declared (either directly or via base class within source/)
+- [ ] 1.7 Sort findings deterministically by `(file, line)`; serialize as pretty-printed JSON with trailing newline; write atomically to `--output`
+- [ ] 1.8 Smoke-test: invoke from `/tmp` with explicit arguments; with `--help`; with a missing inventory path. Confirm correct behavior on each.
+
+## 2. Phase 1 — Gate test
+
+- [ ] 2.1 Create `tests/Unit/BackwardsCompatibility/InternalShimCallSitesTest.php` (namespace `OxidEsales\EshopCommunity\Tests\Unit\BackwardsCompatibility`) — single test method that invokes the detector logic in-process and asserts the findings array is empty
+- [ ] 2.2 Detector logic factored into a reusable class so the test does not shell-out (e.g. `OxidEsales\EshopCommunity\Tests\Unit\BackwardsCompatibility\Tooling\InternalShimCallSiteDetector` shared with `bin/find-internal-shim-call-sites.php`)
+- [ ] 2.3 Test docblock cross-references `InheritanceContractTest`, explains division of labour (structural BC vs. call-site convention), and references issue #107
+- [ ] 2.4 Wire into the existing PHPUnit config so it runs in the normal `tests/Unit/` suite; accept that CI will be red until Phase 2 lands the same session
+
+## 3. Phase 1 — Findings + verification gate (USER)
+
+- [ ] 3.1 Run the detector against `b-1.6.0`'s current state; commit `openspec/changes/fix-internal-shim-call-sites/findings.json`
+- [ ] 3.2 **User step:** review findings; sanity-check the count against the known grep numbers (60+52+31 = ~143 in AdminAjax trio)
+- [ ] 3.3 **User step:** decide and communicate three things to Claude:
+  - (a) Sweep scope — full inventory or restricted subset?
+  - (b) PHPDoc rewrite scope — only classes touched by Phase 2, or all 225 from PR #104?
+  - (c) Batching — one PR or per-directory?
+
+## 4. Phase 2 — Remediation
+
+- [ ] 4.1 For each approved finding, apply the D6 single-token rewrite: `$this->method(` → `$this->_method(`. No other edits.
+- [ ] 4.2 Per file, run `./docker.sh test --fast <test-path>` for the matching test. If the test mocks the public name, update the mock to the underscore name. Track every mock update.
+- [ ] 4.3 Per directory batch, run `./docker.sh test` (full unit suite) to catch cross-cutting regressions.
+- [ ] 4.4 If the gate approved a PHPDoc rewrite: apply D7 to each affected shim pair. The three load-bearing clauses on each side must be present.
+- [ ] 4.5 Re-run the equivalence check `bin/verify-underscore-method-body-equivalence.php --compare-sibling` over the touched classes. Every pair must report `[EQUIVALENT]` (this change does not move bodies).
+- [ ] 4.6 **User step:** approve each Phase 2 commit (per-file or per-directory batch, per the granularity decided at the gate); on approval, Claude creates the commit.
+
+## 5. Phase 4 — Verification + close-out
+
+- [ ] 5.1 `./docker.sh test --fast tests/Unit/BackwardsCompatibility/InternalShimCallSitesTest.php` — must pass (findings empty)
+- [ ] 5.2 `./docker.sh test --fast tests/Unit/BackwardsCompatibility/InheritanceContractTest.php` — must still pass (no public-surface regression)
+- [ ] 5.3 `./docker.sh test-all` — full unit suite green
+- [ ] 5.4 Manual smoke (admin browser, dev shop running): Catalogue → Categories → Articles tab; Master Data → Delivery Sets → Groups; Discount → Categories; Voucher Series → Groups
+- [ ] 5.5 Open PR off `b-1.6.0`. Body cites Ralf's reopen comment, links PR #104 as precedent, calls out the override-style narrowing explicitly, references #108. **Closes #107.**
+- [ ] 5.6 Run `openspec validate` on the change directory; fix any structural issues
+- [ ] 5.7 After PR is merged, archive the change via `/opsx:archive`

--- a/source/Application/Component/BasketComponent.php
+++ b/source/Application/Component/BasketComponent.php
@@ -174,8 +174,8 @@ class BasketComponent extends BaseController
         }
 
         // adding articles
-        if ($aProducts = $this->getItems($sProductId, $dAmount, $aSel, $aPersParam, $blOverride)) {
-            $this->setLastCallFnc('tobasket');
+        if ($aProducts = $this->_getItems($sProductId, $dAmount, $aSel, $aPersParam, $blOverride)) {
+            $this->_setLastCallFnc('tobasket');
 
             $database = DatabaseProvider::getDb();
             $database->startTransaction();
@@ -206,7 +206,7 @@ class BasketComponent extends BaseController
             }
 
             // redirect to basket
-            $redirectUrl = $this->getRedirectUrl();
+            $redirectUrl = $this->_getRedirectUrl();
             $this->dispatchEvent(new BasketChangedEvent($this));
 
             return $redirectUrl;
@@ -268,11 +268,11 @@ class BasketComponent extends BaseController
         $aPersParam = $aPersParam ?: Registry::getRequest()->getRequestEscapedParameter('persparam');
 
         // adding articles
-        if ($aProducts = $this->getItems($sProductId, $dAmount, $aSel, $aPersParam, $blOverride)) {
+        if ($aProducts = $this->_getItems($sProductId, $dAmount, $aSel, $aPersParam, $blOverride)) {
             // information that last call was changebasket
             $oBasket = Registry::getSession()->getBasket();
             $oBasket->onUpdate();
-            $this->setLastCallFnc('changebasket');
+            $this->_setLastCallFnc('changebasket');
 
             $database = DatabaseProvider::getDb();
             $database->startTransaction();
@@ -378,9 +378,13 @@ class BasketComponent extends BaseController
      * @param bool   $blOverride amount override status
      *
      * @return array|bool
-     * @deprecated Use getItems() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getItems().
+     * @deprecated Transitional during #107. Modules SHOULD override _getItems()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getItems() to the canonical override
+      *             target and retires _getItems(); until then, _getItems() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getItems(// phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
         $sProductId = null,
@@ -446,9 +450,10 @@ class BasketComponent extends BaseController
      *
      * @return array|bool
      *
-     * @internal If your override does not fully replace the behavior, call parent::getItems()
-     *           (not the deprecated _getItems()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getItems(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getItems() the canonical override target.
      */
     protected function getItems(
         $sProductId = null,
@@ -522,7 +527,7 @@ class BasketComponent extends BaseController
         }
 
         // information that last call was tobasket
-        $this->setLastCall($this->getLastCallFnc(), $products, $basketInfo);
+        $this->_setLastCall($this->_getLastCallFnc(), $products, $basketInfo);
 
         return $basketItem;
     }
@@ -549,9 +554,10 @@ class BasketComponent extends BaseController
      * @param array  $aProductInfo data which comes from request when you press button "to basket"
      * @param array  $aBasketInfo  array returned by \OxidEsales\Eshop\Application\Model\Basket::getBasketSummary()
      *
-     * @internal If your override does not fully replace the behavior, call parent::setLastCall()
-     *           (not the deprecated _setLastCall()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _setLastCall(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make setLastCall() the canonical override target.
      */
     protected function setLastCall($sCallName, $aProductInfo, $aBasketInfo)
     {

--- a/source/Application/Component/CategoriesComponent.php
+++ b/source/Application/Component/CategoriesComponent.php
@@ -91,16 +91,16 @@ class CategoriesComponent extends BaseController
             return;
         }
 
-        $sActCat = $this->getActCat();
+        $sActCat = $this->_getActCat();
 
         if ($myConfig->getConfigParam('bl_perfLoadManufacturerTree')) {
             // building Manufacturer tree
             $sActManufacturer = Registry::getRequest()->getRequestEscapedParameter('mnid');
-            $this->loadManufacturerTree($sActManufacturer);
+            $this->_loadManufacturerTree($sActManufacturer);
         }
 
         // building category tree for all purposes (nav, search and simple category trees)
-        $this->loadCategoryTree($sActCat);
+        $this->_loadCategoryTree($sActCat);
     }
 
     /**
@@ -134,9 +134,13 @@ class CategoriesComponent extends BaseController
      * @throws DatabaseConnectionException
      * @throws DatabaseErrorException
      * @throws ObjectException
-     * @deprecated Use getActCat() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getActCat().
+     * @deprecated Transitional during #107. Modules SHOULD override _getActCat()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getActCat() to the canonical override
+      *             target and retires _getActCat(); until then, _getActCat() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getActCat() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -153,7 +157,7 @@ class CategoriesComponent extends BaseController
 
             $sActVendor = (Str::getStr()->preg_match('/^v_.?/i', $sActCat)) ? $sActCat : null;
 
-            $sActCat = $this->addAdditionalParams($oProduct, $sActCat, $sActManufacturer, $sActVendor);
+            $sActCat = $this->_addAdditionalParams($oProduct, $sActCat, $sActManufacturer, $sActVendor);
         }
 
         // Checking for the default category
@@ -177,9 +181,10 @@ class CategoriesComponent extends BaseController
      * @throws DatabaseErrorException
      * @throws ObjectException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getActCat()
-     *           (not the deprecated _getActCat()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getActCat(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getActCat() the canonical override target.
      */
     protected function getActCat()
     {
@@ -340,7 +345,7 @@ class CategoriesComponent extends BaseController
             } elseif ($sActCat && $oProduct->isAssignedToCategory($sActCat)) {
                 // category ?
             } else {
-                list($sListType, $sActCat) = $this->getDefaultParams($oProduct);
+                list($sListType, $sActCat) = $this->_getDefaultParams($oProduct);
             }
         }
 

--- a/source/Application/Component/UserComponent.php
+++ b/source/Application/Component/UserComponent.php
@@ -120,9 +120,9 @@ class UserComponent extends BaseController
      */
     public function init()
     {
-        $this->saveDeliveryAddressState();
-        $this->loadSessionUser();
-        $this->saveInvitor();
+        $this->_saveDeliveryAddressState();
+        $this->_loadSessionUser();
+        $this->_saveInvitor();
 
         parent::init();
     }
@@ -136,7 +136,7 @@ class UserComponent extends BaseController
     public function render()
     {
         // checks if private sales allows further tasks
-        $this->checkPsState();
+        $this->_checkPsState();
 
         parent::render();
 
@@ -283,7 +283,7 @@ class UserComponent extends BaseController
         }
 
         // finalizing ..
-        return $this->afterLogin($oUser);
+        return $this->_afterLogin($oUser);
     }
 
     /**
@@ -342,9 +342,10 @@ class UserComponent extends BaseController
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::afterLogin()
-     *           (not the deprecated _afterLogin()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _afterLogin(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make afterLogin() the canonical override target.
      */
     protected function afterLogin($oUser)
     {
@@ -417,9 +418,10 @@ class UserComponent extends BaseController
      * session parameters as user chosen payment id, delivery
      * address id, active delivery set.
      *
-     * @internal If your override does not fully replace the behavior, call parent::afterLogout()
-     *           (not the deprecated _afterLogout()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _afterLogout(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make afterLogout() the canonical override target.
      */
     protected function afterLogout()
     {
@@ -443,7 +445,7 @@ class UserComponent extends BaseController
             $this->setLoginStatus(USER_LOGOUT);
 
             // finalizing ..
-            $this->afterLogout();
+            $this->_afterLogout();
 
             $this->resetPermissions();
 
@@ -453,7 +455,7 @@ class UserComponent extends BaseController
 
             // redirecting if user logs out in SSL mode
             if (Registry::getRequest()->getRequestEscapedParameter('redirect') && $myConfig->getConfigParam('sSSLShopURL')) {
-                Registry::getUtils()->redirect($this->getLogoutLink());
+                Registry::getUtils()->redirect($this->_getLogoutLink());
             }
         }
     }
@@ -551,7 +553,7 @@ class UserComponent extends BaseController
         $aInvAddress = $this->cleanAddress($aInvAddress, oxNew(UserUpdatableFields::class));
         $aInvAddress = $this->trimAddress($aInvAddress);
 
-        $aDelAddress = $this->getDelAddressData();
+        $aDelAddress = $this->_getDelAddressData();
         $aDelAddress = $this->cleanAddress($aDelAddress, oxNew(UserShippingAddressUpdatableFields::class));
         $aDelAddress = $this->trimAddress($aDelAddress);
 
@@ -639,7 +641,7 @@ class UserComponent extends BaseController
 
         if (!$blActiveLogin) {
             Registry::getSession()->setVariable('usr', $oUser->getId());
-            $this->afterLogin($oUser);
+            $this->_afterLogin($oUser);
 
             // order remark
             //V #427: order remark for new users
@@ -754,9 +756,10 @@ class UserComponent extends BaseController
     /**
      * Saves invitor ID
      *
-     * @internal If your override does not fully replace the behavior, call parent::saveInvitor()
-     *           (not the deprecated _saveInvitor()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _saveInvitor(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make saveInvitor() the canonical override target.
      */
     protected function saveInvitor()
     {
@@ -841,7 +844,7 @@ class UserComponent extends BaseController
         }
 
         // collecting values to check
-        $aDelAddress = $this->getDelAddressData();
+        $aDelAddress = $this->_getDelAddressData();
         $aDelAddress = $this->cleanAddress($aDelAddress, oxNew(UserShippingAddressUpdatableFields::class));
         $aDelAddress = $this->trimAddress($aDelAddress);
 

--- a/source/Application/Component/UtilsComponent.php
+++ b/source/Application/Component/UtilsComponent.php
@@ -139,7 +139,7 @@ class UtilsComponent extends BaseController
             return;
         }
 
-        $this->toList('noticelist', $sProductId, $dAmount, $aSel);
+        $this->_toList('noticelist', $sProductId, $dAmount, $aSel);
     }
 
     /**
@@ -159,7 +159,7 @@ class UtilsComponent extends BaseController
 
         // only if enabled
         if ($this->getViewConfig()->getShowWishlist()) {
-            $this->toList('wishlist', $sProductId, $dAmount, $aSel);
+            $this->_toList('wishlist', $sProductId, $dAmount, $aSel);
         }
     }
 
@@ -171,9 +171,13 @@ class UtilsComponent extends BaseController
      * @param double $dAmount product amount
      * @param array $aSel product selection list
      * @throws Exception
-     * @deprecated Use toList() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _toList().
+     * @deprecated Transitional during #107. Modules SHOULD override _toList()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes toList() to the canonical override
+      *             target and retires _toList(); until then, _toList() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _toList($sListType, $sProductId, $dAmount, $aSel) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -242,9 +246,10 @@ class UtilsComponent extends BaseController
      * @param array $aSel product selection list
      * @throws Exception
      *
-     * @internal If your override does not fully replace the behavior, call parent::toList()
-     *           (not the deprecated _toList()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _toList(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make toList() the canonical override target.
      */
     protected function toList($sListType, $sProductId, $dAmount, $aSel)
     {

--- a/source/Application/Component/Widget/Actions.php
+++ b/source/Application/Component/Widget/Actions.php
@@ -52,7 +52,7 @@ class Actions extends \OxidEsales\Eshop\Application\Component\Widget\WidgetContr
     public function getAction()
     {
         $actionId = $this->getViewParameter('action');
-        if ($actionId && $this->getLoadActionsParam()) {
+        if ($actionId && $this->_getLoadActionsParam()) {
             $artList = oxNew(ArticleList::class);
             $artList->loadActionArticles($actionId);
             if ($artList->count()) {

--- a/source/Application/Component/Widget/ArticleBox.php
+++ b/source/Application/Component/Widget/ArticleBox.php
@@ -119,8 +119,8 @@ class ArticleBox extends \OxidEsales\Eshop\Application\Component\Widget\WidgetCo
 
                 $sAddDynParams = $this->updateDynamicParameters($sAddDynParams);
 
-                $oArticle = $this->getArticleById($this->getViewParameter('anid'));
-                $this->addDynParamsToLink($sAddDynParams, $oArticle);
+                $oArticle = $this->_getArticleById($this->getViewParameter('anid'));
+                $this->_addDynParamsToLink($sAddDynParams, $oArticle);
             }
 
             $this->setProduct($oArticle);

--- a/source/Application/Component/Widget/ArticleDetails.php
+++ b/source/Application/Component/Widget/ArticleDetails.php
@@ -251,7 +251,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
             $this->_oParentProd = false;
             $oProduct = oxNew(Article::class);
             if (($oProduct->load($sParentId))) {
-                $this->processProduct($oProduct);
+                $this->_processProduct($oProduct);
                 $this->_oParentProd = $oProduct;
             }
         }
@@ -320,7 +320,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
     protected function _processProduct($oProduct) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $oProduct->setLinkType($this->getLinkType());
-        if ($sAddParams = $this->getAddUrlParams()) {
+        if ($sAddParams = $this->_getAddUrlParams()) {
             $oProduct->appendLink($sAddParams);
         }
     }
@@ -484,7 +484,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
 
             // setting link type for variants ..
             foreach ($this->_aVariantList as $oVariant) {
-                $this->processProduct($oVariant);
+                $this->_processProduct($oVariant);
             }
         }
 
@@ -820,9 +820,10 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
      * @return object
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getSubject()
-     *           (not the deprecated _getSubject()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getSubject(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getSubject() the canonical override target.
      */
     protected function getSubject($iLang)
     {
@@ -962,7 +963,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
         // finding parent
         $oProduct = $this->getProduct();
         $sParentIdField = 'oxarticles__oxparentid';
-        if (($oParent = $this->getParentProduct($oProduct->$sParentIdField->value))) {
+        if (($oParent = $this->_getParentProduct($oProduct->$sParentIdField->value))) {
             $sVarSelId = Registry::getRequest()->getRequestEscapedParameter('varselid');
 
             return $oParent->getVariantSelections($sVarSelId, $oProduct->getId());
@@ -1024,7 +1025,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
             }
         }
         if (!$this->_blIsInitialized) {
-            $this->additionalChecksForArticle($myUtils, $myConfig);
+            $this->_additionalChecksForArticle($myUtils, $myConfig);
         }
 
         return $this->_oProduct;
@@ -1084,7 +1085,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
         } else {
             $oCategory->load($sCatId);
         }
-        $this->setSortingParameters();
+        $this->_setSortingParameters();
 
         $this->setActiveCategory($oCategory);
 
@@ -1133,7 +1134,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
         if (!$this->_oProduct->isVisible()) {
             $blContinue = false;
         } elseif ($this->_oProduct->oxarticles__oxparentid->value) {
-            $oParent = $this->getParentProduct($this->_oProduct->oxarticles__oxparentid->value);
+            $oParent = $this->_getParentProduct($this->_oProduct->oxarticles__oxparentid->value);
             if (!$oParent || !$oParent->isVisible()) {
                 $blContinue = false;
             }
@@ -1144,7 +1145,7 @@ class ArticleDetails extends \OxidEsales\Eshop\Application\Component\Widget\Widg
             $myUtils->showMessageAndExit('');
         }
 
-        $this->processProduct($this->_oProduct);
+        $this->_processProduct($this->_oProduct);
         $this->_blIsInitialized = true;
     }
 

--- a/source/Application/Component/Widget/Information.php
+++ b/source/Application/Component/Widget/Information.php
@@ -48,7 +48,7 @@ class Information extends \OxidEsales\Eshop\Application\Component\Widget\WidgetC
      */
     public function getServicesKeys()
     {
-        $oContentList = $this->getContentList();
+        $oContentList = $this->_getContentList();
 
         return $oContentList->getServiceKeys();
     }
@@ -60,7 +60,7 @@ class Information extends \OxidEsales\Eshop\Application\Component\Widget\WidgetC
      */
     public function getServicesList()
     {
-        $oContentList = $this->getContentList();
+        $oContentList = $this->_getContentList();
         $oContentList->loadServices();
 
         return $oContentList;

--- a/source/Application/Controller/AccountController.php
+++ b/source/Application/Controller/AccountController.php
@@ -148,7 +148,7 @@ class AccountController extends FrontendController
             !$user || !$user->$passwordField->value ||
             ($this->isEnabledPrivateSales() && (!$user->isTermsAccepted() || $this->confirmTerms()))
         ) {
-            $this->_sThisTemplate = $this->getLoginTemplate();
+            $this->_sThisTemplate = $this->_getLoginTemplate();
         }
 
         return $this->_sThisTemplate;

--- a/source/Application/Controller/AccountDownloadsController.php
+++ b/source/Application/Controller/AccountDownloadsController.php
@@ -88,7 +88,7 @@ class AccountDownloadsController extends AccountController
         $oOrderFileList = oxNew(OrderFileList::class);
         $oOrderFileList->loadUserFiles($this->getUser()->getId());
 
-        $this->_oOrderFilesList = $this->prepareForTemplate($oOrderFileList);
+        $this->_oOrderFilesList = $this->_prepareForTemplate($oOrderFileList);
 
         return $this->_oOrderFilesList;
     }

--- a/source/Application/Controller/Admin/ActionsArticleAjax.php
+++ b/source/Application/Controller/Admin/ActionsArticleAjax.php
@@ -63,9 +63,13 @@ class ActionsArticleAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -109,9 +113,10 @@ class ActionsArticleAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -125,9 +130,13 @@ class ActionsArticleAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use addFilter() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _addFilter().
+     * @deprecated Transitional during #107. Modules SHOULD override _addFilter()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes addFilter() to the canonical override
+      *             target and retires _addFilter(); until then, _addFilter() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -148,9 +157,10 @@ class ActionsArticleAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::addFilter()
-     *           (not the deprecated _addFilter()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _addFilter(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make addFilter() the canonical override target.
      */
     protected function addFilter($sQ)
     {

--- a/source/Application/Controller/Admin/ActionsGroupsAjax.php
+++ b/source/Application/Controller/Admin/ActionsGroupsAjax.php
@@ -58,9 +58,13 @@ class ActionsGroupsAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -96,9 +100,10 @@ class ActionsGroupsAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -110,9 +115,9 @@ class ActionsGroupsAjax extends ListComponentAjax
      */
     public function removePromotionGroup()
     {
-        $aRemoveGroups = $this->getActionIds('oxobject2action.oxid');
+        $aRemoveGroups = $this->_getActionIds('oxobject2action.oxid');
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $sQ = $this->addFilter('delete oxobject2action.* ' . $this->getQuery());
+            $sQ = $this->_addFilter('delete oxobject2action.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
             $sRemoveGroups = implode(', ', DatabaseProvider::getDb()->quoteArray($aRemoveGroups));
@@ -130,12 +135,12 @@ class ActionsGroupsAjax extends ListComponentAjax
      */
     public function addPromotionGroup()
     {
-        $aChosenGroup = $this->getActionIds('oxgroups.oxid');
+        $aChosenGroup = $this->_getActionIds('oxgroups.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sGroupTable = $this->getViewName('oxgroups');
-            $aChosenGroup = $this->getAll($this->addFilter("select $sGroupTable.oxid " . $this->getQuery()));
+            $aChosenGroup = $this->_getAll($this->_addFilter("select $sGroupTable.oxid " . $this->getQuery()));
         }
 
         $promotionAdded = false;

--- a/source/Application/Controller/Admin/ActionsMain.php
+++ b/source/Application/Controller/Admin/ActionsMain.php
@@ -76,7 +76,7 @@ class ActionsMain extends AdminDetailsController
 
         if (Registry::getRequest()->getRequestEscapedParameter('aoc')) {
             // generating category tree for select list
-            $this->createCategoryTree('artcattree', $soxId);
+            $this->_createCategoryTree('artcattree', $soxId);
 
             $oActionsMainAjax = oxNew(ActionsMainAjax::class);
             $this->_aViewData['oxajax'] = $oActionsMainAjax->getColumns();
@@ -91,7 +91,7 @@ class ActionsMain extends AdminDetailsController
                     switch ($iAoc) {
                         case 'article':
                             // generating category tree for select list
-                            $this->createCategoryTree('artcattree', $soxId);
+                            $this->_createCategoryTree('artcattree', $soxId);
 
                             if ($oArticle = $oPromotion->getBannerArticle()) {
                                 $this->_aViewData['actionarticle_artnum'] = $oArticle->oxarticles__oxartnum->value;
@@ -113,7 +113,7 @@ class ActionsMain extends AdminDetailsController
                     }
                 } else {
                     if ($oPromotion->oxactions__oxtype->value == 2) {
-                        $this->_aViewData['editor'] = $this->generateTextEditor(
+                        $this->_aViewData['editor'] = $this->_generateTextEditor(
                             '100%',
                             300,
                             $oPromotion,

--- a/source/Application/Controller/Admin/ActionsMainAjax.php
+++ b/source/Application/Controller/Admin/ActionsMainAjax.php
@@ -77,9 +77,13 @@ class ActionsMainAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -129,9 +133,10 @@ class ActionsMainAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -145,9 +150,13 @@ class ActionsMainAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use addFilter() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _addFilter().
+     * @deprecated Transitional during #107. Modules SHOULD override _addFilter()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes addFilter() to the canonical override
+      *             target and retires _addFilter(); until then, _addFilter() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -174,9 +183,10 @@ class ActionsMainAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::addFilter()
-     *           (not the deprecated _addFilter()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _addFilter(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make addFilter() the canonical override target.
      */
     protected function addFilter($sQ)
     {
@@ -187,9 +197,13 @@ class ActionsMainAjax extends ListComponentAjax
      * Returns SQL query addon for sorting
      *
      * @return string
-     * @deprecated Use getSorting() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getSorting().
+     * @deprecated Transitional during #107. Modules SHOULD override _getSorting()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getSorting() to the canonical override
+      *             target and retires _getSorting(); until then, _getSorting() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -210,9 +224,10 @@ class ActionsMainAjax extends ListComponentAjax
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getSorting()
-     *           (not the deprecated _getSorting()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getSorting(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getSorting() the canonical override target.
      */
     protected function getSorting()
     {
@@ -224,7 +239,7 @@ class ActionsMainAjax extends ListComponentAjax
      */
     public function removeArtFromAct()
     {
-        $aChosenArt = $this->getActionIds('oxactions2article.oxid');
+        $aChosenArt = $this->_getActionIds('oxactions2article.oxid');
         $sOxid = Registry::getRequest()->getRequestEscapedParameter('oxid');
 
         $this->getOxRssFeed()->removeCacheFile($sOxid);
@@ -249,14 +264,14 @@ class ActionsMainAjax extends ListComponentAjax
     public function addArtToAct()
     {
         $myConfig = Registry::getConfig();
-        $aArticles = $this->getActionIds('oxarticles.oxid');
+        $aArticles = $this->_getActionIds('oxarticles.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         $this->getOxRssFeed()->removeCacheFile($soxId);
 
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sArtTable = $this->getViewName('oxarticles');
-            $aArticles = $this->getAll($this->addFilter("select $sArtTable.oxid " . $this->getQuery()));
+            $aArticles = $this->_getAll($this->_addFilter("select $sArtTable.oxid " . $this->getQuery()));
         }
 
         // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804 and ESDEV-3822).
@@ -303,7 +318,7 @@ class ActionsMainAjax extends ListComponentAjax
         $sSelId = Registry::getRequest()->getRequestEscapedParameter('oxid');
         $sSelect = "select * from $sArtTable left join oxactions2article on $sArtTable.oxid=oxactions2article.oxartid ";
         $sSelect .= 'where oxactions2article.oxactionid = :oxactionid ' .
-                    'and oxactions2article.oxshopid = :oxshopid ' . $this->getSorting();
+                    'and oxactions2article.oxshopid = :oxshopid ' . $this->_getSorting();
 
         $oList = oxNew(ListModel::class);
         $oList->init('oxbase', 'oxactions2article');
@@ -345,10 +360,10 @@ class ActionsMainAjax extends ListComponentAjax
 
         $sQAdd = $this->getQuery();
 
-        $sQ = 'select ' . $this->getQueryCols() . $sQAdd;
+        $sQ = 'select ' . $this->_getQueryCols() . $sQAdd;
         $sCountQ = 'select count( * ) ' . $sQAdd;
 
-        $this->outputResponse($this->getData($sCountQ, $sQ));
+        $this->_outputResponse($this->getData($sCountQ, $sQ));
     }
 
     /**

--- a/source/Application/Controller/Admin/ActionsOrderAjax.php
+++ b/source/Application/Controller/Admin/ActionsOrderAjax.php
@@ -52,9 +52,13 @@ class ActionsOrderAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -71,9 +75,10 @@ class ActionsOrderAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -84,9 +89,13 @@ class ActionsOrderAjax extends ListComponentAjax
      * Returns SQL query addon for sorting
      *
      * @return string
-     * @deprecated Use getSorting() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getSorting().
+     * @deprecated Transitional during #107. Modules SHOULD override _getSorting()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getSorting() to the canonical override
+      *             target and retires _getSorting(); until then, _getSorting() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -98,9 +107,10 @@ class ActionsOrderAjax extends ListComponentAjax
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getSorting()
-     *           (not the deprecated _getSorting()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getSorting(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getSorting() the canonical override target.
      */
     protected function getSorting()
     {
@@ -154,9 +164,9 @@ class ActionsOrderAjax extends ListComponentAjax
 
         $sQAdd = $this->getQuery();
 
-        $sQ = 'select ' . $this->getQueryCols() . $sQAdd;
+        $sQ = 'select ' . $this->_getQueryCols() . $sQAdd;
         $sCountQ = 'select count( * ) ' . $sQAdd;
 
-        $this->outputResponse($this->getData($sCountQ, $sQ));
+        $this->_outputResponse($this->getData($sCountQ, $sQ));
     }
 }

--- a/source/Application/Controller/Admin/AdminController.php
+++ b/source/Application/Controller/Admin/AdminController.php
@@ -140,7 +140,7 @@ class AdminController extends BaseController
         $myConfig->setConfigParam('blAdmin', true);
         $this->setAdminMode(true);
 
-        if ($oShop = $this->getEditShop($myConfig->getShopId())) {
+        if ($oShop = $this->_getEditShop($myConfig->getShopId())) {
             // passing shop info
             $this->_sShopTitle = $oShop->oxshops__oxname->getRawValue();
             $this->_sShopVersion = oxNew(ShopVersion::class)->getVersion();
@@ -180,9 +180,10 @@ class AdminController extends BaseController
      *
      * @return Shop
      *
-     * @internal If your override does not fully replace the behavior, call parent::getEditShop()
-     *           (not the deprecated _getEditShop()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getEditShop(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getEditShop() the canonical override target.
      */
     protected function getEditShop($sShopId)
     {
@@ -296,7 +297,7 @@ class AdminController extends BaseController
     public function getServiceUrl($sLangAbbr = null)
     {
         if ($this->_sServiceUrl === null) {
-            $sProtocol = $this->getServiceProtocol();
+            $sProtocol = $this->_getServiceProtocol();
 
             $oFacts = new Facts();
             $sUrl = $sProtocol . '://admin.oxid-esales.com/' . $oFacts->getEdition() . '/';
@@ -380,7 +381,7 @@ class AdminController extends BaseController
         $oLang = Registry::getLang();
 
         // sets up navigation data
-        $this->setupNavigation(Registry::getConfig()->getRequestControllerId());
+        $this->_setupNavigation(Registry::getConfig()->getRequestControllerId());
 
         // active object id
         $sOxId = $this->getEditObjectId();
@@ -395,7 +396,7 @@ class AdminController extends BaseController
         // loading active shop
         if ($sActShopId = Registry::getSession()->getVariable('actshop')) {
             // load object
-            $this->_aViewData['actshopobj'] = $this->getEditShop($sActShopId);
+            $this->_aViewData['actshopobj'] = $this->_getEditShop($sActShopId);
         }
 
         // add language data to all templates
@@ -516,7 +517,7 @@ class AdminController extends BaseController
                     $myUtilsCount->resetManufacturerArticleCount($sValue);
                     break;
             }
-            $this->resetContentCache();
+            $this->_resetContentCache();
         }
     }
 

--- a/source/Application/Controller/Admin/AdminDetailsController.php
+++ b/source/Application/Controller/Admin/AdminDetailsController.php
@@ -76,7 +76,7 @@ class AdminDetailsController extends AdminController
                 $sEditObjectValue = $oObject->$sField->value;
             }
 
-            $sEditObjectValue = $this->processEditValue($sEditObjectValue);
+            $sEditObjectValue = $this->_processEditValue($sEditObjectValue);
             $oObject->$sField = new Field($sEditObjectValue, Field::T_RAW);
         }
 
@@ -91,9 +91,10 @@ class AdminDetailsController extends AdminController
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getEditValue()
-     *           (not the deprecated _getEditValue()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getEditValue(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getEditValue() the canonical override target.
      */
     protected function getEditValue($oObject, $sField)
     {
@@ -155,7 +156,7 @@ class AdminDetailsController extends AdminController
      */
     protected function _getPlainEditor($width, $height, $object, $field) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $objectValue = $this->getEditValue($object, $field);
+        $objectValue = $this->_getEditValue($object, $field);
 
         $textEditor = oxNew(TextEditorHandler::class);
 
@@ -180,7 +181,7 @@ class AdminDetailsController extends AdminController
      */
     protected function _generateTextEditor($width, $height, $object, $field, $stylesheet = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $objectValue = $this->getEditValue($object, $field);
+        $objectValue = $this->_getEditValue($object, $field);
 
         $textEditorHandler = $this->createTextEditorHandler();
         $this->configureTextEditorHandler($textEditorHandler, $object, $field, $stylesheet);
@@ -326,7 +327,7 @@ class AdminDetailsController extends AdminController
         $blForceNonCache = false,
         $iTreeShopId = null
     ) {
-        $oCatTree = $this->createCategoryTree($sTplVarName, $sEditCatId, $blForceNonCache, $iTreeShopId);
+        $oCatTree = $this->_createCategoryTree($sTplVarName, $sEditCatId, $blForceNonCache, $iTreeShopId);
 
         // mark selected
         if ($sSelectedCatId) {
@@ -440,9 +441,13 @@ class AdminDetailsController extends AdminController
      * Resets count of vendor/manufacturer category items.
      *
      * @param array $aIds to reset type => id
-     * @deprecated Use resetCounts() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _resetCounts().
+     * @deprecated Transitional during #107. Modules SHOULD override _resetCounts()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes resetCounts() to the canonical override
+      *             target and retires _resetCounts(); until then, _resetCounts() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _resetCounts($aIds) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -465,9 +470,10 @@ class AdminDetailsController extends AdminController
      *
      * @param array $aIds to reset type => id
      *
-     * @internal If your override does not fully replace the behavior, call parent::resetCounts()
-     *           (not the deprecated _resetCounts()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _resetCounts(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make resetCounts() the canonical override target.
      */
     protected function resetCounts($aIds)
     {

--- a/source/Application/Controller/Admin/AdminListController.php
+++ b/source/Application/Controller/Admin/AdminListController.php
@@ -267,7 +267,7 @@ class AdminListController extends AdminController
         $this->_aViewData['mylist'] = $this->getItemList();
 
         // set navigation parameters
-        $this->setListNavigationParams();
+        $this->_setListNavigationParams();
 
         return $return;
     }
@@ -353,7 +353,7 @@ class AdminListController extends AdminController
      */
     protected function _setCurrentListPosition($page = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $adminListSize = $this->getViewListSize();
+        $adminListSize = $this->_getViewListSize();
 
         $jumpToPage = (int)($page ? $page : (((int)Registry::getRequest()->getRequestEscapedParameter('lstrt')) / $adminListSize));
         $jumpToPage = ($page && $jumpToPage) ? ($jumpToPage - 1) : $jumpToPage;
@@ -515,9 +515,10 @@ class AdminListController extends AdminController
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::processFilter()
-     *           (not the deprecated _processFilter()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _processFilter(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make processFilter() the canonical override target.
      */
     protected function processFilter($fieldValue)
     {
@@ -532,9 +533,13 @@ class AdminListController extends AdminController
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use buildFilter() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _buildFilter().
+     * @deprecated Transitional during #107. Modules SHOULD override _buildFilter()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes buildFilter() to the canonical override
+      *             target and retires _buildFilter(); until then, _buildFilter() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _buildFilter($value, $isSearchValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -558,9 +563,10 @@ class AdminListController extends AdminController
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::buildFilter()
-     *           (not the deprecated _buildFilter()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _buildFilter(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make buildFilter() the canonical override target.
      */
     protected function buildFilter($value, $isSearchValue)
     {
@@ -590,9 +596,10 @@ class AdminListController extends AdminController
      *
      * @return bool
      *
-     * @internal If your override does not fully replace the behavior, call parent::isSearchValue()
-     *           (not the deprecated _isSearchValue()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _isSearchValue(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make isSearchValue() the canonical override target.
      */
     protected function isSearchValue($fieldValue)
     {
@@ -622,10 +629,10 @@ class AdminListController extends AdminController
                 $fieldValue = trim($fieldValue);
 
                 //check if this is search string (contains % sign at beginning and end of string)
-                $isSearchValue = $this->isSearchValue($fieldValue);
+                $isSearchValue = $this->_isSearchValue($fieldValue);
 
                 //removing % symbols
-                $fieldValue = $this->processFilter($fieldValue);
+                $fieldValue = $this->_processFilter($fieldValue);
 
                 if (strlen($fieldValue)) {
                     $values = explode(' ', $fieldValue);
@@ -647,12 +654,12 @@ class AdminListController extends AdminController
                         //for search in same field for different values using AND
                         $queryBoolAction = ' and ';
 
-                        $fullQuery .= $this->buildFilter($value, $isSearchValue);
+                        $fullQuery .= $this->_buildFilter($value, $isSearchValue);
 
                         if ($uml) {
                             $fullQuery .= " or {$quotedIdentifierName} ";
 
-                            $fullQuery .= $this->buildFilter($uml, $isSearchValue);
+                            $fullQuery .= $this->_buildFilter($uml, $isSearchValue);
                             $fullQuery .= ')'; // end of OR section
                         }
                     }
@@ -923,7 +930,7 @@ class AdminListController extends AdminController
     {
         // list navigation
         $showNavigation = false;
-        $adminListSize = $this->getViewListSize();
+        $adminListSize = $this->_getViewListSize();
         if ($this->_iListSize > $adminListSize) {
             // yes, we need to build the navigation object
             $pageNavigation = new stdClass();
@@ -988,7 +995,7 @@ class AdminListController extends AdminController
 
         // determine not used space in List
         $listSizeToShow = $this->_iListSize - $this->_iCurrListPos;
-        $adminListSize = $this->getViewListSize();
+        $adminListSize = $this->_getViewListSize();
         $notUsed = $adminListSize - min($listSizeToShow, $adminListSize);
         $space = $notUsed * 15;
 
@@ -1077,19 +1084,19 @@ class AdminListController extends AdminController
                 }
             }
 
-            $query = $this->buildSelectString($listObject);
-            $query = $this->prepareWhereQuery($where, $query);
-            $query = $this->prepareOrderByQuery($query);
+            $query = $this->_buildSelectString($listObject);
+            $query = $this->_prepareWhereQuery($where, $query);
+            $query = $this->_prepareOrderByQuery($query);
             $query = $this->changeselect($query);
 
             // calculates count of list items
-            $this->calcListItemsCount($query);
+            $this->_calcListItemsCount($query);
 
             // setting current list position (page)
-            $this->setCurrentListPosition(Registry::getRequest()->getRequestEscapedParameter('jumppage'));
+            $this->_setCurrentListPosition(Registry::getRequest()->getRequestEscapedParameter('jumppage'));
 
             // setting addition params for list: current list size
-            $this->_oList->setSqlLimit($this->_iCurrListPos, $this->getViewListSize());
+            $this->_oList->setSqlLimit($this->_iCurrListPos, $this->_getViewListSize());
 
             $this->_oList->selectString($query);
         }

--- a/source/Application/Controller/Admin/AdminlinksMain.php
+++ b/source/Application/Controller/Admin/AdminlinksMain.php
@@ -75,7 +75,7 @@ class AdminlinksMain extends AdminDetailsController
         }
 
         // generate editor
-        $this->_aViewData['editor'] = $this->generateTextEditor(
+        $this->_aViewData['editor'] = $this->_generateTextEditor(
             '100%',
             255,
             $oLinks,

--- a/source/Application/Controller/Admin/ArticleAccessoriesAjax.php
+++ b/source/Application/Controller/Admin/ArticleAccessoriesAjax.php
@@ -82,9 +82,13 @@ class ArticleAccessoriesAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -140,9 +144,10 @@ class ArticleAccessoriesAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {

--- a/source/Application/Controller/Admin/ArticleAttributeAjax.php
+++ b/source/Application/Controller/Admin/ArticleAttributeAjax.php
@@ -59,9 +59,13 @@ class ArticleAttributeAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -92,9 +96,10 @@ class ArticleAttributeAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -106,11 +111,11 @@ class ArticleAttributeAjax extends ListComponentAjax
      */
     public function removeAttr()
     {
-        $aChosenArt = $this->getActionIds('oxobject2attribute.oxid');
+        $aChosenArt = $this->_getActionIds('oxobject2attribute.oxid');
         $sOxid = Registry::getRequest()->getRequestEscapedParameter('oxid');
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sO2AViewName = $this->getViewName('oxobject2attribute');
-            $sQ = $this->addFilter("delete $sO2AViewName.* " . $this->getQuery());
+            $sQ = $this->_addFilter("delete $sO2AViewName.* " . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif (is_array($aChosenArt)) {
             $sChosenArticles = implode(', ', DatabaseProvider::getDb()->quoteArray($aChosenArt));
@@ -126,12 +131,12 @@ class ArticleAttributeAjax extends ListComponentAjax
      */
     public function addAttr()
     {
-        $aAddCat = $this->getActionIds('oxattribute.oxid');
+        $aAddCat = $this->_getActionIds('oxattribute.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sAttrViewName = $this->getViewName('oxattribute');
-            $aAddCat = $this->getAll($this->addFilter("select $sAttrViewName.oxid " . $this->getQuery()));
+            $aAddCat = $this->_getAll($this->_addFilter("select $sAttrViewName.oxid " . $this->getQuery()));
         }
 
         if ($soxId && $soxId != '-1' && is_array($aAddCat)) {

--- a/source/Application/Controller/Admin/ArticleBundleAjax.php
+++ b/source/Application/Controller/Admin/ArticleBundleAjax.php
@@ -61,9 +61,13 @@ class ArticleBundleAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -108,9 +112,10 @@ class ArticleBundleAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -124,9 +129,13 @@ class ArticleBundleAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use addFilter() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _addFilter().
+     * @deprecated Transitional during #107. Modules SHOULD override _addFilter()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes addFilter() to the canonical override
+      *             target and retires _addFilter(); until then, _addFilter() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -147,9 +156,10 @@ class ArticleBundleAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::addFilter()
-     *           (not the deprecated _addFilter()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _addFilter(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make addFilter() the canonical override target.
      */
     protected function addFilter($sQ)
     {

--- a/source/Application/Controller/Admin/ArticleCrossselling.php
+++ b/source/Application/Controller/Admin/ArticleCrossselling.php
@@ -51,10 +51,10 @@ class ArticleCrossselling extends AdminDetailsController
         $this->_aViewData['edit'] = $oArticle = oxNew(Article::class);
 
         // cross-selling
-        $this->createCategoryTree('artcattree');
+        $this->_createCategoryTree('artcattree');
 
         // accessoires
-        $this->createCategoryTree('artcattree2');
+        $this->_createCategoryTree('artcattree2');
 
         $soxId = $this->getEditObjectId();
         if (isset($soxId) && $soxId != '-1') {

--- a/source/Application/Controller/Admin/ArticleCrosssellingAjax.php
+++ b/source/Application/Controller/Admin/ArticleCrosssellingAjax.php
@@ -73,9 +73,13 @@ class ArticleCrosssellingAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -147,9 +151,10 @@ class ArticleCrosssellingAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -161,10 +166,10 @@ class ArticleCrosssellingAjax extends ListComponentAjax
      */
     public function removeArticleCross()
     {
-        $aChosenArt = $this->getActionIds('oxobject2article.oxid');
+        $aChosenArt = $this->_getActionIds('oxobject2article.oxid');
         // removing all
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $sQ = $this->addFilter('delete oxobject2article.* ' . $this->getQuery());
+            $sQ = $this->_addFilter('delete oxobject2article.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif (is_array($aChosenArt)) {
             $sChosenArticles = implode(', ', DatabaseProvider::getDb()->quoteArray($aChosenArt));
@@ -178,13 +183,13 @@ class ArticleCrosssellingAjax extends ListComponentAjax
      */
     public function addArticleCross()
     {
-        $aChosenArt = $this->getActionIds('oxarticles.oxid');
+        $aChosenArt = $this->_getActionIds('oxarticles.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         // adding
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sArtTable = $this->getViewName('oxarticles');
-            $aChosenArt = $this->getAll(parent::addFilter("select $sArtTable.oxid " . $this->getQuery()));
+            $aChosenArt = $this->_getAll(parent::addFilter("select $sArtTable.oxid " . $this->getQuery()));
         }
 
         $oArticle = oxNew(Article::class);

--- a/source/Application/Controller/Admin/ArticleExtend.php
+++ b/source/Application/Controller/Admin/ArticleExtend.php
@@ -68,7 +68,7 @@ class ArticleExtend extends AdminDetailsController
 
         $oxId = $this->getEditObjectId();
 
-        $this->createCategoryTree('artcattree');
+        $this->_createCategoryTree('artcattree');
 
         // all categories
         if (isset($oxId) && $oxId != '-1') {

--- a/source/Application/Controller/Admin/ArticleExtendAjax.php
+++ b/source/Application/Controller/Admin/ArticleExtendAjax.php
@@ -61,9 +61,13 @@ class ArticleExtendAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -96,9 +100,10 @@ class ArticleExtendAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -178,7 +183,7 @@ class ArticleExtendAjax extends ListComponentAjax
      */
     public function removeCat()
     {
-        $categoriesToRemove = $this->getActionIds('oxcategories.oxid');
+        $categoriesToRemove = $this->_getActionIds('oxcategories.oxid');
 
         $oxId = Registry::getRequest()->getRequestEscapedParameter('oxid');
         $dataBase = DatabaseProvider::getDb();
@@ -186,7 +191,7 @@ class ArticleExtendAjax extends ListComponentAjax
         // adding
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $categoriesTable = $this->getViewName('oxcategories');
-            $categoriesToRemove = $this->getAll($this->addFilter("select {$categoriesTable}.oxid " . $this->getQuery()));
+            $categoriesToRemove = $this->_getAll($this->_addFilter("select {$categoriesTable}.oxid " . $this->getQuery()));
         }
 
         // removing all
@@ -199,7 +204,7 @@ class ArticleExtendAjax extends ListComponentAjax
             ]);
 
             // updating oxtime values
-            $this->updateOxTime($oxId);
+            $this->_updateOxTime($oxId);
         }
 
         $this->resetArtSeoUrl($oxId, $categoriesToRemove);
@@ -216,7 +221,7 @@ class ArticleExtendAjax extends ListComponentAjax
     public function addCat()
     {
         $config = Registry::getConfig();
-        $categoriesToAdd = $this->getActionIds('oxcategories.oxid');
+        $categoriesToAdd = $this->_getActionIds('oxcategories.oxid');
         $oxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
         $shopId = $config->getShopId();
         $objectToCategoryView = $this->getViewName('oxobject2category');
@@ -224,7 +229,7 @@ class ArticleExtendAjax extends ListComponentAjax
         // adding
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $categoriesTable = $this->getViewName('oxcategories');
-            $categoriesToAdd = $this->getAll($this->addFilter("select $categoriesTable.oxid " . $this->getQuery()));
+            $categoriesToAdd = $this->_getAll($this->_addFilter("select $categoriesTable.oxid " . $this->getQuery()));
         }
 
         if (isset($categoriesToAdd) && is_array($categoriesToAdd)) {
@@ -250,7 +255,7 @@ class ArticleExtendAjax extends ListComponentAjax
                 $objectToCategory->save();
             }
 
-            $this->updateOxTime($oxId);
+            $this->_updateOxTime($oxId);
 
             $this->resetArtSeoUrl($oxId);
             $this->resetContentCache();

--- a/source/Application/Controller/Admin/ArticleFiles.php
+++ b/source/Application/Controller/Admin/ArticleFiles.php
@@ -95,7 +95,7 @@ class ArticleFiles extends AdminDetailsController
             foreach ($aArticleFiles as $sArticleFileId => $aArticleFileUpdate) {
                 $oArticleFile = oxNew(File::class);
                 $oArticleFile->load($sArticleFileId);
-                $aArticleFileUpdate = $this->processOptions($aArticleFileUpdate);
+                $aArticleFileUpdate = $this->_processOptions($aArticleFileUpdate);
                 $oArticleFile->assign($aArticleFileUpdate);
 
                 if ($oArticleFile->isUnderDownloadFolder()) {
@@ -149,7 +149,7 @@ class ArticleFiles extends AdminDetailsController
         $soxId = $this->getEditObjectId();
 
         $aParams = Registry::getRequest()->getRequestEscapedParameter('newfile');
-        $aParams = $this->processOptions($aParams);
+        $aParams = $this->_processOptions($aParams);
         $aNewFile = Registry::getConfig()->getUploadedFile('newArticleFile');
 
         //uploading and processing supplied file
@@ -260,9 +260,10 @@ class ArticleFiles extends AdminDetailsController
      *
      * @return array
      *
-     * @internal If your override does not fully replace the behavior, call parent::processOptions()
-     *           (not the deprecated _processOptions()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _processOptions(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make processOptions() the canonical override target.
      */
     protected function processOptions($aParams)
     {

--- a/source/Application/Controller/Admin/ArticleMain.php
+++ b/source/Application/Controller/Admin/ArticleMain.php
@@ -99,7 +99,7 @@ class ArticleMain extends AdminDetailsController
             }
 
             // #381A
-            $this->formJumpList($oArticle, $oParentArticle);
+            $this->_formJumpList($oArticle, $oParentArticle);
 
             //hook for modules
             $oArticle = $this->customizeArticleInformation($oArticle);
@@ -117,7 +117,7 @@ class ArticleMain extends AdminDetailsController
             }
         }
 
-        $this->_aViewData['editor'] = $this->generateTextEditor(
+        $this->_aViewData['editor'] = $this->_generateTextEditor(
             '100%',
             300,
             $oArticle,
@@ -146,7 +146,7 @@ class ArticleMain extends AdminDetailsController
         $sEditObjectValue = '';
         if ($oObject) {
             $oDescField = $oObject->getLongDescription();
-            $sEditObjectValue = $this->processEditValue($oDescField->getRawValue());
+            $sEditObjectValue = $this->_processEditValue($oDescField->getRawValue());
         }
 
         return $sEditObjectValue;
@@ -160,9 +160,10 @@ class ArticleMain extends AdminDetailsController
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getEditValue()
-     *           (not the deprecated _getEditValue()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getEditValue(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getEditValue() the canonical override target.
      */
     protected function getEditValue($oObject, $sField)
     {
@@ -236,7 +237,7 @@ class ArticleMain extends AdminDetailsController
         }
 
         $oArticle->assign($aParams);
-        $oArticle->setArticleLongDesc($this->processLongDesc($aParams['oxarticles__oxlongdesc']));
+        $oArticle->setArticleLongDesc($this->_processLongDesc($aParams['oxarticles__oxlongdesc']));
         $oArticle->setLanguage($this->_iEditLang);
         $oArticle = Registry::getUtilsFile()->processFiles($oArticle);
         $oArticle->save();
@@ -286,9 +287,10 @@ class ArticleMain extends AdminDetailsController
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::processLongDesc()
-     *           (not the deprecated _processLongDesc()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _processLongDesc(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make processLongDesc() the canonical override target.
      */
     protected function processLongDesc($sValue)
     {
@@ -400,28 +402,28 @@ class ArticleMain extends AdminDetailsController
             $oArticle->save();
 
             //copy categories
-            $this->copyCategories($sOldId, $sNewId);
+            $this->_copyCategories($sOldId, $sNewId);
 
             //attributes
-            $this->copyAttributes($sOldId, $sNewId);
+            $this->_copyAttributes($sOldId, $sNewId);
 
             //select-list
-            $this->copySelectlists($sOldId, $sNewId);
+            $this->_copySelectlists($sOldId, $sNewId);
 
             //cross-selling
-            $this->copyCrossseling($sOldId, $sNewId);
+            $this->_copyCrossseling($sOldId, $sNewId);
 
             //accessoire
-            $this->copyAccessoires($sOldId, $sNewId);
+            $this->_copyAccessoires($sOldId, $sNewId);
 
             // #983A copying staffelpreis info
-            $this->copyStaffelpreis($sOldId, $sNewId);
+            $this->_copyStaffelpreis($sOldId, $sNewId);
 
             //copy article extends (long-description)
-            $this->copyArtExtends($sOldId, $sNewId);
+            $this->_copyArtExtends($sOldId, $sNewId);
 
             //files
-            $this->copyFiles($sOldId, $sNewId);
+            $this->_copyFiles($sOldId, $sNewId);
 
             $this->resetContentCache();
 
@@ -505,9 +507,10 @@ class ArticleMain extends AdminDetailsController
      * @throws DatabaseConnectionException
      * @throws DatabaseErrorException
      *
-     * @internal If your override does not fully replace the behavior, call parent::copyCategories()
-     *           (not the deprecated _copyCategories()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _copyCategories(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make copyCategories() the canonical override target.
      */
     protected function copyCategories($sOldId, $newArticleId)
     {

--- a/source/Application/Controller/Admin/ArticlePictures.php
+++ b/source/Application/Controller/Admin/ArticlePictures.php
@@ -135,15 +135,15 @@ class ArticlePictures extends AdminDetailsController
 
         if ($iIndex == 'ICO') {
             // deleting main icon
-            $this->deleteMainIcon($oArticle);
+            $this->_deleteMainIcon($oArticle);
         } elseif ($iIndex == 'TH') {
             // deleting thumbnail
-            $this->deleteThumbnail($oArticle);
+            $this->_deleteThumbnail($oArticle);
         } else {
             $iIndex = (int) $iIndex;
             if ($iIndex > 0) {
                 // deleting master picture
-                $this->resetMasterPicture($oArticle, $iIndex, true);
+                $this->_resetMasterPicture($oArticle, $iIndex, true);
             }
         }
 
@@ -181,7 +181,7 @@ class ArticlePictures extends AdminDetailsController
             }
 
             if ($iIndex == 1) {
-                $this->cleanupCustomFields($oArticle);
+                $this->_cleanupCustomFields($oArticle);
             }
         }
     }
@@ -231,9 +231,10 @@ class ArticlePictures extends AdminDetailsController
      *
      * @param Article $oArticle article object
      *
-     * @internal If your override does not fully replace the behavior, call parent::deleteMainIcon()
-     *           (not the deprecated _deleteMainIcon()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _deleteMainIcon(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make deleteMainIcon() the canonical override target.
      */
     protected function deleteMainIcon($oArticle)
     {
@@ -267,9 +268,10 @@ class ArticlePictures extends AdminDetailsController
      *
      * @param Article $oArticle article object
      *
-     * @internal If your override does not fully replace the behavior, call parent::deleteThumbnail()
-     *           (not the deprecated _deleteThumbnail()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _deleteThumbnail(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make deleteThumbnail() the canonical override target.
      */
     protected function deleteThumbnail($oArticle)
     {

--- a/source/Application/Controller/Admin/ArticleReview.php
+++ b/source/Application/Controller/Admin/ArticleReview.php
@@ -65,7 +65,7 @@ class ArticleReview extends AdminDetailsController
                 $this->_aViewData['readonly'] = true;
             }
 
-            $reviewList = $this->getReviewList($article);
+            $reviewList = $this->_getReviewList($article);
 
             foreach ($reviewList as $review) {
                 if ($review->oxreviews__oxid->value == $reviewId) {
@@ -140,9 +140,10 @@ class ArticleReview extends AdminDetailsController
      * @return ListModel
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getReviewList()
-     *           (not the deprecated _getReviewList()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getReviewList(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getReviewList() the canonical override target.
      */
     protected function getReviewList($article)
     {

--- a/source/Application/Controller/Admin/ArticleSelectionAjax.php
+++ b/source/Application/Controller/Admin/ArticleSelectionAjax.php
@@ -60,9 +60,13 @@ class ArticleSelectionAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -105,9 +109,10 @@ class ArticleSelectionAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -119,9 +124,9 @@ class ArticleSelectionAjax extends ListComponentAjax
      */
     public function removeSel()
     {
-        $aChosenArt = $this->getActionIds('oxobject2selectlist.oxid');
+        $aChosenArt = $this->_getActionIds('oxobject2selectlist.oxid');
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $sQ = $this->addFilter('delete oxobject2selectlist.* ' . $this->getQuery());
+            $sQ = $this->_addFilter('delete oxobject2selectlist.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif (is_array($aChosenArt)) {
             $sChosenArticles = implode(', ', DatabaseProvider::getDb()->quoteArray($aChosenArt));
@@ -141,13 +146,13 @@ class ArticleSelectionAjax extends ListComponentAjax
      */
     public function addSel()
     {
-        $aAddSel = $this->getActionIds('oxselectlist.oxid');
+        $aAddSel = $this->_getActionIds('oxselectlist.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         // adding
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sSLViewName = $this->getViewName('oxselectlist');
-            $aAddSel = $this->getAll($this->addFilter("select $sSLViewName.oxid " . $this->getQuery()));
+            $aAddSel = $this->_getAll($this->_addFilter("select $sSLViewName.oxid " . $this->getQuery()));
         }
 
         if ($soxId && $soxId != '-1' && is_array($aAddSel)) {

--- a/source/Application/Controller/Admin/ArticleSeo.php
+++ b/source/Application/Controller/Admin/ArticleSeo.php
@@ -147,7 +147,7 @@ class ArticleSeo extends ObjectSeo
             $oProduct = oxNew(Article::class);
             $oProduct->load($this->getEditObjectId());
 
-            if ($oCatList = $this->getCategoryList($oProduct)) {
+            if ($oCatList = $this->_getCategoryList($oProduct)) {
                 $this->_aSelectionList['oxcategory'][$this->_iEditLang] = $oCatList;
             }
 

--- a/source/Application/Controller/Admin/ArticleVariant.php
+++ b/source/Application/Controller/Admin/ArticleVariant.php
@@ -98,7 +98,7 @@ class ArticleVariant extends AdminDetailsController
             }
 
             if ($oArticle->oxarticles__oxparentid->value) {
-                $this->_aViewData['parentarticle'] = $this->getProductParent($oArticle->oxarticles__oxparentid->value);
+                $this->_aViewData['parentarticle'] = $this->_getProductParent($oArticle->oxarticles__oxparentid->value);
                 $this->_aViewData['oxparentid'] = $oArticle->oxarticles__oxparentid->value;
                 $this->_aViewData['issubvariant'] = 1;
                 // A. disable variant information editing for variant
@@ -157,7 +157,7 @@ class ArticleVariant extends AdminDetailsController
             $aParams['oxarticles__oxactive'] = 0;
         }
 
-        if (!$this->isAnythingChanged($oArticle, $aParams)) {
+        if (!$this->_isAnythingChanged($oArticle, $aParams)) {
             return;
         }
 
@@ -169,7 +169,7 @@ class ArticleVariant extends AdminDetailsController
         $oArticle->resetRemindStatus();
 
         if ($sOXID == '-1') {
-            if ($oParent = $this->getProductParent($oArticle->oxarticles__oxparentid->value)) {
+            if ($oParent = $this->_getProductParent($oArticle->oxarticles__oxparentid->value)) {
                 // assign field from parent for new variant
                 // #4406
                 $oArticle->oxarticles__oxisconfigurable = new Field($oParent->oxarticles__oxisconfigurable->value);

--- a/source/Application/Controller/Admin/AttributeCategoryAjax.php
+++ b/source/Application/Controller/Admin/AttributeCategoryAjax.php
@@ -67,9 +67,13 @@ class AttributeCategoryAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -110,9 +114,10 @@ class AttributeCategoryAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -124,10 +129,10 @@ class AttributeCategoryAjax extends ListComponentAjax
      */
     public function removeCatFromAttr()
     {
-        $aChosenCat = $this->getActionIds('oxcategory2attribute.oxid');
+        $aChosenCat = $this->_getActionIds('oxcategory2attribute.oxid');
 
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $sQ = $this->addFilter('delete oxcategory2attribute.* ' . $this->getQuery());
+            $sQ = $this->_addFilter('delete oxcategory2attribute.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif (is_array($aChosenCat)) {
             $sChosenCategories = implode(', ', DatabaseProvider::getDb()->quoteArray($aChosenCat));
@@ -145,14 +150,14 @@ class AttributeCategoryAjax extends ListComponentAjax
      */
     public function addCatToAttr()
     {
-        $aAddCategory = $this->getActionIds('oxcategories.oxid');
+        $aAddCategory = $this->_getActionIds('oxcategories.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         $oAttribute = oxNew(Attribute::class);
         // adding
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sCatTable = $this->getViewName('oxcategories');
-            $aAddCategory = $this->getAll($this->addFilter("select $sCatTable.oxid " . $this->getQuery()));
+            $aAddCategory = $this->_getAll($this->_addFilter("select $sCatTable.oxid " . $this->getQuery()));
         }
 
         if ($oAttribute->load($soxId) && is_array($aAddCategory)) {

--- a/source/Application/Controller/Admin/AttributeMain.php
+++ b/source/Application/Controller/Admin/AttributeMain.php
@@ -52,7 +52,7 @@ class AttributeMain extends AdminDetailsController
         // copy this tree for our article choose
         if (isset($soxId) && $soxId != '-1') {
             // generating category tree for select list
-            $this->createCategoryTree('artcattree', $soxId);
+            $this->_createCategoryTree('artcattree', $soxId);
             // load object
             $oAttr->loadInLang($this->_iEditLang, $soxId);
 

--- a/source/Application/Controller/Admin/AttributeMainAjax.php
+++ b/source/Application/Controller/Admin/AttributeMainAjax.php
@@ -74,9 +74,13 @@ class AttributeMainAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -125,9 +129,10 @@ class AttributeMainAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -141,9 +146,13 @@ class AttributeMainAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use addFilter() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _addFilter().
+     * @deprecated Transitional during #107. Modules SHOULD override _addFilter()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes addFilter() to the canonical override
+      *             target and retires _addFilter(); until then, _addFilter() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -170,9 +179,10 @@ class AttributeMainAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::addFilter()
-     *           (not the deprecated _addFilter()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _addFilter(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make addFilter() the canonical override target.
      */
     protected function addFilter($sQ)
     {
@@ -184,7 +194,7 @@ class AttributeMainAjax extends ListComponentAjax
      */
     public function removeAttrArticle()
     {
-        $aChosenCat = $this->getActionIds('oxobject2attribute.oxid');
+        $aChosenCat = $this->_getActionIds('oxobject2attribute.oxid');
 
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sO2AttributeView = $this->getViewName('oxobject2attribute');
@@ -203,13 +213,13 @@ class AttributeMainAjax extends ListComponentAjax
      */
     public function addAttrArticle()
     {
-        $aAddArticle = $this->getActionIds('oxarticles.oxid');
+        $aAddArticle = $this->_getActionIds('oxarticles.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         // adding
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sArticleTable = $this->getViewName('oxarticles');
-            $aAddArticle = $this->getAll($this->addFilter("select $sArticleTable.oxid " . $this->getQuery()));
+            $aAddArticle = $this->_getAll($this->_addFilter("select $sArticleTable.oxid " . $this->getQuery()));
         }
 
         $oAttribute = oxNew(Attribute::class);

--- a/source/Application/Controller/Admin/AttributeOrderAjax.php
+++ b/source/Application/Controller/Admin/AttributeOrderAjax.php
@@ -50,9 +50,13 @@ class AttributeOrderAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -69,9 +73,10 @@ class AttributeOrderAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -82,9 +87,13 @@ class AttributeOrderAjax extends ListComponentAjax
      * Returns SQL query addon for sorting
      *
      * @return string
-     * @deprecated Use getSorting() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getSorting().
+     * @deprecated Transitional during #107. Modules SHOULD override _getSorting()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getSorting() to the canonical override
+      *             target and retires _getSorting(); until then, _getSorting() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -96,9 +105,10 @@ class AttributeOrderAjax extends ListComponentAjax
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getSorting()
-     *           (not the deprecated _getSorting()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getSorting(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getSorting() the canonical override target.
      */
     protected function getSorting()
     {
@@ -149,9 +159,9 @@ class AttributeOrderAjax extends ListComponentAjax
 
         $sQAdd = $this->getQuery();
 
-        $sQ = 'select ' . $this->getQueryCols() . $sQAdd;
+        $sQ = 'select ' . $this->_getQueryCols() . $sQAdd;
         $sCountQ = 'select count( * ) ' . $sQAdd;
 
-        $this->outputResponse($this->getData($sCountQ, $sQ));
+        $this->_outputResponse($this->getData($sCountQ, $sQ));
     }
 }

--- a/source/Application/Controller/Admin/CategoryMain.php
+++ b/source/Application/Controller/Admin/CategoryMain.php
@@ -64,7 +64,7 @@ class CategoryMain extends AdminDetailsController
 
         if (isset($categoryId) && $categoryId != self::NEW_CATEGORY_ID) {
             // generating category tree for select list
-            $this->createCategoryTree('artcattree', $categoryId);
+            $this->_createCategoryTree('artcattree', $categoryId);
 
             // load object
             $oCategory->loadInLang($this->_iEditLang, $categoryId);
@@ -97,11 +97,11 @@ class CategoryMain extends AdminDetailsController
                 $oCategory->oxcategories__oxparentid->setValue('');
             }
 
-            $this->getCategoryTree('cattree', $oCategory->oxcategories__oxparentid->value, $oCategory->oxcategories__oxid->value, true, $oCategory->oxcategories__oxshopid->value);
+            $this->_getCategoryTree('cattree', $oCategory->oxcategories__oxparentid->value, $oCategory->oxcategories__oxid->value, true, $oCategory->oxcategories__oxshopid->value);
 
             $this->_aViewData['defsort'] = $oCategory->oxcategories__oxdefsort->value;
         } else {
-            $this->createCategoryTree('cattree', '', true, $myConfig->getShopId());
+            $this->_createCategoryTree('cattree', '', true, $myConfig->getShopId());
         }
 
         $this->_aViewData['sortableFields'] = $this->getSortableFields();
@@ -157,7 +157,7 @@ class CategoryMain extends AdminDetailsController
 
         $soxId = $this->getEditObjectId();
 
-        $aParams = $this->parseRequestParametersForSave(
+        $aParams = $this->_parseRequestParametersForSave(
             Registry::getRequest()->getRequestEscapedParameter('editval')
         );
 
@@ -186,9 +186,13 @@ class CategoryMain extends AdminDetailsController
      * @param string $sValue value to fix
      *
      * @return string
-     * @deprecated Use processLongDesc() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _processLongDesc().
+     * @deprecated Transitional during #107. Modules SHOULD override _processLongDesc()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes processLongDesc() to the canonical override
+      *             target and retires _processLongDesc(); until then, _processLongDesc() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _processLongDesc($sValue) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -203,9 +207,10 @@ class CategoryMain extends AdminDetailsController
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::processLongDesc()
-     *           (not the deprecated _processLongDesc()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _processLongDesc(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make processLongDesc() the canonical override target.
      */
     protected function processLongDesc($sValue)
     {
@@ -252,7 +257,7 @@ class CategoryMain extends AdminDetailsController
         /** @var Category $oItem */
         $oItem = oxNew(Category::class);
         $oItem->load($sOxId);
-        $this->deleteCatPicture($oItem, $sField);
+        $this->_deleteCatPicture($oItem, $sField);
     }
 
     /**
@@ -263,9 +268,13 @@ class CategoryMain extends AdminDetailsController
      *
      * @return void
      * @throws Exception
-     * @deprecated Use deleteCatPicture() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _deleteCatPicture().
+     * @deprecated Transitional during #107. Modules SHOULD override _deleteCatPicture()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes deleteCatPicture() to the canonical override
+      *             target and retires _deleteCatPicture(); until then, _deleteCatPicture() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _deleteCatPicture($item, $field) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -316,9 +325,10 @@ class CategoryMain extends AdminDetailsController
      * @return void
      * @throws Exception
      *
-     * @internal If your override does not fully replace the behavior, call parent::deleteCatPicture()
-     *           (not the deprecated _deleteCatPicture()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _deleteCatPicture(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make deleteCatPicture() the canonical override target.
      */
     protected function deleteCatPicture($item, $field)
     {
@@ -331,9 +341,13 @@ class CategoryMain extends AdminDetailsController
      * @param array $aReqParams Request parameters.
      *
      * @return array
-     * @deprecated Use parseRequestParametersForSave() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _parseRequestParametersForSave().
+     * @deprecated Transitional during #107. Modules SHOULD override _parseRequestParametersForSave()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes parseRequestParametersForSave() to the canonical override
+      *             target and retires _parseRequestParametersForSave(); until then, _parseRequestParametersForSave() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _parseRequestParametersForSave($aReqParams) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -361,7 +375,7 @@ class CategoryMain extends AdminDetailsController
         }
 
         if (isset($aReqParams['oxcategories__oxlongdesc'])) {
-            $aReqParams['oxcategories__oxlongdesc'] = $this->processLongDesc($aReqParams['oxcategories__oxlongdesc']);
+            $aReqParams['oxcategories__oxlongdesc'] = $this->_processLongDesc($aReqParams['oxcategories__oxlongdesc']);
         }
 
         if (empty($aReqParams['oxcategories__oxpricefrom'])) {
@@ -381,9 +395,10 @@ class CategoryMain extends AdminDetailsController
      *
      * @return array
      *
-     * @internal If your override does not fully replace the behavior, call parent::parseRequestParametersForSave()
-     *           (not the deprecated _parseRequestParametersForSave()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _parseRequestParametersForSave(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make parseRequestParametersForSave() the canonical override target.
      */
     protected function parseRequestParametersForSave($aReqParams)
     {

--- a/source/Application/Controller/Admin/CategoryMainAjax.php
+++ b/source/Application/Controller/Admin/CategoryMainAjax.php
@@ -75,9 +75,13 @@ class CategoryMainAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -118,9 +122,10 @@ class CategoryMainAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -134,9 +139,13 @@ class CategoryMainAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use addFilter() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _addFilter().
+     * @deprecated Transitional during #107. Modules SHOULD override _addFilter()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes addFilter() to the canonical override
+      *             target and retires _addFilter(); until then, _addFilter() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -159,9 +168,10 @@ class CategoryMainAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::addFilter()
-     *           (not the deprecated _addFilter()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _addFilter(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make addFilter() the canonical override target.
      */
     protected function addFilter($sQ)
     {
@@ -176,7 +186,7 @@ class CategoryMainAjax extends ListComponentAjax
      */
     public function addArticle()
     {
-        $aArticles = $this->getActionIds('oxarticles.oxid');
+        $aArticles = $this->_getActionIds('oxarticles.oxid');
         $sCategoryID = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
         $sShopID = Registry::getConfig()->getShopId();
 
@@ -187,7 +197,7 @@ class CategoryMainAjax extends ListComponentAjax
 
             // adding
             if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-                $aArticles = $this->getAll($this->addFilter("select $sArticleTable.oxid " . $this->getQuery()));
+                $aArticles = $this->_getAll($this->_addFilter("select $sArticleTable.oxid " . $this->getQuery()));
             }
 
             if (is_array($aArticles)) {
@@ -218,7 +228,7 @@ class CategoryMainAjax extends ListComponentAjax
                 }
 
                 // updating oxtime values
-                $this->updateOxTime($sProdIds);
+                $this->_updateOxTime($sProdIds);
 
                 $this->resetArtSeoUrl($aArticles);
                 $this->resetCounter('catArticle', $sCategoryID);
@@ -297,13 +307,13 @@ class CategoryMainAjax extends ListComponentAjax
      */
     public function removeArticle()
     {
-        $aArticles = $this->getActionIds('oxarticles.oxid');
+        $aArticles = $this->_getActionIds('oxarticles.oxid');
         $sCategoryID = Registry::getRequest()->getRequestEscapedParameter('oxid');
 
         // adding
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sArticleTable = $this->getViewName('oxarticles');
-            $aArticles = $this->getAll($this->addFilter("select $sArticleTable.oxid " . $this->getQuery()));
+            $aArticles = $this->_getAll($this->_addFilter("select $sArticleTable.oxid " . $this->getQuery()));
         }
 
         // adding
@@ -340,7 +350,7 @@ class CategoryMainAjax extends ListComponentAjax
         $db->execute($sQ);
 
         // updating oxtime values
-        $this->updateOxTime($prodIds);
+        $this->_updateOxTime($prodIds);
     }
 
     /**

--- a/source/Application/Controller/Admin/CategoryOrderAjax.php
+++ b/source/Application/Controller/Admin/CategoryOrderAjax.php
@@ -68,9 +68,13 @@ class CategoryOrderAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -104,9 +108,10 @@ class CategoryOrderAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -118,9 +123,13 @@ class CategoryOrderAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getSorting() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getSorting().
+     * @deprecated Transitional during #107. Modules SHOULD override _getSorting()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getSorting() to the canonical override
+      *             target and retires _getSorting(); until then, _getSorting() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -150,9 +159,10 @@ class CategoryOrderAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getSorting()
-     *           (not the deprecated _getSorting()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getSorting(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getSorting() the canonical override target.
      */
     protected function getSorting()
     {
@@ -164,7 +174,7 @@ class CategoryOrderAjax extends ListComponentAjax
      */
     public function removeCatOrderArticle()
     {
-        $aRemoveArt = $this->getActionIds('oxarticles.oxid');
+        $aRemoveArt = $this->_getActionIds('oxarticles.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('oxid');
         $aSkipArt = Registry::getSession()->getVariable('neworder_sess');
 
@@ -200,7 +210,7 @@ class CategoryOrderAjax extends ListComponentAjax
      */
     public function addCatOrderArticle()
     {
-        $aAddArticle = $this->getActionIds('oxarticles.oxid');
+        $aAddArticle = $this->_getActionIds('oxarticles.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         $aOrdArt = Registry::getSession()->getVariable('neworder_sess');

--- a/source/Application/Controller/Admin/CategorySeo.php
+++ b/source/Application/Controller/Admin/CategorySeo.php
@@ -60,9 +60,13 @@ class CategorySeo extends ObjectSeo
      * Returns current object type seo encoder object
      *
      * @return SeoEncoderCategory
-     * @deprecated Use getEncoder() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getEncoder().
+     * @deprecated Transitional during #107. Modules SHOULD override _getEncoder()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getEncoder() to the canonical override
+      *             target and retires _getEncoder(); until then, _getEncoder() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -74,9 +78,10 @@ class CategorySeo extends ObjectSeo
      *
      * @return SeoEncoderCategory
      *
-     * @internal If your override does not fully replace the behavior, call parent::getEncoder()
-     *           (not the deprecated _getEncoder()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getEncoder(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getEncoder() the canonical override target.
      */
     protected function getEncoder()
     {
@@ -97,9 +102,13 @@ class CategorySeo extends ObjectSeo
      * Returns url type
      *
      * @return string
-     * @deprecated Use getType() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getType().
+     * @deprecated Transitional during #107. Modules SHOULD override _getType()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getType() to the canonical override
+      *             target and retires _getType(); until then, _getType() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -111,9 +120,10 @@ class CategorySeo extends ObjectSeo
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getType()
-     *           (not the deprecated _getType()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getType(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getType() the canonical override target.
      */
     protected function getType()
     {

--- a/source/Application/Controller/Admin/CategoryText.php
+++ b/source/Application/Controller/Admin/CategoryText.php
@@ -72,7 +72,7 @@ class CategoryText extends AdminDetailsController
             }
         }
 
-        $this->_aViewData['editor'] = $this->generateTextEditor('100%', 300, $oCategory, 'oxcategories__oxlongdesc', 'list.tpl.css');
+        $this->_aViewData['editor'] = $this->_generateTextEditor('100%', 300, $oCategory, 'oxcategories__oxlongdesc', 'list.tpl.css');
 
         return 'category_text.tpl';
     }

--- a/source/Application/Controller/Admin/CategoryUpdate.php
+++ b/source/Application/Controller/Admin/CategoryUpdate.php
@@ -49,9 +49,13 @@ class CategoryUpdate extends AdminController
      *
      * @return CategoryList
      * @throws Exception
-     * @deprecated Use getCategoryList() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getCategoryList().
+     * @deprecated Transitional during #107. Modules SHOULD override _getCategoryList()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getCategoryList() to the canonical override
+      *             target and retires _getCategoryList(); until then, _getCategoryList() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getCategoryList() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -69,9 +73,10 @@ class CategoryUpdate extends AdminController
      * @return CategoryList
      * @throws Exception
      *
-     * @internal If your override does not fully replace the behavior, call parent::getCategoryList()
-     *           (not the deprecated _getCategoryList()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getCategoryList(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getCategoryList() the canonical override target.
      */
     protected function getCategoryList()
     {
@@ -86,6 +91,6 @@ class CategoryUpdate extends AdminController
      */
     public function getCatListUpdateInfo()
     {
-        return $this->getCategoryList()->getUpdateInfo();
+        return $this->_getCategoryList()->getUpdateInfo();
     }
 }

--- a/source/Application/Controller/Admin/ContentMain.php
+++ b/source/Application/Controller/Admin/ContentMain.php
@@ -99,7 +99,7 @@ class ContentMain extends AdminDetailsController
             $sCSS = null;
         }
 
-        $this->_aViewData['editor'] = $this->generateTextEditor('100%', 300, $oContent, 'oxcontents__oxcontent', $sCSS);
+        $this->_aViewData['editor'] = $this->_generateTextEditor('100%', 300, $oContent, 'oxcontents__oxcontent', $sCSS);
         $this->_aViewData['afolder'] = $myConfig->getConfigParam('aCMSfolder');
 
         return 'content_main.tpl';
@@ -119,11 +119,11 @@ class ContentMain extends AdminDetailsController
         $aParams = Registry::getRequest()->getRequestEscapedParameter('editval');
 
         if (isset($aParams['oxcontents__oxloadid'])) {
-            $aParams['oxcontents__oxloadid'] = $this->prepareIdent($aParams['oxcontents__oxloadid']);
+            $aParams['oxcontents__oxloadid'] = $this->_prepareIdent($aParams['oxcontents__oxloadid']);
         }
 
         // check if loadid is unique
-        if ($this->checkIdent($aParams['oxcontents__oxloadid'], $soxId)) {
+        if ($this->_checkIdent($aParams['oxcontents__oxloadid'], $soxId)) {
             // loadid already used, display error message
             $this->_aViewData['blLoadError'] = true;
 
@@ -184,7 +184,7 @@ class ContentMain extends AdminDetailsController
         $aParams = Registry::getRequest()->getRequestEscapedParameter('editval');
 
         if (isset($aParams['oxcontents__oxloadid'])) {
-            $aParams['oxcontents__oxloadid'] = $this->prepareIdent($aParams['oxcontents__oxloadid']);
+            $aParams['oxcontents__oxloadid'] = $this->_prepareIdent($aParams['oxcontents__oxloadid']);
         }
 
         // checkbox handling
@@ -217,9 +217,13 @@ class ContentMain extends AdminDetailsController
      * @param string $sIdent ident to filter
      *
      * @return string|null
-     * @deprecated Use prepareIdent() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _prepareIdent().
+     * @deprecated Transitional during #107. Modules SHOULD override _prepareIdent()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes prepareIdent() to the canonical override
+      *             target and retires _prepareIdent(); until then, _prepareIdent() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _prepareIdent($sIdent) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -235,9 +239,10 @@ class ContentMain extends AdminDetailsController
      *
      * @return string|void
      *
-     * @internal If your override does not fully replace the behavior, call parent::prepareIdent()
-     *           (not the deprecated _prepareIdent()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _prepareIdent(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make prepareIdent() the canonical override target.
      */
     protected function prepareIdent($sIdent)
     {
@@ -252,9 +257,13 @@ class ContentMain extends AdminDetailsController
      *
      * @return null
      * @throws DatabaseConnectionException
-     * @deprecated Use checkIdent() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _checkIdent().
+     * @deprecated Transitional during #107. Modules SHOULD override _checkIdent()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes checkIdent() to the canonical override
+      *             target and retires _checkIdent(); until then, _checkIdent() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _checkIdent($sIdent, $sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -289,9 +298,10 @@ class ContentMain extends AdminDetailsController
      * @return null
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::checkIdent()
-     *           (not the deprecated _checkIdent()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _checkIdent(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make checkIdent() the canonical override target.
      */
     protected function checkIdent($sIdent, $sOxId)
     {

--- a/source/Application/Controller/Admin/ContentSeo.php
+++ b/source/Application/Controller/Admin/ContentSeo.php
@@ -36,9 +36,13 @@ class ContentSeo extends ObjectSeo
      * Returns url type
      *
      * @return string
-     * @deprecated Use getType() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getType().
+     * @deprecated Transitional during #107. Modules SHOULD override _getType()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getType() to the canonical override
+      *             target and retires _getType(); until then, _getType() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -50,9 +54,10 @@ class ContentSeo extends ObjectSeo
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getType()
-     *           (not the deprecated _getType()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getType(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getType() the canonical override target.
      */
     protected function getType()
     {
@@ -63,9 +68,13 @@ class ContentSeo extends ObjectSeo
      * Returns current object type seo encoder object
      *
      * @return SeoEncoderContent
-     * @deprecated Use getEncoder() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getEncoder().
+     * @deprecated Transitional during #107. Modules SHOULD override _getEncoder()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getEncoder() to the canonical override
+      *             target and retires _getEncoder(); until then, _getEncoder() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -77,9 +86,10 @@ class ContentSeo extends ObjectSeo
      *
      * @return SeoEncoderContent
      *
-     * @internal If your override does not fully replace the behavior, call parent::getEncoder()
-     *           (not the deprecated _getEncoder()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getEncoder(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getEncoder() the canonical override target.
      */
     protected function getEncoder()
     {

--- a/source/Application/Controller/Admin/CountryList.php
+++ b/source/Application/Controller/Admin/CountryList.php
@@ -83,7 +83,7 @@ class CountryList extends AdminListController
         $aListSorting = parent::getListSorting();
 
         if (array_keys($aListSorting['oxcountry']) === ['oxactive']) {
-            $aListSorting['oxcountry'][$this->getSecondSortFieldName()] = 'asc';
+            $aListSorting['oxcountry'][$this->_getSecondSortFieldName()] = 'asc';
         }
 
         return $aListSorting;
@@ -93,9 +93,13 @@ class CountryList extends AdminListController
      * Getter for the second sort field name (for getting the expected order out of the database).
      *
      * @return string The name of the field we want to be the second order by argument.
-     * @deprecated Use getSecondSortFieldName() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getSecondSortFieldName().
+     * @deprecated Transitional during #107. Modules SHOULD override _getSecondSortFieldName()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getSecondSortFieldName() to the canonical override
+      *             target and retires _getSecondSortFieldName(); until then, _getSecondSortFieldName() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getSecondSortFieldName() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -107,9 +111,10 @@ class CountryList extends AdminListController
      *
      * @return string The name of the field we want to be the second order by argument.
      *
-     * @internal If your override does not fully replace the behavior, call parent::getSecondSortFieldName()
-     *           (not the deprecated _getSecondSortFieldName()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getSecondSortFieldName(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getSecondSortFieldName() the canonical override target.
      */
     protected function getSecondSortFieldName()
     {

--- a/source/Application/Controller/Admin/DeliveryArticles.php
+++ b/source/Application/Controller/Admin/DeliveryArticles.php
@@ -47,7 +47,7 @@ class DeliveryArticles extends AdminDetailsController
         $soxId = $this->getEditObjectId();
 
         if (isset($soxId) && $soxId != '-1') {
-            $this->createCategoryTree('artcattree');
+            $this->_createCategoryTree('artcattree');
 
             // load object
             $oDelivery = oxNew(Delivery::class);

--- a/source/Application/Controller/Admin/DeliveryArticlesAjax.php
+++ b/source/Application/Controller/Admin/DeliveryArticlesAjax.php
@@ -72,9 +72,13 @@ class DeliveryArticlesAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -120,9 +124,10 @@ class DeliveryArticlesAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -151,7 +156,7 @@ class DeliveryArticlesAjax extends ListComponentAjax
      */
     public function removeArtFromDel()
     {
-        $aChosenArt = $this->getActionIds('oxobject2delivery.oxid');
+        $aChosenArt = $this->_getActionIds('oxobject2delivery.oxid');
         // removing all
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sQ = parent::addFilter('delete oxobject2delivery.* ' . $this->getQuery());
@@ -167,13 +172,13 @@ class DeliveryArticlesAjax extends ListComponentAjax
      */
     public function addArtToDel()
     {
-        $aChosenArt = $this->getActionIds('oxarticles.oxid');
+        $aChosenArt = $this->_getActionIds('oxarticles.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         // adding
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sArtTable = $this->getViewName('oxarticles');
-            $aChosenArt = $this->getAll($this->addFilter("select $sArtTable.oxid " . $this->getQuery()));
+            $aChosenArt = $this->_getAll($this->_addFilter("select $sArtTable.oxid " . $this->getQuery()));
         }
 
         if ($soxId && $soxId != '-1' && is_array($aChosenArt)) {

--- a/source/Application/Controller/Admin/DeliveryCategoriesAjax.php
+++ b/source/Application/Controller/Admin/DeliveryCategoriesAjax.php
@@ -60,9 +60,13 @@ class DeliveryCategoriesAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -105,9 +109,10 @@ class DeliveryCategoriesAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -119,11 +124,11 @@ class DeliveryCategoriesAjax extends ListComponentAjax
      */
     public function removeCatFromDel()
     {
-        $aChosenCat = $this->getActionIds('oxobject2delivery.oxid');
+        $aChosenCat = $this->_getActionIds('oxobject2delivery.oxid');
 
         // removing all
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $sQ = $this->addFilter('delete oxobject2delivery.* ' . $this->getQuery());
+            $sQ = $this->_addFilter('delete oxobject2delivery.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif (is_array($aChosenCat)) {
             $sChosenCategories = implode(', ', DatabaseProvider::getDb()->quoteArray($aChosenCat));
@@ -137,13 +142,13 @@ class DeliveryCategoriesAjax extends ListComponentAjax
      */
     public function addCatToDel()
     {
-        $aChosenCat = $this->getActionIds('oxcategories.oxid');
+        $aChosenCat = $this->_getActionIds('oxcategories.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         // adding
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sCatTable = $this->getViewName('oxcategories');
-            $aChosenCat = $this->getAll($this->addFilter("select $sCatTable.oxid " . $this->getQuery()));
+            $aChosenCat = $this->_getAll($this->_addFilter("select $sCatTable.oxid " . $this->getQuery()));
         }
 
         if (isset($soxId) && $soxId != '-1' && isset($aChosenCat) && $aChosenCat) {

--- a/source/Application/Controller/Admin/DeliveryGroupsAjax.php
+++ b/source/Application/Controller/Admin/DeliveryGroupsAjax.php
@@ -57,9 +57,13 @@ class DeliveryGroupsAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -99,9 +103,10 @@ class DeliveryGroupsAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -113,9 +118,9 @@ class DeliveryGroupsAjax extends ListComponentAjax
      */
     public function removeGroupFromDel()
     {
-        $aRemoveGroups = $this->getActionIds('oxobject2delivery.oxid');
+        $aRemoveGroups = $this->_getActionIds('oxobject2delivery.oxid');
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $sQ = $this->addFilter('delete oxobject2delivery.* ' . $this->getQuery());
+            $sQ = $this->_addFilter('delete oxobject2delivery.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
             $sRemoveGroups = implode(', ', DatabaseProvider::getDb()->quoteArray($aRemoveGroups));
@@ -129,13 +134,13 @@ class DeliveryGroupsAjax extends ListComponentAjax
      */
     public function addGroupToDel()
     {
-        $aChosenCat = $this->getActionIds('oxgroups.oxid');
+        $aChosenCat = $this->_getActionIds('oxgroups.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         // adding
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sGroupTable = $this->getViewName('oxgroups');
-            $aChosenCat = $this->getAll($this->addFilter("select $sGroupTable.oxid " . $this->getQuery()));
+            $aChosenCat = $this->_getAll($this->_addFilter("select $sGroupTable.oxid " . $this->getQuery()));
         }
 
         if ($soxId && $soxId != '-1' && is_array($aChosenCat)) {

--- a/source/Application/Controller/Admin/DeliveryMainAjax.php
+++ b/source/Application/Controller/Admin/DeliveryMainAjax.php
@@ -61,9 +61,13 @@ class DeliveryMainAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -99,9 +103,10 @@ class DeliveryMainAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -113,9 +118,9 @@ class DeliveryMainAjax extends ListComponentAjax
      */
     public function removeCountryFromDel()
     {
-        $aChosenCntr = $this->getActionIds('oxobject2delivery.oxid');
+        $aChosenCntr = $this->_getActionIds('oxobject2delivery.oxid');
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $sQ = $this->addFilter('delete oxobject2delivery.* ' . $this->getQuery());
+            $sQ = $this->_addFilter('delete oxobject2delivery.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif (is_array($aChosenCntr)) {
             $sQ = 'delete from oxobject2delivery where oxobject2delivery.oxid in (' . implode(', ', DatabaseProvider::getDb()->quoteArray($aChosenCntr)) . ') ';
@@ -128,13 +133,13 @@ class DeliveryMainAjax extends ListComponentAjax
      */
     public function addCountryToDel()
     {
-        $aChosenCntr = $this->getActionIds('oxcountry.oxid');
+        $aChosenCntr = $this->_getActionIds('oxcountry.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         // adding
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sCountryTable = $this->getViewName('oxcountry');
-            $aChosenCntr = $this->getAll($this->addFilter("select $sCountryTable.oxid " . $this->getQuery()));
+            $aChosenCntr = $this->_getAll($this->_addFilter("select $sCountryTable.oxid " . $this->getQuery()));
         }
 
         if ($soxId && $soxId != '-1' && is_array($aChosenCntr)) {

--- a/source/Application/Controller/Admin/DeliverySetCountryAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetCountryAjax.php
@@ -61,9 +61,13 @@ class DeliverySetCountryAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -100,9 +104,10 @@ class DeliverySetCountryAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -114,10 +119,10 @@ class DeliverySetCountryAjax extends ListComponentAjax
      */
     public function removeCountryFromSet()
     {
-        $aChosenCntr = $this->getActionIds('oxobject2delivery.oxid');
+        $aChosenCntr = $this->_getActionIds('oxobject2delivery.oxid');
         // removing all
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $sQ = $this->addFilter('delete oxobject2delivery.* ' . $this->getQuery());
+            $sQ = $this->_addFilter('delete oxobject2delivery.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif (is_array($aChosenCntr)) {
             $sChosenCountries = implode(', ', DatabaseProvider::getDb()->quoteArray($aChosenCntr));
@@ -131,13 +136,13 @@ class DeliverySetCountryAjax extends ListComponentAjax
      */
     public function addCountryToSet()
     {
-        $aChosenCntr = $this->getActionIds('oxcountry.oxid');
+        $aChosenCntr = $this->_getActionIds('oxcountry.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         // adding
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sCountryTable = $this->getViewName('oxcountry');
-            $aChosenCntr = $this->getAll($this->addFilter("select $sCountryTable.oxid " . $this->getQuery()));
+            $aChosenCntr = $this->_getAll($this->_addFilter("select $sCountryTable.oxid " . $this->getQuery()));
         }
 
         if ($soxId && $soxId != '-1' && is_array($aChosenCntr)) {

--- a/source/Application/Controller/Admin/DeliverySetGroupsAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetGroupsAjax.php
@@ -57,9 +57,13 @@ class DeliverySetGroupsAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -96,9 +100,10 @@ class DeliverySetGroupsAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -110,9 +115,9 @@ class DeliverySetGroupsAjax extends ListComponentAjax
      */
     public function removeGroupFromSet()
     {
-        $aRemoveGroups = $this->getActionIds('oxobject2delivery.oxid');
+        $aRemoveGroups = $this->_getActionIds('oxobject2delivery.oxid');
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $sQ = $this->addFilter('delete oxobject2delivery.* ' . $this->getQuery());
+            $sQ = $this->_addFilter('delete oxobject2delivery.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
             $sRemoveGroups = implode(', ', DatabaseProvider::getDb()->quoteArray($aRemoveGroups));
@@ -126,13 +131,13 @@ class DeliverySetGroupsAjax extends ListComponentAjax
      */
     public function addGroupToSet()
     {
-        $aChosenCat = $this->getActionIds('oxgroups.oxid');
+        $aChosenCat = $this->_getActionIds('oxgroups.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         // adding
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sGroupTable = $this->getViewName('oxgroups');
-            $aChosenCat = $this->getAll($this->addFilter("select $sGroupTable.oxid " . $this->getQuery()));
+            $aChosenCat = $this->_getAll($this->_addFilter("select $sGroupTable.oxid " . $this->getQuery()));
         }
         if ($soxId && $soxId != '-1' && is_array($aChosenCat)) {
             foreach ($aChosenCat as $sChosenCat) {

--- a/source/Application/Controller/Admin/DeliverySetMainAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetMainAjax.php
@@ -60,9 +60,13 @@ class DeliverySetMainAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -94,9 +98,10 @@ class DeliverySetMainAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -108,9 +113,9 @@ class DeliverySetMainAjax extends ListComponentAjax
      */
     public function removeFromSet()
     {
-        $aRemoveGroups = $this->getActionIds('oxdel2delset.oxid');
+        $aRemoveGroups = $this->_getActionIds('oxdel2delset.oxid');
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $sQ = $this->addFilter('delete oxdel2delset.* ' . $this->getQuery());
+            $sQ = $this->_addFilter('delete oxdel2delset.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
             $sQ = 'delete from oxdel2delset where oxdel2delset.oxid in (' . implode(', ', DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ') ';
@@ -125,13 +130,13 @@ class DeliverySetMainAjax extends ListComponentAjax
      */
     public function addToSet()
     {
-        $aChosenSets = $this->getActionIds('oxdelivery.oxid');
+        $aChosenSets = $this->_getActionIds('oxdelivery.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         // adding
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sDeliveryViewName = $this->getViewName('oxdelivery');
-            $aChosenSets = $this->getAll($this->addFilter("select $sDeliveryViewName.oxid " . $this->getQuery()));
+            $aChosenSets = $this->_getAll($this->_addFilter("select $sDeliveryViewName.oxid " . $this->getQuery()));
         }
         if ($soxId && $soxId != '-1' && is_array($aChosenSets)) {
             // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804 and ESDEV-3822).

--- a/source/Application/Controller/Admin/DeliverySetPaymentAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetPaymentAjax.php
@@ -60,9 +60,13 @@ class DeliverySetPaymentAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -94,9 +98,10 @@ class DeliverySetPaymentAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -108,9 +113,9 @@ class DeliverySetPaymentAjax extends ListComponentAjax
      */
     public function removePayFromSet()
     {
-        $aChosenCntr = $this->getActionIds('oxobject2payment.oxid');
+        $aChosenCntr = $this->_getActionIds('oxobject2payment.oxid');
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $sQ = $this->addFilter('delete oxobject2payment.* ' . $this->getQuery());
+            $sQ = $this->_addFilter('delete oxobject2payment.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif (is_array($aChosenCntr)) {
             $sQ = 'delete from oxobject2payment where oxobject2payment.oxid in (' . implode(', ', DatabaseProvider::getDb()->quoteArray($aChosenCntr)) . ') ';
@@ -125,13 +130,13 @@ class DeliverySetPaymentAjax extends ListComponentAjax
      */
     public function addPayToSet()
     {
-        $aChosenSets = $this->getActionIds('oxpayments.oxid');
+        $aChosenSets = $this->_getActionIds('oxpayments.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         // adding
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sPayTable = $this->getViewName('oxpayments');
-            $aChosenSets = $this->getAll($this->addFilter("select $sPayTable.oxid " . $this->getQuery()));
+            $aChosenSets = $this->_getAll($this->_addFilter("select $sPayTable.oxid " . $this->getQuery()));
         }
         if ($soxId && $soxId != '-1' && is_array($aChosenSets)) {
             // We force reading from master to prevent issues with slow replications or open transactions (see ESDEV-3804 and ESDEV-3822).

--- a/source/Application/Controller/Admin/DeliverySetUsersAjax.php
+++ b/source/Application/Controller/Admin/DeliverySetUsersAjax.php
@@ -71,9 +71,13 @@ class DeliverySetUsersAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -121,9 +125,10 @@ class DeliverySetUsersAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -135,9 +140,9 @@ class DeliverySetUsersAjax extends ListComponentAjax
      */
     public function removeUserFromSet()
     {
-        $aRemoveGroups = $this->getActionIds('oxobject2delivery.oxid');
+        $aRemoveGroups = $this->_getActionIds('oxobject2delivery.oxid');
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $sQ = $this->addFilter('delete oxobject2delivery.* ' . $this->getQuery());
+            $sQ = $this->_addFilter('delete oxobject2delivery.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
             $sQ = 'delete from oxobject2delivery where oxobject2delivery.oxid in (' . implode(', ', DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ') ';
@@ -150,13 +155,13 @@ class DeliverySetUsersAjax extends ListComponentAjax
      */
     public function addUserToSet()
     {
-        $aChosenUsr = $this->getActionIds('oxuser.oxid');
+        $aChosenUsr = $this->_getActionIds('oxuser.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         // adding
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sUserTable = $this->getViewName('oxuser');
-            $aChosenUsr = $this->getAll($this->addFilter("select $sUserTable.oxid " . $this->getQuery()));
+            $aChosenUsr = $this->_getAll($this->_addFilter("select $sUserTable.oxid " . $this->getQuery()));
         }
         if ($soxId && $soxId != '-1' && is_array($aChosenUsr)) {
             foreach ($aChosenUsr as $sChosenUsr) {

--- a/source/Application/Controller/Admin/DeliveryUsersAjax.php
+++ b/source/Application/Controller/Admin/DeliveryUsersAjax.php
@@ -71,9 +71,13 @@ class DeliveryUsersAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -117,9 +121,10 @@ class DeliveryUsersAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -131,9 +136,9 @@ class DeliveryUsersAjax extends ListComponentAjax
      */
     public function removeUserFromDel()
     {
-        $aRemoveGroups = $this->getActionIds('oxobject2delivery.oxid');
+        $aRemoveGroups = $this->_getActionIds('oxobject2delivery.oxid');
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $sQ = $this->addFilter('delete oxobject2delivery.* ' . $this->getQuery());
+            $sQ = $this->_addFilter('delete oxobject2delivery.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
             $sQ = 'delete from oxobject2delivery where oxobject2delivery.oxid in (' . implode(', ', DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ') ';
@@ -146,13 +151,13 @@ class DeliveryUsersAjax extends ListComponentAjax
      */
     public function addUserToDel()
     {
-        $aChosenUsr = $this->getActionIds('oxuser.oxid');
+        $aChosenUsr = $this->_getActionIds('oxuser.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         // adding
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sUserTable = $this->getViewName('oxuser');
-            $aChosenUsr = $this->getAll($this->addFilter("select $sUserTable.oxid " . $this->getQuery()));
+            $aChosenUsr = $this->_getAll($this->_addFilter("select $sUserTable.oxid " . $this->getQuery()));
         }
 
         if ($soxId && $soxId != '-1' && is_array($aChosenUsr)) {

--- a/source/Application/Controller/Admin/DiagnosticsMain.php
+++ b/source/Application/Controller/Admin/DiagnosticsMain.php
@@ -89,9 +89,13 @@ class DiagnosticsMain extends AdminDetailsController
      * Error status getter
      *
      * @return bool
-     * @deprecated Use hasError() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _hasError().
+     * @deprecated Transitional during #107. Modules SHOULD override _hasError()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes hasError() to the canonical override
+      *             target and retires _hasError(); until then, _hasError() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _hasError() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -103,9 +107,10 @@ class DiagnosticsMain extends AdminDetailsController
      *
      * @return bool
      *
-     * @internal If your override does not fully replace the behavior, call parent::hasError()
-     *           (not the deprecated _hasError()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _hasError(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make hasError() the canonical override target.
      */
     protected function hasError()
     {
@@ -116,9 +121,13 @@ class DiagnosticsMain extends AdminDetailsController
      * Error status getter
      *
      * @return string
-     * @deprecated Use getErrorMessage() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getErrorMessage().
+     * @deprecated Transitional during #107. Modules SHOULD override _getErrorMessage()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getErrorMessage() to the canonical override
+      *             target and retires _getErrorMessage(); until then, _getErrorMessage() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getErrorMessage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -130,9 +139,10 @@ class DiagnosticsMain extends AdminDetailsController
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getErrorMessage()
-     *           (not the deprecated _getErrorMessage()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getErrorMessage(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getErrorMessage() the canonical override target.
      */
     protected function getErrorMessage()
     {
@@ -161,8 +171,8 @@ class DiagnosticsMain extends AdminDetailsController
     {
         parent::render();
 
-        if ($this->hasError()) {
-            $this->_aViewData['sErrorMessage'] = $this->getErrorMessage();
+        if ($this->_hasError()) {
+            $this->_aViewData['sErrorMessage'] = $this->_getErrorMessage();
         }
 
         return 'diagnostics_form.tpl';
@@ -267,7 +277,7 @@ class DiagnosticsMain extends AdminDetailsController
     {
         $sReport = '';
 
-        $aDiagnosticsResult = $this->runBasicDiagnostics();
+        $aDiagnosticsResult = $this->_runBasicDiagnostics();
         $sReport .= $this->_oRenderer->renderTemplate('diagnostics_main.tpl', $aDiagnosticsResult);
 
         /**
@@ -277,7 +287,7 @@ class DiagnosticsMain extends AdminDetailsController
             $aFileList = $this->_getFilesToCheck();
             $oFileCheckerResult = $this->_checkOxidFiles($aFileList);
 
-            if ($this->hasError()) {
+            if ($this->_hasError()) {
                 return;
             }
 
@@ -297,9 +307,13 @@ class DiagnosticsMain extends AdminDetailsController
      * @return array
      * @throws DatabaseConnectionException
      * @throws DatabaseErrorException
-     * @deprecated Use runBasicDiagnostics() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _runBasicDiagnostics().
+     * @deprecated Transitional during #107. Modules SHOULD override _runBasicDiagnostics()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes runBasicDiagnostics() to the canonical override
+      *             target and retires _runBasicDiagnostics(); until then, _runBasicDiagnostics() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _runBasicDiagnostics() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -374,9 +388,10 @@ class DiagnosticsMain extends AdminDetailsController
      * @throws DatabaseConnectionException
      * @throws DatabaseErrorException
      *
-     * @internal If your override does not fully replace the behavior, call parent::runBasicDiagnostics()
-     *           (not the deprecated _runBasicDiagnostics()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _runBasicDiagnostics(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make runBasicDiagnostics() the canonical override target.
      */
     protected function runBasicDiagnostics()
     {

--- a/source/Application/Controller/Admin/DiscountArticles.php
+++ b/source/Application/Controller/Admin/DiscountArticles.php
@@ -55,7 +55,7 @@ class DiscountArticles extends AdminDetailsController
             }
 
             // generating category tree for artikel choose select list
-            $this->createCategoryTree('artcattree');
+            $this->_createCategoryTree('artcattree');
         }
 
         $iAoc = Registry::getRequest()->getRequestEscapedParameter('aoc');

--- a/source/Application/Controller/Admin/DiscountArticlesAjax.php
+++ b/source/Application/Controller/Admin/DiscountArticlesAjax.php
@@ -76,9 +76,13 @@ class DiscountArticlesAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -130,9 +134,10 @@ class DiscountArticlesAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -144,7 +149,7 @@ class DiscountArticlesAjax extends ListComponentAjax
      */
     public function removeDiscArt()
     {
-        $aChosenArt = $this->getActionIds('oxobject2discount.oxid');
+        $aChosenArt = $this->_getActionIds('oxobject2discount.oxid');
 
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sQ = parent::addFilter('delete oxobject2discount.* ' . $this->getQuery());
@@ -161,13 +166,13 @@ class DiscountArticlesAjax extends ListComponentAjax
     public function addDiscArt()
     {
         $oRequest = Registry::getRequest();
-        $articleIds = $this->getActionIds('oxarticles.oxid');
+        $articleIds = $this->_getActionIds('oxarticles.oxid');
         $discountListId = $oRequest->getRequestEscapedParameter('synchoxid');
 
         // adding
         if ($oRequest->getRequestEscapedParameter('all')) {
             $articleTable = $this->getViewName('oxarticles');
-            $articleIds = $this->getAll(parent::addFilter("select $articleTable.oxid " . $this->getQuery()));
+            $articleIds = $this->_getAll(parent::addFilter("select $articleTable.oxid " . $this->getQuery()));
         }
         if ($discountListId && $discountListId != self::NEW_DISCOUNT_LIST_ID && is_array($articleIds)) {
             foreach ($articleIds as $articleId) {

--- a/source/Application/Controller/Admin/DiscountCategoriesAjax.php
+++ b/source/Application/Controller/Admin/DiscountCategoriesAjax.php
@@ -64,9 +64,13 @@ class DiscountCategoriesAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -110,9 +114,10 @@ class DiscountCategoriesAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -124,10 +129,10 @@ class DiscountCategoriesAjax extends ListComponentAjax
      */
     public function removeDiscCat()
     {
-        $categoryIds = $this->getActionIds('oxobject2discount.oxid');
+        $categoryIds = $this->_getActionIds('oxobject2discount.oxid');
 
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $query = $this->addFilter('delete oxobject2discount.* ' . $this->getQuery());
+            $query = $this->_addFilter('delete oxobject2discount.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($query);
         } elseif (is_array($categoryIds)) {
             $chosenCategories = implode(', ', DatabaseProvider::getDb()->quoteArray($categoryIds));
@@ -142,12 +147,12 @@ class DiscountCategoriesAjax extends ListComponentAjax
     public function addDiscCat()
     {
         $oRequest = Registry::getRequest();
-        $categoryIds = $this->getActionIds('oxcategories.oxid');
+        $categoryIds = $this->_getActionIds('oxcategories.oxid');
         $discountId = $oRequest->getRequestEscapedParameter('synchoxid');
 
         if ($oRequest->getRequestEscapedParameter('all')) {
             $categoryTable = $this->getViewName('oxcategories');
-            $categoryIds = $this->getAll($this->addFilter("select $categoryTable.oxid " . $this->getQuery()));
+            $categoryIds = $this->_getAll($this->_addFilter("select $categoryTable.oxid " . $this->getQuery()));
         }
         if ($discountId && $discountId != self::NEW_DISCOUNT_ID && is_array($categoryIds)) {
             foreach ($categoryIds as $categoryId) {

--- a/source/Application/Controller/Admin/DiscountGroupsAjax.php
+++ b/source/Application/Controller/Admin/DiscountGroupsAjax.php
@@ -60,9 +60,13 @@ class DiscountGroupsAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -98,9 +102,10 @@ class DiscountGroupsAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -112,9 +117,9 @@ class DiscountGroupsAjax extends ListComponentAjax
      */
     public function removeDiscGroup()
     {
-        $groupIds = $this->getActionIds('oxobject2discount.oxid');
+        $groupIds = $this->_getActionIds('oxobject2discount.oxid');
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $query = $this->addFilter('delete oxobject2discount.* ' . $this->getQuery());
+            $query = $this->_addFilter('delete oxobject2discount.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($query);
         } elseif ($groupIds && is_array($groupIds)) {
             $groupIdsQuoted = implode(', ', DatabaseProvider::getDb()->quoteArray($groupIds));
@@ -129,12 +134,12 @@ class DiscountGroupsAjax extends ListComponentAjax
     public function addDiscGroup()
     {
         $oRequest = Registry::getRequest();
-        $groupIds = $this->getActionIds('oxgroups.oxid');
+        $groupIds = $this->_getActionIds('oxgroups.oxid');
         $discountId = $oRequest->getRequestEscapedParameter('synchoxid');
 
         if ($oRequest->getRequestEscapedParameter('all')) {
             $groupTable = $this->getViewName('oxgroups');
-            $groupIds = $this->getAll($this->addFilter("select $groupTable.oxid " . $this->getQuery()));
+            $groupIds = $this->_getAll($this->_addFilter("select $groupTable.oxid " . $this->getQuery()));
         }
         if ($discountId && $discountId != self::NEW_DISCOUNT_ID && is_array($groupIds)) {
             foreach ($groupIds as $groupId) {

--- a/source/Application/Controller/Admin/DiscountItemAjax.php
+++ b/source/Application/Controller/Admin/DiscountItemAjax.php
@@ -63,9 +63,13 @@ class DiscountItemAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -124,9 +128,10 @@ class DiscountItemAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -139,7 +144,7 @@ class DiscountItemAjax extends ListComponentAjax
     public function removeDiscArt()
     {
         $soxId = Registry::getRequest()->getRequestEscapedParameter('oxid');
-        $aChosenArt = $this->getActionIds('oxdiscount.oxitmartid');
+        $aChosenArt = $this->_getActionIds('oxdiscount.oxitmartid');
         if (is_array($aChosenArt)) {
             $sQ = "update oxdiscount set oxitmartid = '' where oxid = :oxid and oxitmartid = :oxitmartid";
             DatabaseProvider::getDb()->execute($sQ, [
@@ -154,7 +159,7 @@ class DiscountItemAjax extends ListComponentAjax
      */
     public function addDiscArt()
     {
-        $aChosenArt = $this->getActionIds('oxarticles.oxid');
+        $aChosenArt = $this->_getActionIds('oxarticles.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
         if ($soxId && $soxId != '-1' && is_array($aChosenArt)) {
             $sQ = 'update oxdiscount set oxitmartid = :oxitmartid where oxid = :oxid';
@@ -170,9 +175,13 @@ class DiscountItemAjax extends ListComponentAjax
      * fields to load from DB. Adds sub-select to get variant title from parent article
      *
      * @return string
-     * @deprecated Use getQueryCols() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQueryCols().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQueryCols()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQueryCols() to the canonical override
+      *             target and retires _getQueryCols(); until then, _getQueryCols() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQueryCols() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -192,9 +201,10 @@ class DiscountItemAjax extends ListComponentAjax
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQueryCols()
-     *           (not the deprecated _getQueryCols()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQueryCols(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQueryCols() the canonical override target.
      */
     protected function getQueryCols()
     {
@@ -206,7 +216,7 @@ class DiscountItemAjax extends ListComponentAjax
         $query = '';
         $languageSuffix = $this->getLanguageSuffix();
         $selectVariantsEnabled = Registry::getConfig()->getConfigParam('blVariantsSelection');
-        foreach ($this->getVisibleColNames() as $key => [$columnName, $tableName]) {
+        foreach ($this->_getVisibleColNames() as $key => [$columnName, $tableName]) {
             $view = $this->getViewName($tableName);
             if ($selectVariantsEnabled && $columnName === 'oxtitle') {
                 $query .= sprintf(
@@ -227,7 +237,7 @@ class DiscountItemAjax extends ListComponentAjax
     private function getQueryForIdentifierColumns(): string
     {
         $query = '';
-        foreach ($this->getIdentColNames() as $key => [$columnName, $tableName]) {
+        foreach ($this->_getIdentColNames() as $key => [$columnName, $tableName]) {
             $view = $this->getViewName($tableName);
             $query .= "{$view}.{$columnName} as _{$key}";
             $query .= ', ';

--- a/source/Application/Controller/Admin/DiscountMain.php
+++ b/source/Application/Controller/Admin/DiscountMain.php
@@ -90,7 +90,7 @@ class DiscountMain extends AdminDetailsController
                 return 'popups/discount_main.tpl';
             } elseif ($iAoc == '2') {
                 // generating category tree for artikel choose select list
-                $this->createCategoryTree('artcattree');
+                $this->_createCategoryTree('artcattree');
 
                 $oDiscountItemAjax = oxNew(\OxidEsales\Eshop\Application\Controller\Admin\DiscountItemAjax::class);
                 $this->_aViewData['oxajax'] = $oDiscountItemAjax->getColumns();

--- a/source/Application/Controller/Admin/DiscountMainAjax.php
+++ b/source/Application/Controller/Admin/DiscountMainAjax.php
@@ -59,9 +59,13 @@ class DiscountMainAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -93,9 +97,10 @@ class DiscountMainAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -107,9 +112,9 @@ class DiscountMainAjax extends ListComponentAjax
      */
     public function removeDiscCountry()
     {
-        $aChosenCntr = $this->getActionIds('oxobject2discount.oxid');
+        $aChosenCntr = $this->_getActionIds('oxobject2discount.oxid');
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $sQ = $this->addFilter('delete oxobject2discount.* ' . $this->getQuery());
+            $sQ = $this->_addFilter('delete oxobject2discount.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif (is_array($aChosenCntr)) {
             $sQ = 'delete from oxobject2discount where oxobject2discount.oxid in (' . implode(', ', DatabaseProvider::getDb()->quoteArray($aChosenCntr)) . ') ';
@@ -123,12 +128,12 @@ class DiscountMainAjax extends ListComponentAjax
     public function addDiscCountry()
     {
         $oRequest = Registry::getRequest();
-        $aChosenCntr = $this->getActionIds('oxcountry.oxid');
+        $aChosenCntr = $this->_getActionIds('oxcountry.oxid');
         $soxId = $oRequest->getRequestEscapedParameter('synchoxid');
 
         if ($oRequest->getRequestEscapedParameter('all')) {
             $sCountryTable = $this->getViewName('oxcountry');
-            $aChosenCntr = $this->getAll($this->addFilter("select $sCountryTable.oxid " . $this->getQuery()));
+            $aChosenCntr = $this->_getAll($this->_addFilter("select $sCountryTable.oxid " . $this->getQuery()));
         }
         if ($soxId && $soxId != '-1' && is_array($aChosenCntr)) {
             foreach ($aChosenCntr as $sChosenCntr) {

--- a/source/Application/Controller/Admin/DiscountUsersAjax.php
+++ b/source/Application/Controller/Admin/DiscountUsersAjax.php
@@ -71,9 +71,13 @@ class DiscountUsersAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -118,9 +122,10 @@ class DiscountUsersAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -132,9 +137,9 @@ class DiscountUsersAjax extends ListComponentAjax
      */
     public function removeDiscUser()
     {
-        $aRemoveGroups = $this->getActionIds('oxobject2discount.oxid');
+        $aRemoveGroups = $this->_getActionIds('oxobject2discount.oxid');
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $sQ = $this->addFilter('delete oxobject2discount.* ' . $this->getQuery());
+            $sQ = $this->_addFilter('delete oxobject2discount.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
             $sQ = 'delete from oxobject2discount where oxobject2discount.oxid in (' . implode(', ', DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ') ';
@@ -148,12 +153,12 @@ class DiscountUsersAjax extends ListComponentAjax
     public function addDiscUser()
     {
         $oRequest = Registry::getRequest();
-        $aChosenUsr = $this->getActionIds('oxuser.oxid');
+        $aChosenUsr = $this->_getActionIds('oxuser.oxid');
         $soxId = $oRequest->getRequestEscapedParameter('synchoxid');
 
         if ($oRequest->getRequestEscapedParameter('all')) {
             $sUserTable = $this->getViewName('oxuser');
-            $aChosenUsr = $this->getAll($this->addFilter("select $sUserTable.oxid " . $this->getQuery()));
+            $aChosenUsr = $this->_getAll($this->_addFilter("select $sUserTable.oxid " . $this->getQuery()));
         }
         if ($soxId && $soxId != '-1' && is_array($aChosenUsr)) {
             foreach ($aChosenUsr as $sChosenUsr) {

--- a/source/Application/Controller/Admin/DynamicExportBaseController.php
+++ b/source/Application/Controller/Admin/DynamicExportBaseController.php
@@ -513,8 +513,8 @@ class DynamicExportBaseController extends AdminDetailsController
             Registry::getUtils()->showMessageAndExit("Could not insert Articles in Table {$sHeapTable}\n<br>");
         }
 
-        $this->removeParentArticles($sHeapTable);
-        $this->setSessionParams();
+        $this->_removeParentArticles($sHeapTable);
+        $this->_setSessionParams();
 
         // get total cnt
         return $oDB->getOne("select count(*) from {$sHeapTable}");
@@ -540,7 +540,7 @@ class DynamicExportBaseController extends AdminDetailsController
         $myConfig->setConfigParam('blExport', true);
         $blContinue = false;
 
-        if (($oArticle = $this->initArticle($this->getHeapTableName(), $iCnt, $blContinue))) {
+        if (($oArticle = $this->_initArticle($this->getHeapTableName(), $iCnt, $blContinue))) {
             $blContinue = true;
             $oArticle = $this->setCampaignDetailLink($oArticle);
         }

--- a/source/Application/Controller/Admin/DynamicScreenController.php
+++ b/source/Application/Controller/Admin/DynamicScreenController.php
@@ -49,9 +49,13 @@ class DynamicScreenController extends AdminListController
      * Sets up navigation for current view
      *
      * @param string $sNode None name
-     * @deprecated Use setupNavigation() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _setupNavigation().
+     * @deprecated Transitional during #107. Modules SHOULD override _setupNavigation()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes setupNavigation() to the canonical override
+      *             target and retires _setupNavigation(); until then, _setupNavigation() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -100,9 +104,10 @@ class DynamicScreenController extends AdminListController
      *
      * @param string $sNode None name
      *
-     * @internal If your override does not fully replace the behavior, call parent::setupNavigation()
-     *           (not the deprecated _setupNavigation()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _setupNavigation(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make setupNavigation() the canonical override target.
      */
     protected function setupNavigation($sNode)
     {

--- a/source/Application/Controller/Admin/GenericImportMain.php
+++ b/source/Application/Controller/Admin/GenericImportMain.php
@@ -111,10 +111,10 @@ class GenericImportMain extends AdminDetailsController
             $navigationStep++;
         }
 
-        $navigationStep = $this->checkErrors($navigationStep);
+        $navigationStep = $this->_checkErrors($navigationStep);
 
         if ($navigationStep == 1) {
-            $this->_aViewData['sGiCsvFieldTerminator'] = Str::getStr()->htmlentities($this->getCsvFieldsTerminator());
+            $this->_aViewData['sGiCsvFieldTerminator'] = Str::getStr()->htmlentities($this->_getCsvFieldsTerminator());
             $this->_aViewData['sGiCsvFieldEncloser'] = Str::getStr()->htmlentities($this->getCsvFieldsEncloser());
         }
 
@@ -141,7 +141,7 @@ class GenericImportMain extends AdminDetailsController
             $importObject = $genericImport->getImportObject($type);
             $this->_aViewData['sType'] = $type;
             $this->_aViewData['sImportTable'] = $importObject->getBaseTableName();
-            $this->_aViewData['aCsvFieldsList'] = $this->getCsvFieldsNames();
+            $this->_aViewData['aCsvFieldsList'] = $this->_getCsvFieldsNames();
             $this->_aViewData['aDbFieldsList'] = $importObject->getFieldList();
         }
 
@@ -154,14 +154,14 @@ class GenericImportMain extends AdminDetailsController
             $genericImport->setCsvFileFieldsOrder($csvFields);
             $genericImport->setCsvContainsHeader(Registry::getSession()->getVariable('blCsvContainsHeader'));
 
-            $genericImport->importFile($this->getUploadedCsvFilePath());
+            $genericImport->importFile($this->_getUploadedCsvFilePath());
             $this->_aViewData['iTotalRows'] = $genericImport->getImportedRowCount();
 
             //checking if errors occurred during import
-            $this->checkImportErrors($genericImport);
+            $this->_checkImportErrors($genericImport);
 
             //deleting uploaded csv file from temp dir
-            $this->deleteCsvFile();
+            $this->_deleteCsvFile();
 
             //check if repeating import - then forcing first step
             if ($oRequest->getRequestEscapedParameter('iRepeatImport')) {
@@ -173,7 +173,7 @@ class GenericImportMain extends AdminDetailsController
         if ($navigationStep == 1) {
             $this->_aViewData['aImportTables'] = $genericImport->getImportObjectsList();
             asort($this->_aViewData['aImportTables']);
-            $this->resetUploadedCsvData();
+            $this->_resetUploadedCsvData();
         }
 
         $this->_aViewData['sNavStep'] = $navigationStep;
@@ -183,13 +183,17 @@ class GenericImportMain extends AdminDetailsController
 
     /**
      * Deletes uploaded csv file from temp directory
-     * @deprecated Use deleteCsvFile() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _deleteCsvFile().
+     * @deprecated Transitional during #107. Modules SHOULD override _deleteCsvFile()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes deleteCsvFile() to the canonical override
+      *             target and retires _deleteCsvFile(); until then, _deleteCsvFile() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _deleteCsvFile() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $sPath = $this->getUploadedCsvFilePath();
+        $sPath = $this->_getUploadedCsvFilePath();
         if (is_file($sPath)) {
             @unlink($sPath);
         }
@@ -198,9 +202,10 @@ class GenericImportMain extends AdminDetailsController
     /**
      * Deletes uploaded csv file from temp directory
      *
-     * @internal If your override does not fully replace the behavior, call parent::deleteCsvFile()
-     *           (not the deprecated _deleteCsvFile()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _deleteCsvFile(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make deleteCsvFile() the canonical override target.
      */
     protected function deleteCsvFile()
     {
@@ -212,17 +217,21 @@ class GenericImportMain extends AdminDetailsController
      * returns default columns names Column 1, Column 2 ...
      *
      * @return array
-     * @deprecated Use getCsvFieldsNames() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getCsvFieldsNames().
+     * @deprecated Transitional during #107. Modules SHOULD override _getCsvFieldsNames()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getCsvFieldsNames() to the canonical override
+      *             target and retires _getCsvFieldsNames(); until then, _getCsvFieldsNames() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getCsvFieldsNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $blCsvContainsHeader = Registry::getRequest()->getRequestEscapedParameter('blContainsHeader');
         Registry::getSession()->setVariable('blCsvContainsHeader', $blCsvContainsHeader);
-        $this->getUploadedCsvFilePath();
+        $this->_getUploadedCsvFilePath();
 
-        $aFirstRow = $this->getCsvFirstRow();
+        $aFirstRow = $this->_getCsvFirstRow();
         $aCsvFields = [];
 
         if (!$blCsvContainsHeader) {
@@ -247,9 +256,10 @@ class GenericImportMain extends AdminDetailsController
      *
      * @return array
      *
-     * @internal If your override does not fully replace the behavior, call parent::getCsvFieldsNames()
-     *           (not the deprecated _getCsvFieldsNames()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getCsvFieldsNames(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getCsvFieldsNames() the canonical override target.
      */
     protected function getCsvFieldsNames()
     {
@@ -260,19 +270,23 @@ class GenericImportMain extends AdminDetailsController
      * Get first row from uploaded CSV file
      *
      * @return array
-     * @deprecated Use getCsvFirstRow() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getCsvFirstRow().
+     * @deprecated Transitional during #107. Modules SHOULD override _getCsvFirstRow()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getCsvFirstRow() to the canonical override
+      *             target and retires _getCsvFirstRow(); until then, _getCsvFirstRow() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getCsvFirstRow() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $sPath = $this->getUploadedCsvFilePath();
+        $sPath = $this->_getUploadedCsvFilePath();
         $iMaxLineLength = 8192;
         $aRow = [];
 
         //getting first row
         if (($rFile = @fopen($sPath, 'r')) !== false) {
-            $aRow = fgetcsv($rFile, $iMaxLineLength, $this->getCsvFieldsTerminator(), $this->getCsvFieldsEncloser());
+            $aRow = fgetcsv($rFile, $iMaxLineLength, $this->_getCsvFieldsTerminator(), $this->getCsvFieldsEncloser());
             fclose($rFile);
         }
 
@@ -284,9 +298,10 @@ class GenericImportMain extends AdminDetailsController
      *
      * @return array
      *
-     * @internal If your override does not fully replace the behavior, call parent::getCsvFirstRow()
-     *           (not the deprecated _getCsvFirstRow()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getCsvFirstRow(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getCsvFirstRow() the canonical override target.
      */
     protected function getCsvFirstRow()
     {
@@ -295,9 +310,13 @@ class GenericImportMain extends AdminDetailsController
 
     /**
      * Resets CSV parameters stored in session
-     * @deprecated Use resetUploadedCsvData() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _resetUploadedCsvData().
+     * @deprecated Transitional during #107. Modules SHOULD override _resetUploadedCsvData()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes resetUploadedCsvData() to the canonical override
+      *             target and retires _resetUploadedCsvData(); until then, _resetUploadedCsvData() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _resetUploadedCsvData() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -309,9 +328,10 @@ class GenericImportMain extends AdminDetailsController
     /**
      * Resets CSV parameters stored in session
      *
-     * @internal If your override does not fully replace the behavior, call parent::resetUploadedCsvData()
-     *           (not the deprecated _resetUploadedCsvData()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _resetUploadedCsvData(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make resetUploadedCsvData() the canonical override target.
      */
     protected function resetUploadedCsvData()
     {
@@ -325,14 +345,18 @@ class GenericImportMain extends AdminDetailsController
      * @param int $iNavStep Navigation step id
      *
      * @return int
-     * @deprecated Use checkErrors() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _checkErrors().
+     * @deprecated Transitional during #107. Modules SHOULD override _checkErrors()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes checkErrors() to the canonical override
+      *             target and retires _checkErrors(); until then, _checkErrors() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _checkErrors($iNavStep) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         if ($iNavStep == 2) {
-            if (!$this->getUploadedCsvFilePath()) {
+            if (!$this->_getUploadedCsvFilePath()) {
                 $oEx = oxNew(ExceptionToDisplay::class);
                 $oEx->setMessage('GENIMPORT_ERRORUPLOADINGFILE');
                 Registry::getUtilsView()->addErrorToDisplay($oEx, false, true, 'genimport');
@@ -371,9 +395,10 @@ class GenericImportMain extends AdminDetailsController
      *
      * @return int
      *
-     * @internal If your override does not fully replace the behavior, call parent::checkErrors()
-     *           (not the deprecated _checkErrors()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _checkErrors(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make checkErrors() the canonical override target.
      */
     protected function checkErrors($iNavStep)
     {
@@ -385,9 +410,13 @@ class GenericImportMain extends AdminDetailsController
      * and stores path to file in session. Return path to uploaded file.
      *
      * @return string|null
-     * @deprecated Use getUploadedCsvFilePath() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getUploadedCsvFilePath().
+     * @deprecated Transitional during #107. Modules SHOULD override _getUploadedCsvFilePath()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getUploadedCsvFilePath() to the canonical override
+      *             target and retires _getUploadedCsvFilePath(); until then, _getUploadedCsvFilePath() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getUploadedCsvFilePath() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -415,9 +444,10 @@ class GenericImportMain extends AdminDetailsController
      *
      * @return string|null|void
      *
-     * @internal If your override does not fully replace the behavior, call parent::getUploadedCsvFilePath()
-     *           (not the deprecated _getUploadedCsvFilePath()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getUploadedCsvFilePath(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getUploadedCsvFilePath() the canonical override target.
      */
     protected function getUploadedCsvFilePath()
     {
@@ -428,9 +458,13 @@ class GenericImportMain extends AdminDetailsController
      * Checks if any error occurred during import and displays them
      *
      * @param object $oErpImport Import object
-     * @deprecated Use checkImportErrors() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _checkImportErrors().
+     * @deprecated Transitional during #107. Modules SHOULD override _checkImportErrors()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes checkImportErrors() to the canonical override
+      *             target and retires _checkImportErrors(); until then, _checkImportErrors() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _checkImportErrors($oErpImport) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -448,9 +482,10 @@ class GenericImportMain extends AdminDetailsController
      *
      * @param object $oErpImport Import object
      *
-     * @internal If your override does not fully replace the behavior, call parent::checkImportErrors()
-     *           (not the deprecated _checkImportErrors()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _checkImportErrors(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make checkImportErrors() the canonical override target.
      */
     protected function checkImportErrors($oErpImport)
     {
@@ -461,9 +496,13 @@ class GenericImportMain extends AdminDetailsController
      * Get csv field terminator symbol
      *
      * @return string
-     * @deprecated Use getCsvFieldsTerminator() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getCsvFieldsTerminator().
+     * @deprecated Transitional during #107. Modules SHOULD override _getCsvFieldsTerminator()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getCsvFieldsTerminator() to the canonical override
+      *             target and retires _getCsvFieldsTerminator(); until then, _getCsvFieldsTerminator() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getCsvFieldsTerminator() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -482,9 +521,10 @@ class GenericImportMain extends AdminDetailsController
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getCsvFieldsTerminator()
-     *           (not the deprecated _getCsvFieldsTerminator()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getCsvFieldsTerminator(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getCsvFieldsTerminator() the canonical override target.
      */
     protected function getCsvFieldsTerminator()
     {

--- a/source/Application/Controller/Admin/LanguageList.php
+++ b/source/Application/Controller/Admin/LanguageList.php
@@ -103,7 +103,7 @@ class LanguageList extends AdminListController
     public function render()
     {
         parent::render();
-        $this->_aViewData['mylist'] = $this->getLanguagesList();
+        $this->_aViewData['mylist'] = $this->_getLanguagesList();
 
         return 'language_list.tpl';
     }
@@ -113,9 +113,13 @@ class LanguageList extends AdminListController
      *
      * @return array
      * @throws DatabaseConnectionException
-     * @deprecated Use getLanguagesList() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getLanguagesList().
+     * @deprecated Transitional during #107. Modules SHOULD override _getLanguagesList()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getLanguagesList() to the canonical override
+      *             target and retires _getLanguagesList(); until then, _getLanguagesList() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getLanguagesList() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -160,9 +164,10 @@ class LanguageList extends AdminListController
      * @return array
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getLanguagesList()
-     *           (not the deprecated _getLanguagesList()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getLanguagesList(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getLanguagesList() the canonical override target.
      */
     protected function getLanguagesList()
     {
@@ -177,9 +182,13 @@ class LanguageList extends AdminListController
      * @param object $oLang2 language object
      *
      * @return int
-     * @deprecated Use sortLanguagesCallback() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _sortLanguagesCallback().
+     * @deprecated Transitional during #107. Modules SHOULD override _sortLanguagesCallback()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes sortLanguagesCallback() to the canonical override
+      *             target and retires _sortLanguagesCallback(); until then, _sortLanguagesCallback() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _sortLanguagesCallback($oLang1, $oLang2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -203,9 +212,10 @@ class LanguageList extends AdminListController
      *
      * @return int
      *
-     * @internal If your override does not fully replace the behavior, call parent::sortLanguagesCallback()
-     *           (not the deprecated _sortLanguagesCallback()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _sortLanguagesCallback(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make sortLanguagesCallback() the canonical override target.
      */
     protected function sortLanguagesCallback($oLang1, $oLang2)
     {
@@ -219,9 +229,13 @@ class LanguageList extends AdminListController
      * @param string $iLangId language ID
      * @throws DatabaseConnectionException
      * @throws DatabaseErrorException
-     * @deprecated Use resetMultiLangDbFields() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _resetMultiLangDbFields().
+     * @deprecated Transitional during #107. Modules SHOULD override _resetMultiLangDbFields()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes resetMultiLangDbFields() to the canonical override
+      *             target and retires _resetMultiLangDbFields(); until then, _resetMultiLangDbFields() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _resetMultiLangDbFields($iLangId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -256,9 +270,10 @@ class LanguageList extends AdminListController
      * @throws DatabaseConnectionException
      * @throws DatabaseErrorException
      *
-     * @internal If your override does not fully replace the behavior, call parent::resetMultiLangDbFields()
-     *           (not the deprecated _resetMultiLangDbFields()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _resetMultiLangDbFields(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make resetMultiLangDbFields() the canonical override target.
      */
     protected function resetMultiLangDbFields($iLangId)
     {

--- a/source/Application/Controller/Admin/LanguageMain.php
+++ b/source/Application/Controller/Admin/LanguageMain.php
@@ -87,12 +87,12 @@ class LanguageMain extends AdminDetailsController
 
         $sOxId = $this->_aViewData['oxid'] = $this->getEditObjectId();
         //loading languages info from config
-        $this->_aLangData = $this->getLanguages();
+        $this->_aLangData = $this->_getLanguages();
 
         if (isset($sOxId) && $sOxId != '-1') {
             //checking if translations files exists
-            $this->checkLangTranslations($sOxId);
-            $this->_aViewData['edit'] = $this->getLanguageInfo($sOxId);
+            $this->_checkLangTranslations($sOxId);
+            $this->_aViewData['edit'] = $this->_getLanguageInfo($sOxId);
         }
 
         return 'language_main.tpl';
@@ -125,9 +125,9 @@ class LanguageMain extends AdminDetailsController
         }
 
         //loading languages info from config
-        $this->_aLangData = $this->getLanguages();
+        $this->_aLangData = $this->_getLanguages();
         //checking input errors
-        if (!$this->validateInput()) {
+        if (!$this->_validateInput()) {
             return;
         }
 
@@ -163,7 +163,7 @@ class LanguageMain extends AdminDetailsController
         // if adding new language, setting lang id to abbreviation
         if ($blNewLanguage = ($sOxId == -1)) {
             $sOxId = $aParams['abbr'];
-            $this->_aLangData['params'][$sOxId]['baseId'] = $this->getAvailableLangBaseId();
+            $this->_aLangData['params'][$sOxId]['baseId'] = $this->_getAvailableLangBaseId();
             $this->setEditObjectId($sOxId);
         }
 
@@ -177,7 +177,7 @@ class LanguageMain extends AdminDetailsController
 
         //if setting lang as default
         if ($aParams['default'] == '1') {
-            $this->setDefaultLang($sOxId);
+            $this->_setDefaultLang($sOxId);
         }
 
         //updating language urls
@@ -186,7 +186,7 @@ class LanguageMain extends AdminDetailsController
         $this->_aLangData['sslUrls'][$iBaseId] = $aParams['basesslurl'];
 
         //sort parameters, urls and languages arrays by language base id
-        $this->sortLangArraysByBaseId();
+        $this->_sortLangArraysByBaseId();
 
         $this->_aViewData['updatelist'] = '1';
 
@@ -199,8 +199,8 @@ class LanguageMain extends AdminDetailsController
             //checking if added language already has created multilang fields
             //with new base ID - if not, creating new fields
             if ($blNewLanguage) {
-                if (!$this->checkMultilangFieldsExistsInDb($sOxId)) {
-                    $this->addNewMultilangFieldsToDb();
+                if (!$this->_checkMultilangFieldsExistsInDb($sOxId)) {
+                    $this->_addNewMultilangFieldsToDb();
                 } else {
                     $blViewError = true;
                 }
@@ -220,9 +220,13 @@ class LanguageMain extends AdminDetailsController
      * @param string $sOxId language abbreviation
      *
      * @return array
-     * @deprecated Use getLanguageInfo() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getLanguageInfo().
+     * @deprecated Transitional during #107. Modules SHOULD override _getLanguageInfo()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getLanguageInfo() to the canonical override
+      *             target and retires _getLanguageInfo(); until then, _getLanguageInfo() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getLanguageInfo($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -245,9 +249,10 @@ class LanguageMain extends AdminDetailsController
      *
      * @return array
      *
-     * @internal If your override does not fully replace the behavior, call parent::getLanguageInfo()
-     *           (not the deprecated _getLanguageInfo()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getLanguageInfo(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getLanguageInfo() the canonical override target.
      */
     protected function getLanguageInfo($sOxId)
     {
@@ -258,9 +263,13 @@ class LanguageMain extends AdminDetailsController
      * Languages array setter
      *
      * @param array $aLangData languages parameters array
-     * @deprecated Use setLanguages() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _setLanguages().
+     * @deprecated Transitional during #107. Modules SHOULD override _setLanguages()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes setLanguages() to the canonical override
+      *             target and retires _setLanguages(); until then, _setLanguages() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _setLanguages($aLangData) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -272,9 +281,10 @@ class LanguageMain extends AdminDetailsController
      *
      * @param array $aLangData languages parameters array
      *
-     * @internal If your override does not fully replace the behavior, call parent::setLanguages()
-     *           (not the deprecated _setLanguages()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _setLanguages(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make setLanguages() the canonical override target.
      */
     protected function setLanguages($aLangData)
     {
@@ -287,9 +297,13 @@ class LanguageMain extends AdminDetailsController
      * Returns collected languages parameters array.
      *
      * @return array
-     * @deprecated Use getLanguages() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getLanguages().
+     * @deprecated Transitional during #107. Modules SHOULD override _getLanguages()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getLanguages() to the canonical override
+      *             target and retires _getLanguages(); until then, _getLanguages() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getLanguages() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -300,7 +314,7 @@ class LanguageMain extends AdminDetailsController
 
         // empty languages parameters array - creating new one with default values
         if (!is_array($aLangData['params'])) {
-            $aLangData['params'] = $this->assignDefaultLangParams($aLangData['lang']);
+            $aLangData['params'] = $this->_assignDefaultLangParams($aLangData['lang']);
         }
 
         return $aLangData;
@@ -313,9 +327,10 @@ class LanguageMain extends AdminDetailsController
      *
      * @return array
      *
-     * @internal If your override does not fully replace the behavior, call parent::getLanguages()
-     *           (not the deprecated _getLanguages()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getLanguages(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getLanguages() the canonical override target.
      */
     protected function getLanguages()
     {
@@ -362,9 +377,13 @@ class LanguageMain extends AdminDetailsController
     /**
      * Sort languages, languages parameters, urls, ssl urls arrays according
      * base land ID
-     * @deprecated Use sortLangArraysByBaseId() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _sortLangArraysByBaseId().
+     * @deprecated Transitional during #107. Modules SHOULD override _sortLangArraysByBaseId()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes sortLangArraysByBaseId() to the canonical override
+      *             target and retires _sortLangArraysByBaseId(); until then, _sortLangArraysByBaseId() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _sortLangArraysByBaseId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -390,9 +409,10 @@ class LanguageMain extends AdminDetailsController
      * Sort languages, languages parameters, urls, ssl urls arrays according
      * base land ID
      *
-     * @internal If your override does not fully replace the behavior, call parent::sortLangArraysByBaseId()
-     *           (not the deprecated _sortLangArraysByBaseId()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _sortLangArraysByBaseId(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make sortLangArraysByBaseId() the canonical override target.
      */
     protected function sortLangArraysByBaseId()
     {
@@ -405,9 +425,13 @@ class LanguageMain extends AdminDetailsController
      * @param array $aLanguages language array
      *
      * @return array
-     * @deprecated Use assignDefaultLangParams() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _assignDefaultLangParams().
+     * @deprecated Transitional during #107. Modules SHOULD override _assignDefaultLangParams()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes assignDefaultLangParams() to the canonical override
+      *             target and retires _assignDefaultLangParams(); until then, _assignDefaultLangParams() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _assignDefaultLangParams($aLanguages) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -432,9 +456,10 @@ class LanguageMain extends AdminDetailsController
      *
      * @return array
      *
-     * @internal If your override does not fully replace the behavior, call parent::assignDefaultLangParams()
-     *           (not the deprecated _assignDefaultLangParams()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _assignDefaultLangParams(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make assignDefaultLangParams() the canonical override target.
      */
     protected function assignDefaultLangParams($aLanguages)
     {
@@ -445,9 +470,13 @@ class LanguageMain extends AdminDetailsController
      * Sets default language base ID to config var 'sDefaultLang'
      *
      * @param string $sOxId language abbreviation
-     * @deprecated Use setDefaultLang() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _setDefaultLang().
+     * @deprecated Transitional during #107. Modules SHOULD override _setDefaultLang()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes setDefaultLang() to the canonical override
+      *             target and retires _setDefaultLang(); until then, _setDefaultLang() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _setDefaultLang($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -460,9 +489,10 @@ class LanguageMain extends AdminDetailsController
      *
      * @param string $sOxId language abbreviation
      *
-     * @internal If your override does not fully replace the behavior, call parent::setDefaultLang()
-     *           (not the deprecated _setDefaultLang()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _setDefaultLang(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make setDefaultLang() the canonical override target.
      */
     protected function setDefaultLang($sOxId)
     {
@@ -473,9 +503,13 @@ class LanguageMain extends AdminDetailsController
      * Get available language base ID
      *
      * @return int
-     * @deprecated Use getAvailableLangBaseId() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getAvailableLangBaseId().
+     * @deprecated Transitional during #107. Modules SHOULD override _getAvailableLangBaseId()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getAvailableLangBaseId() to the canonical override
+      *             target and retires _getAvailableLangBaseId(); until then, _getAvailableLangBaseId() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getAvailableLangBaseId() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -504,9 +538,10 @@ class LanguageMain extends AdminDetailsController
      *
      * @return int
      *
-     * @internal If your override does not fully replace the behavior, call parent::getAvailableLangBaseId()
-     *           (not the deprecated _getAvailableLangBaseId()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getAvailableLangBaseId(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getAvailableLangBaseId() the canonical override target.
      */
     protected function getAvailableLangBaseId()
     {
@@ -518,9 +553,13 @@ class LanguageMain extends AdminDetailsController
      * If not - displays warning
      *
      * @param string $sOxId language abbreviation
-     * @deprecated Use checkLangTranslations() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _checkLangTranslations().
+     * @deprecated Transitional during #107. Modules SHOULD override _checkLangTranslations()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes checkLangTranslations() to the canonical override
+      *             target and retires _checkLangTranslations(); until then, _checkLangTranslations() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _checkLangTranslations($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -541,9 +580,10 @@ class LanguageMain extends AdminDetailsController
      *
      * @param string $sOxId language abbreviation
      *
-     * @internal If your override does not fully replace the behavior, call parent::checkLangTranslations()
-     *           (not the deprecated _checkLangTranslations()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _checkLangTranslations(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make checkLangTranslations() the canonical override target.
      */
     protected function checkLangTranslations($sOxId)
     {
@@ -556,9 +596,13 @@ class LanguageMain extends AdminDetailsController
      * @param string $sOxId language abbreviation
      *
      * @return bool
-     * @deprecated Use checkMultilangFieldsExistsInDb() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _checkMultilangFieldsExistsInDb().
+     * @deprecated Transitional during #107. Modules SHOULD override _checkMultilangFieldsExistsInDb()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes checkMultilangFieldsExistsInDb() to the canonical override
+      *             target and retires _checkMultilangFieldsExistsInDb(); until then, _checkMultilangFieldsExistsInDb() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _checkMultilangFieldsExistsInDb($sOxId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -578,9 +622,10 @@ class LanguageMain extends AdminDetailsController
      *
      * @return bool
      *
-     * @internal If your override does not fully replace the behavior, call parent::checkMultilangFieldsExistsInDb()
-     *           (not the deprecated _checkMultilangFieldsExistsInDb()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _checkMultilangFieldsExistsInDb(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make checkMultilangFieldsExistsInDb() the canonical override target.
      */
     protected function checkMultilangFieldsExistsInDb($sOxId)
     {
@@ -594,9 +639,13 @@ class LanguageMain extends AdminDetailsController
      * @return void
      * @throws DatabaseConnectionException
      * @throws DatabaseErrorException
-     * @deprecated Use addNewMultilangFieldsToDb() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _addNewMultilangFieldsToDb().
+     * @deprecated Transitional during #107. Modules SHOULD override _addNewMultilangFieldsToDb()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes addNewMultilangFieldsToDb() to the canonical override
+      *             target and retires _addNewMultilangFieldsToDb(); until then, _addNewMultilangFieldsToDb() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _addNewMultilangFieldsToDb() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -627,9 +676,10 @@ class LanguageMain extends AdminDetailsController
      * @throws DatabaseConnectionException
      * @throws DatabaseErrorException
      *
-     * @internal If your override does not fully replace the behavior, call parent::addNewMultilangFieldsToDb()
-     *           (not the deprecated _addNewMultilangFieldsToDb()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _addNewMultilangFieldsToDb(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make addNewMultilangFieldsToDb() the canonical override target.
      */
     protected function addNewMultilangFieldsToDb()
     {
@@ -642,9 +692,13 @@ class LanguageMain extends AdminDetailsController
      * @param string $sAbbr language abbreviation
      *
      * @return bool
-     * @deprecated Use checkLangExists() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _checkLangExists().
+     * @deprecated Transitional during #107. Modules SHOULD override _checkLangExists()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes checkLangExists() to the canonical override
+      *             target and retires _checkLangExists(); until then, _checkLangExists() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _checkLangExists($sAbbr) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -660,9 +714,10 @@ class LanguageMain extends AdminDetailsController
      *
      * @return bool
      *
-     * @internal If your override does not fully replace the behavior, call parent::checkLangExists()
-     *           (not the deprecated _checkLangExists()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _checkLangExists(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make checkLangExists() the canonical override target.
      */
     protected function checkLangExists($sAbbr)
     {
@@ -677,9 +732,13 @@ class LanguageMain extends AdminDetailsController
      * @param object $oLang2 language array
      *
      * @return int
-     * @deprecated Use sortLangParamsByBaseIdCallback() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _sortLangParamsByBaseIdCallback().
+     * @deprecated Transitional during #107. Modules SHOULD override _sortLangParamsByBaseIdCallback()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes sortLangParamsByBaseIdCallback() to the canonical override
+      *             target and retires _sortLangParamsByBaseIdCallback(); until then, _sortLangParamsByBaseIdCallback() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _sortLangParamsByBaseIdCallback($oLang1, $oLang2) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -695,9 +754,10 @@ class LanguageMain extends AdminDetailsController
      *
      * @return int
      *
-     * @internal If your override does not fully replace the behavior, call parent::sortLangParamsByBaseIdCallback()
-     *           (not the deprecated _sortLangParamsByBaseIdCallback()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _sortLangParamsByBaseIdCallback(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make sortLangParamsByBaseIdCallback() the canonical override target.
      */
     protected function sortLangParamsByBaseIdCallback($oLang1, $oLang2)
     {
@@ -709,9 +769,13 @@ class LanguageMain extends AdminDetailsController
      *
      * @return bool
      * @throws Exception
-     * @deprecated Use validateInput() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _validateInput().
+     * @deprecated Transitional during #107. Modules SHOULD override _validateInput()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes validateInput() to the canonical override
+      *             target and retires _validateInput(); until then, _validateInput() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _validateInput() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -722,7 +786,7 @@ class LanguageMain extends AdminDetailsController
 
         // if creating new language, checking if language already exists with
         // entered language abbreviation
-        if (($oxid == -1) && $this->checkLangExists($parameters['abbr'])) {
+        if (($oxid == -1) && $this->_checkLangExists($parameters['abbr'])) {
             $this->addDisplayException('LANGUAGE_ALREADYEXISTS_ERROR');
             $result = false;
         }
@@ -748,9 +812,10 @@ class LanguageMain extends AdminDetailsController
      * @return bool
      * @throws Exception
      *
-     * @internal If your override does not fully replace the behavior, call parent::validateInput()
-     *           (not the deprecated _validateInput()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _validateInput(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make validateInput() the canonical override target.
      */
     protected function validateInput()
     {
@@ -879,7 +944,7 @@ class LanguageMain extends AdminDetailsController
         $shopId = (int) $config->getShopId();
         $newBaseId = isset($this->_aLangData['params'][$sOxId]['baseId'])
             ? (int) $this->_aLangData['params'][$sOxId]['baseId']
-            : (int) $this->getAvailableLangBaseId();
+            : (int) $this->_getAvailableLangBaseId();
 
         $missing = $this->getRevocationTemplateValidator()->validate($shopId, $themeId, [$newBaseId]);
         if ($missing === []) {

--- a/source/Application/Controller/Admin/ListComponentAjax.php
+++ b/source/Application/Controller/Admin/ListComponentAjax.php
@@ -100,13 +100,17 @@ class ListComponentAjax extends Base
      * @param string $sId "table_name.col_name"
      *
      * @return array|null
-     * @deprecated Use getActionIds() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getActionIds().
+     * @deprecated Transitional during #107. Modules SHOULD override _getActionIds()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getActionIds() to the canonical override
+      *             target and retires _getActionIds(); until then, _getActionIds() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getActionIds($sId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $aColumns = $this->getColNames();
+        $aColumns = $this->_getColNames();
         foreach ($aColumns as $iPos => $aCol) {
             if (isset($aCol[4]) && $aCol[4] == 1 && $sId == $aCol[1] . '.' . $aCol[0]) {
                 return Registry::getRequest()->getRequestEscapedParameter('_' . $iPos);
@@ -123,9 +127,10 @@ class ListComponentAjax extends Base
      *
      * @return array|void
      *
-     * @internal If your override does not fully replace the behavior, call parent::getActionIds()
-     *           (not the deprecated _getActionIds()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getActionIds(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getActionIds() the canonical override target.
      */
     protected function getActionIds($sId)
     {
@@ -146,9 +151,13 @@ class ListComponentAjax extends Base
      * Empty function, developer should override this method according requirements
      *
      * @return string
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -160,9 +169,10 @@ class ListComponentAjax extends Base
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -175,13 +185,17 @@ class ListComponentAjax extends Base
      * @param string $sQ part of initial query
      *
      * @return string
-     * @deprecated Use getDataQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getDataQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getDataQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getDataQuery() to the canonical override
+      *             target and retires _getDataQuery(); until then, _getDataQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getDataQuery($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return 'select ' . $this->getQueryCols() . $sQ;
+        return 'select ' . $this->_getQueryCols() . $sQ;
     }
 
     /**
@@ -191,9 +205,10 @@ class ListComponentAjax extends Base
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getDataQuery()
-     *           (not the deprecated _getDataQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getDataQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getDataQuery() the canonical override target.
      */
     protected function getDataQuery($sQ)
     {
@@ -206,9 +221,13 @@ class ListComponentAjax extends Base
      * @param string $sQ part of initial query
      *
      * @return string
-     * @deprecated Use getCountQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getCountQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getCountQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getCountQuery() to the canonical override
+      *             target and retires _getCountQuery(); until then, _getCountQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getCountQuery($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -222,9 +241,10 @@ class ListComponentAjax extends Base
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getCountQuery()
-     *           (not the deprecated _getCountQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getCountQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getCountQuery() the canonical override target.
      */
     protected function getCountQuery($sQ)
     {
@@ -257,10 +277,10 @@ class ListComponentAjax extends Base
             $sQAdd = $this->_getQuery();
 
             // formatting SQL queries
-            $sQ = $this->getDataQuery($sQAdd);
-            $sCountQ = $this->getCountQuery($sQAdd);
+            $sQ = $this->_getDataQuery($sQAdd);
+            $sCountQ = $this->_getCountQuery($sQAdd);
 
-            $this->outputResponse($this->getData($sCountQ, $sQ));
+            $this->_outputResponse($this->getData($sCountQ, $sQ));
         }
     }
 
@@ -268,13 +288,17 @@ class ListComponentAjax extends Base
      * Returns column id to sort
      *
      * @return int
-     * @deprecated Use getSortCol() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getSortCol().
+     * @deprecated Transitional during #107. Modules SHOULD override _getSortCol()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getSortCol() to the canonical override
+      *             target and retires _getSortCol(); until then, _getSortCol() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getSortCol() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $aVisibleNames = $this->getVisibleColNames();
+        $aVisibleNames = $this->_getVisibleColNames();
         $iCol = Registry::getRequest()->getRequestEscapedParameter('sort');
         $iCol = $iCol ? ((int) str_replace('_', '', $iCol)) : 0;
         $iCol = (!isset($aVisibleNames[$iCol])) ? 0 : $iCol;
@@ -287,9 +311,10 @@ class ListComponentAjax extends Base
      *
      * @return int
      *
-     * @internal If your override does not fully replace the behavior, call parent::getSortCol()
-     *           (not the deprecated _getSortCol()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getSortCol(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getSortCol() the canonical override target.
      */
     protected function getSortCol()
     {
@@ -303,9 +328,13 @@ class ListComponentAjax extends Base
      * @param string $sId container id (optional)
      *
      * @return array
-     * @deprecated Use getColNames() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getColNames().
+     * @deprecated Transitional during #107. Modules SHOULD override _getColNames()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getColNames() to the canonical override
+      *             target and retires _getColNames(); until then, _getColNames() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getColNames($sId = null) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -328,9 +357,10 @@ class ListComponentAjax extends Base
      *
      * @return array
      *
-     * @internal If your override does not fully replace the behavior, call parent::getColNames()
-     *           (not the deprecated _getColNames()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getColNames(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getColNames() the canonical override target.
      */
     protected function getColNames($sId = null)
     {
@@ -342,13 +372,17 @@ class ListComponentAjax extends Base
      * in AJAX and further in this processor class
      *
      * @return array
-     * @deprecated Use getIdentColNames() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getIdentColNames().
+     * @deprecated Transitional during #107. Modules SHOULD override _getIdentColNames()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getIdentColNames() to the canonical override
+      *             target and retires _getIdentColNames(); until then, _getIdentColNames() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getIdentColNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $aColNames = $this->getColNames();
+        $aColNames = $this->_getColNames();
         $aCols = [];
         foreach ($aColNames as $iKey => $aCol) {
             // ident ?
@@ -366,9 +400,10 @@ class ListComponentAjax extends Base
      *
      * @return array
      *
-     * @internal If your override does not fully replace the behavior, call parent::getIdentColNames()
-     *           (not the deprecated _getIdentColNames()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getIdentColNames(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getIdentColNames() the canonical override target.
      */
     protected function getIdentColNames()
     {
@@ -379,13 +414,17 @@ class ListComponentAjax extends Base
      * Returns array of col names which are requested by AJAX call and will be fetched from DB
      *
      * @return array
-     * @deprecated Use getVisibleColNames() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getVisibleColNames().
+     * @deprecated Transitional during #107. Modules SHOULD override _getVisibleColNames()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getVisibleColNames() to the canonical override
+      *             target and retires _getVisibleColNames(); until then, _getVisibleColNames() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getVisibleColNames() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $aColNames = $this->getColNames();
+        $aColNames = $this->_getColNames();
         $aUserCols = Registry::getRequest()->getRequestEscapedParameter('aCols');
         $aVisibleCols = [];
 
@@ -417,9 +456,10 @@ class ListComponentAjax extends Base
      *
      * @return array
      *
-     * @internal If your override does not fully replace the behavior, call parent::getVisibleColNames()
-     *           (not the deprecated _getVisibleColNames()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getVisibleColNames(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getVisibleColNames() the canonical override target.
      */
     protected function getVisibleColNames()
     {
@@ -431,14 +471,18 @@ class ListComponentAjax extends Base
      * fields to load from DB
      *
      * @return string
-     * @deprecated Use getQueryCols() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQueryCols().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQueryCols()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQueryCols() to the canonical override
+      *             target and retires _getQueryCols(); until then, _getQueryCols() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQueryCols() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $sQ = $this->buildColsQuery($this->getVisibleColNames(), false) . ', ';
-        $sQ .= $this->buildColsQuery($this->getIdentColNames());
+        $sQ = $this->_buildColsQuery($this->_getVisibleColNames(), false) . ', ';
+        $sQ .= $this->_buildColsQuery($this->_getIdentColNames());
 
         return " $sQ ";
     }
@@ -449,9 +493,10 @@ class ListComponentAjax extends Base
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQueryCols()
-     *           (not the deprecated _getQueryCols()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQueryCols(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQueryCols() the canonical override target.
      */
     protected function getQueryCols()
     {
@@ -465,9 +510,13 @@ class ListComponentAjax extends Base
      * @param bool  $blIdentCols if true, means ident columns part is build
      *
      * @return string
-     * @deprecated Use buildColsQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _buildColsQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _buildColsQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes buildColsQuery() to the canonical override
+      *             target and retires _buildColsQuery(); until then, _buildColsQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _buildColsQuery($aIdentCols, $blIdentCols = true) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -478,8 +527,8 @@ class ListComponentAjax extends Base
             }
 
             $sViewTable = $this->getViewName($aCol[1]);
-            if (!$blIdentCols && $this->isExtendedColumn($aCol[0])) {
-                $sQ .= $this->getExtendedColQuery($sViewTable, $aCol[0], $iCnt);
+            if (!$blIdentCols && $this->_isExtendedColumn($aCol[0])) {
+                $sQ .= $this->_getExtendedColQuery($sViewTable, $aCol[0], $iCnt);
             } else {
                 $sQ .= $sViewTable . '.' . $aCol[0] . ' as _' . $iCnt;
             }
@@ -496,9 +545,10 @@ class ListComponentAjax extends Base
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::buildColsQuery()
-     *           (not the deprecated _buildColsQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _buildColsQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make buildColsQuery() the canonical override target.
      */
     protected function buildColsQuery($aIdentCols, $blIdentCols = true)
     {
@@ -512,9 +562,13 @@ class ListComponentAjax extends Base
      * @param string $sColumn column name
      *
      * @return bool
-     * @deprecated Use isExtendedColumn() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _isExtendedColumn().
+     * @deprecated Transitional during #107. Modules SHOULD override _isExtendedColumn()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes isExtendedColumn() to the canonical override
+      *             target and retires _isExtendedColumn(); until then, _isExtendedColumn() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _isExtendedColumn($sColumn) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -531,9 +585,10 @@ class ListComponentAjax extends Base
      *
      * @return bool
      *
-     * @internal If your override does not fully replace the behavior, call parent::isExtendedColumn()
-     *           (not the deprecated _isExtendedColumn()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _isExtendedColumn(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make isExtendedColumn() the canonical override target.
      */
     protected function isExtendedColumn($sColumn)
     {
@@ -549,9 +604,13 @@ class ListComponentAjax extends Base
      * @param int    $iCnt       column count
      *
      * @return string
-     * @deprecated Use getExtendedColQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getExtendedColQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getExtendedColQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getExtendedColQuery() to the canonical override
+      *             target and retires _getExtendedColQuery(); until then, _getExtendedColQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getExtendedColQuery($sViewTable, $sColumn, $iCnt) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -573,9 +632,10 @@ class ListComponentAjax extends Base
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getExtendedColQuery()
-     *           (not the deprecated _getExtendedColQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getExtendedColQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getExtendedColQuery() the canonical override target.
      */
     protected function getExtendedColQuery($sViewTable, $sColumn, $iCnt)
     {
@@ -586,13 +646,17 @@ class ListComponentAjax extends Base
      * Formats and returns part of SQL query for sorting
      *
      * @return string
-     * @deprecated Use getSorting() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getSorting().
+     * @deprecated Transitional during #107. Modules SHOULD override _getSorting()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getSorting() to the canonical override
+      *             target and retires _getSorting(); until then, _getSorting() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getSorting() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return ' order by _' . $this->getSortCol() . ' ' . $this->getSortDir() . ' ';
+        return ' order by _' . $this->_getSortCol() . ' ' . $this->getSortDir() . ' ';
     }
 
     /**
@@ -600,9 +664,10 @@ class ListComponentAjax extends Base
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getSorting()
-     *           (not the deprecated _getSorting()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getSorting(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getSorting() the canonical override target.
      */
     protected function getSorting()
     {
@@ -615,9 +680,13 @@ class ListComponentAjax extends Base
      * @param int $iStart start position
      *
      * @return string
-     * @deprecated Use getLimit() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getLimit().
+     * @deprecated Transitional during #107. Modules SHOULD override _getLimit()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getLimit() to the canonical override
+      *             target and retires _getLimit(); until then, _getLimit() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getLimit($iStart) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -634,9 +703,10 @@ class ListComponentAjax extends Base
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getLimit()
-     *           (not the deprecated _getLimit()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getLimit(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getLimit() the canonical override target.
      */
     protected function getLimit($iStart)
     {
@@ -648,16 +718,20 @@ class ListComponentAjax extends Base
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getFilter() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getFilter().
+     * @deprecated Transitional during #107. Modules SHOULD override _getFilter()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getFilter() to the canonical override
+      *             target and retires _getFilter(); until then, _getFilter() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getFilter() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sQ = '';
         $aFilter = Registry::getRequest()->getRequestEscapedParameter('aFilter');
         if (is_array($aFilter) && count($aFilter)) {
-            $aCols = $this->getVisibleColNames();
+            $aCols = $this->_getVisibleColNames();
             $oDb = DatabaseProvider::getDb();
             $oStr = Str::getStr();
 
@@ -694,9 +768,10 @@ class ListComponentAjax extends Base
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getFilter()
-     *           (not the deprecated _getFilter()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getFilter(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getFilter() the canonical override target.
      */
     protected function getFilter()
     {
@@ -710,9 +785,13 @@ class ListComponentAjax extends Base
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use addFilter() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _addFilter().
+     * @deprecated Transitional during #107. Modules SHOULD override _addFilter()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes addFilter() to the canonical override
+      *             target and retires _addFilter(); until then, _addFilter() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -731,9 +810,10 @@ class ListComponentAjax extends Base
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::addFilter()
-     *           (not the deprecated _addFilter()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _addFilter(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make addFilter() the canonical override target.
      */
     protected function addFilter($sQ)
     {
@@ -748,9 +828,13 @@ class ListComponentAjax extends Base
      * @return array
      * @throws DatabaseConnectionException
      * @throws DatabaseErrorException
-     * @deprecated Use getAll() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getAll().
+     * @deprecated Transitional during #107. Modules SHOULD override _getAll()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getAll() to the canonical override
+      *             target and retires _getAll(); until then, _getAll() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getAll($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -775,9 +859,10 @@ class ListComponentAjax extends Base
      * @throws DatabaseConnectionException
      * @throws DatabaseErrorException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getAll()
-     *           (not the deprecated _getAll()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getAll(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getAll() the canonical override target.
      */
     protected function getAll($sQ)
     {
@@ -890,9 +975,10 @@ class ListComponentAjax extends Base
      * @throws DatabaseConnectionException
      * @throws DatabaseErrorException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getDataFields()
-     *           (not the deprecated _getDataFields()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getDataFields(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getDataFields() the canonical override target.
      */
     protected function getDataFields($sQ)
     {
@@ -917,7 +1003,7 @@ class ListComponentAjax extends Base
      */
     protected function outputResponse($aData)
     {
-        $this->output(json_encode($aData));
+        $this->_output(json_encode($aData));
     }
 
     /**
@@ -994,11 +1080,11 @@ class ListComponentAjax extends Base
      */
     protected function getData($sCountQ, $sQ)
     {
-        $sQ = $this->addFilter($sQ);
-        $sCountQ = $this->addFilter($sCountQ);
+        $sQ = $this->_addFilter($sQ);
+        $sCountQ = $this->_addFilter($sCountQ);
 
         $aResponse['startIndex'] = $iStart = $this->getStartIndex();
-        $aResponse['sort'] = '_' . $this->getSortCol();
+        $aResponse['sort'] = '_' . $this->_getSortCol();
         $aResponse['dir'] = $this->getSortDir();
 
         $iDebug = Registry::getConfig()->getConfigParam('iDebug');
@@ -1010,14 +1096,14 @@ class ListComponentAjax extends Base
 
         // skip further execution if no records were found ...
         if (($iTotal = $this->getTotalCount($sCountQ))) {
-            $sQ .= $this->getSorting();
-            $sQ .= $this->getLimit($iStart);
+            $sQ .= $this->_getSorting();
+            $sQ .= $this->_getLimit($iStart);
 
             if ($iDebug) {
                 $aResponse['datasql'] = $sQ;
             }
 
-            $aResponse['records'] = $this->getDataFields($sQ);
+            $aResponse['records'] = $this->_getDataFields($sQ);
         }
 
         $aResponse['totalRecords'] = $iTotal;
@@ -1058,7 +1144,7 @@ class ListComponentAjax extends Base
         $blDeleteCacheOnLogout = Registry::getConfig()->getConfigParam('blClearCacheOnLogout');
 
         if (!$blDeleteCacheOnLogout) {
-            $this->resetCaches();
+            $this->_resetCaches();
 
             Registry::getUtils()->oxResetFileCache();
         }
@@ -1092,7 +1178,7 @@ class ListComponentAjax extends Base
                     break;
             }
 
-            $this->resetContentCache();
+            $this->_resetContentCache();
         }
     }
 

--- a/source/Application/Controller/Admin/ListUser.php
+++ b/source/Application/Controller/Admin/ListUser.php
@@ -48,7 +48,7 @@ class ListUser extends UserList
      */
     protected function _getViewListSize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        return $this->getUserDefListSize();
+        return $this->_getUserDefListSize();
     }
 
     /**

--- a/source/Application/Controller/Admin/LoginController.php
+++ b/source/Application/Controller/Admin/LoginController.php
@@ -82,7 +82,7 @@ class LoginController extends AdminController
         //#533 user profile
         $this->addTplParam('profiles', Registry::getUtils()->loadAdminProfile($myConfig->getConfigParam('aInterfaceProfiles')));
 
-        $aLanguages = $this->getAvailableLanguages();
+        $aLanguages = $this->_getAvailableLanguages();
         $this->addTplParam('aLanguages', $aLanguages);
 
         // setting templates language to selected language id
@@ -192,9 +192,13 @@ class LoginController extends AdminController
      * Rewrites authorization method.
      *
      * @return boolean
-     * @deprecated Use authorize() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _authorize().
+     * @deprecated Transitional during #107. Modules SHOULD override _authorize()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes authorize() to the canonical override
+      *             target and retires _authorize(); until then, _authorize() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _authorize() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -207,9 +211,10 @@ class LoginController extends AdminController
      *
      * @return boolean
      *
-     * @internal If your override does not fully replace the behavior, call parent::authorize()
-     *           (not the deprecated _authorize()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _authorize(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make authorize() the canonical override target.
      */
     protected function authorize()
     {
@@ -230,14 +235,18 @@ class LoginController extends AdminController
      * Get available admin interface languages
      *
      * @return array
-     * @deprecated Use getAvailableLanguages() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getAvailableLanguages().
+     * @deprecated Transitional during #107. Modules SHOULD override _getAvailableLanguages()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getAvailableLanguages() to the canonical override
+      *             target and retires _getAvailableLanguages(); until then, _getAvailableLanguages() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getAvailableLanguages() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
         $sDefLang = Registry::getUtilsServer()->getOxCookie('oxidadminlanguage');
-        $sDefLang = $sDefLang ? $sDefLang : $this->getBrowserLanguage();
+        $sDefLang = $sDefLang ? $sDefLang : $this->_getBrowserLanguage();
 
         $aLanguages = Registry::getLang()->getAdminTplLanguageArray();
         foreach ($aLanguages as $oLang) {
@@ -252,9 +261,10 @@ class LoginController extends AdminController
      *
      * @return array
      *
-     * @internal If your override does not fully replace the behavior, call parent::getAvailableLanguages()
-     *           (not the deprecated _getAvailableLanguages()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getAvailableLanguages(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getAvailableLanguages() the canonical override target.
      */
     protected function getAvailableLanguages()
     {
@@ -265,9 +275,13 @@ class LoginController extends AdminController
      * Get detected user browser language abbreviation
      *
      * @return string
-     * @deprecated Use getBrowserLanguage() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getBrowserLanguage().
+     * @deprecated Transitional during #107. Modules SHOULD override _getBrowserLanguage()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getBrowserLanguage() to the canonical override
+      *             target and retires _getBrowserLanguage(); until then, _getBrowserLanguage() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getBrowserLanguage() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -279,9 +293,10 @@ class LoginController extends AdminController
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getBrowserLanguage()
-     *           (not the deprecated _getBrowserLanguage()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getBrowserLanguage(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getBrowserLanguage() the canonical override target.
      */
     protected function getBrowserLanguage()
     {

--- a/source/Application/Controller/Admin/ManufacturerMain.php
+++ b/source/Application/Controller/Admin/ManufacturerMain.php
@@ -56,7 +56,7 @@ class ManufacturerMain extends AdminDetailsController
             $this->_aViewData['edit'] = $oManufacturer;
 
             // category tree
-            $this->createCategoryTree('artcattree');
+            $this->_createCategoryTree('artcattree');
 
             //Disable editing for derived articles
             if ($oManufacturer->isDerived()) {

--- a/source/Application/Controller/Admin/ManufacturerMainAjax.php
+++ b/source/Application/Controller/Admin/ManufacturerMainAjax.php
@@ -70,9 +70,13 @@ class ManufacturerMainAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -112,9 +116,10 @@ class ManufacturerMainAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -128,9 +133,13 @@ class ManufacturerMainAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use addFilter() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _addFilter().
+     * @deprecated Transitional during #107. Modules SHOULD override _addFilter()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes addFilter() to the canonical override
+      *             target and retires _addFilter(); until then, _addFilter() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _addFilter($sQ) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -152,9 +161,10 @@ class ManufacturerMainAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::addFilter()
-     *           (not the deprecated _addFilter()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _addFilter(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make addFilter() the canonical override target.
      */
     protected function addFilter($sQ)
     {
@@ -166,12 +176,12 @@ class ManufacturerMainAjax extends ListComponentAjax
      */
     public function removeManufacturer()
     {
-        $articleIds = $this->getActionIds('oxarticles.oxid');
+        $articleIds = $this->_getActionIds('oxarticles.oxid');
         $manufacturerId = Registry::getRequest()->getRequestEscapedParameter('oxid');
 
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $articleViewTable = $this->getViewName('oxarticles');
-            $articleIds = $this->getAll($this->addFilter("select $articleViewTable.oxid " . $this->getQuery()));
+            $articleIds = $this->_getAll($this->_addFilter("select $articleViewTable.oxid " . $this->getQuery()));
         }
 
         if (is_array($articleIds) && !empty($articleIds)) {
@@ -205,12 +215,12 @@ class ManufacturerMainAjax extends ListComponentAjax
     {
         $oRequest = Registry::getRequest();
 
-        $articleIds = $this->getActionIds('oxarticles.oxid');
+        $articleIds = $this->_getActionIds('oxarticles.oxid');
         $manufacturerId = $oRequest->getRequestEscapedParameter('synchoxid');
 
         if ($oRequest->getRequestEscapedParameter('all')) {
             $articleViewName = $this->getViewName('oxarticles');
-            $articleIds = $this->getAll($this->addFilter("select $articleViewName.oxid " . $this->getQuery()));
+            $articleIds = $this->_getAll($this->_addFilter("select $articleViewName.oxid " . $this->getQuery()));
         }
 
         if ($manufacturerId && $manufacturerId != '-1' && is_array($articleIds)) {

--- a/source/Application/Controller/Admin/ManufacturerSeo.php
+++ b/source/Application/Controller/Admin/ManufacturerSeo.php
@@ -58,9 +58,13 @@ class ManufacturerSeo extends ObjectSeo
      * Returns current object type seo encoder object
      *
      * @return SeoEncoderManufacturer
-     * @deprecated Use getEncoder() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getEncoder().
+     * @deprecated Transitional during #107. Modules SHOULD override _getEncoder()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getEncoder() to the canonical override
+      *             target and retires _getEncoder(); until then, _getEncoder() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getEncoder() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -72,9 +76,10 @@ class ManufacturerSeo extends ObjectSeo
      *
      * @return SeoEncoderManufacturer
      *
-     * @internal If your override does not fully replace the behavior, call parent::getEncoder()
-     *           (not the deprecated _getEncoder()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getEncoder(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getEncoder() the canonical override target.
      */
     protected function getEncoder()
     {
@@ -95,9 +100,13 @@ class ManufacturerSeo extends ObjectSeo
      * Returns url type
      *
      * @return string
-     * @deprecated Use getType() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getType().
+     * @deprecated Transitional during #107. Modules SHOULD override _getType()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getType() to the canonical override
+      *             target and retires _getType(); until then, _getType() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -109,9 +118,10 @@ class ManufacturerSeo extends ObjectSeo
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getType()
-     *           (not the deprecated _getType()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getType(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getType() the canonical override target.
      */
     protected function getType()
     {

--- a/source/Application/Controller/Admin/ModuleConfiguration.php
+++ b/source/Application/Controller/Admin/ModuleConfiguration.php
@@ -133,7 +133,7 @@ class ModuleConfiguration extends ShopConfiguration
         $aVarConstraints = [];
         $aGrouping = [];
 
-        $aDbVariables = $this->loadConfVars($oConfig->getShopId(), $this->getModuleForConfigVars());
+        $aDbVariables = $this->loadConfVars($oConfig->getShopId(), $this->_getModuleForConfigVars());
 
         if (is_array($aModuleSettings)) {
             foreach ($aModuleSettings as $aValue) {
@@ -143,10 +143,10 @@ class ModuleConfiguration extends ShopConfiguration
                 if (is_null($oConfig->getConfigParam($sName))) {
                     switch ($aValue['type']) {
                         case 'arr':
-                            $sValue = $this->arrayToMultiline($aValue['value']);
+                            $sValue = $this->_arrayToMultiline($aValue['value']);
                             break;
                         case 'aarr':
-                            $sValue = $this->aarrayToMultiline($aValue['value']);
+                            $sValue = $this->_aarrayToMultiline($aValue['value']);
                             break;
                         case 'bool':
                             $sValue = filter_var($aValue['value'], FILTER_VALIDATE_BOOLEAN);
@@ -248,10 +248,10 @@ class ModuleConfiguration extends ShopConfiguration
                 foreach ($moduleConfiguration->getModuleSettings() as $moduleSetting) {
                     if ($moduleSetting->getName() === $name) {
                         if ($moduleSetting->getType() === 'aarr') {
-                            $value = $this->multilineToAarray($value);
+                            $value = $this->_multilineToAarray($value);
                         }
                         if ($moduleSetting->getType() === 'arr') {
-                            $value = $this->multilineToArray($value);
+                            $value = $this->_multilineToArray($value);
                         }
                         if ($moduleSetting->getType() === 'bool') {
                             $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
@@ -310,10 +310,10 @@ class ModuleConfiguration extends ShopConfiguration
             if ($setting->getValue() !== null) {
                 switch ($setting->getType()) {
                     case 'arr':
-                        $value = $this->arrayToMultiline($setting->getValue());
+                        $value = $this->_arrayToMultiline($setting->getValue());
                         break;
                     case 'aarr':
-                        $value = $this->aarrayToMultiline($setting->getValue());
+                        $value = $this->_aarrayToMultiline($setting->getValue());
                         break;
                     case 'bool':
                         $value = filter_var($setting->getValue(), FILTER_VALIDATE_BOOLEAN);

--- a/source/Application/Controller/Admin/NavigationController.php
+++ b/source/Application/Controller/Admin/NavigationController.php
@@ -66,7 +66,7 @@ class NavigationController extends AdminController
             if (!Registry::getRequest()->getRequestEscapedParameter('navReload')) {
                 // #661 execute stuff we run each time when we start admin once
                 if ('home.tpl' == $sItem) {
-                    $this->_aViewData['aMessage'] = $this->doStartUpChecks();
+                    $this->_aViewData['aMessage'] = $this->_doStartUpChecks();
                 }
             } else {
                 //removing reload param to force requirements checking next time
@@ -146,9 +146,13 @@ class NavigationController extends AdminController
      *
      * @return array
      * @throws Exception
-     * @deprecated Use doStartUpChecks() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _doStartUpChecks().
+     * @deprecated Transitional during #107. Modules SHOULD override _doStartUpChecks()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes doStartUpChecks() to the canonical override
+      *             target and retires _doStartUpChecks(); until then, _doStartUpChecks() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _doStartUpChecks() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -202,9 +206,10 @@ class NavigationController extends AdminController
      * @return array
      * @throws Exception
      *
-     * @internal If your override does not fully replace the behavior, call parent::doStartUpChecks()
-     *           (not the deprecated _doStartUpChecks()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _doStartUpChecks(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make doStartUpChecks() the canonical override target.
      */
     protected function doStartUpChecks()
     {
@@ -216,9 +221,13 @@ class NavigationController extends AdminController
      *
      * @return string
      * @throws Exception
-     * @deprecated Use checkVersion() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _checkVersion().
+     * @deprecated Transitional during #107. Modules SHOULD override _checkVersion()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes checkVersion() to the canonical override
+      *             target and retires _checkVersion(); until then, _checkVersion() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _checkVersion() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -240,9 +249,10 @@ class NavigationController extends AdminController
      * @return string|void
      * @throws Exception
      *
-     * @internal If your override does not fully replace the behavior, call parent::checkVersion()
-     *           (not the deprecated _checkVersion()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _checkVersion(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make checkVersion() the canonical override target.
      */
     protected function checkVersion()
     {

--- a/source/Application/Controller/Admin/NavigationTree.php
+++ b/source/Application/Controller/Admin/NavigationTree.php
@@ -69,9 +69,13 @@ class NavigationTree extends Base
      * @param DOMDocument $dom         dom object
      * @param string $parentXPath parent xpath
      * @param string $childXPath  child xpath from parent
-     * @deprecated Use cleanEmptyParents() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _cleanEmptyParents().
+     * @deprecated Transitional during #107. Modules SHOULD override _cleanEmptyParents()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes cleanEmptyParents() to the canonical override
+      *             target and retires _cleanEmptyParents(); until then, _cleanEmptyParents() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _cleanEmptyParents($dom, $parentXPath, $childXPath) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -94,9 +98,10 @@ class NavigationTree extends Base
      * @param string $parentXPath parent xpath
      * @param string $childXPath  child xpath from parent
      *
-     * @internal If your override does not fully replace the behavior, call parent::cleanEmptyParents()
-     *           (not the deprecated _cleanEmptyParents()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _cleanEmptyParents(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make cleanEmptyParents() the canonical override target.
      */
     protected function cleanEmptyParents($dom, $parentXPath, $childXPath)
     {
@@ -184,7 +189,7 @@ class NavigationTree extends Base
         }
 
         if ($merge) {
-            $this->merge($domFile, $dom);
+            $this->_merge($domFile, $dom);
         }
     }
 
@@ -493,10 +498,10 @@ class NavigationTree extends Base
                     $curNode = $curNode->item(0);
 
                     // if found copy all attributes and check child-nodes
-                    $this->copyAttributes($curNode, $fromNode);
+                    $this->_copyAttributes($curNode, $fromNode);
 
                     if ($fromNode->childNodes->length) {
-                        $this->mergeNodes($curNode, $fromNode, $xPathTo, $domDocTo, $query);
+                        $this->_mergeNodes($curNode, $fromNode, $xPathTo, $domDocTo, $query);
                     }
                 }
             }
@@ -524,7 +529,7 @@ class NavigationTree extends Base
     protected function merge($domNew, $dom)
     {
         $xPath = new DOMXPath($dom);
-        $this->mergeNodes($dom->documentElement, $domNew->documentElement, $xPath, $dom, '/OX');
+        $this->_mergeNodes($dom->documentElement, $domNew->documentElement, $xPath, $dom, '/OX');
     }
 
     /**
@@ -741,11 +746,11 @@ class NavigationTree extends Base
                     $this->_oInitialDom->appendChild(new DOMElement('OX'));
 
                     foreach ($filesToLoad as $dynPath) {
-                        $this->loadFromFile($dynPath, $this->_oInitialDom);
+                        $this->_loadFromFile($dynPath, $this->_oInitialDom);
                     }
 
                     // adds links to menu items
-                    $this->addLinks($this->_oInitialDom);
+                    $this->_addLinks($this->_oInitialDom);
 
                     // @deprecated since v5.3 (2016-05-20); Dynpages will be removed.
                     // adds links to dynamic parts
@@ -762,7 +767,7 @@ class NavigationTree extends Base
                 }
 
                 // add session params
-                $this->sessionizeLocalUrls($this->_oInitialDom);
+                $this->_sessionizeLocalUrls($this->_oInitialDom);
             }
         }
 
@@ -780,19 +785,19 @@ class NavigationTree extends Base
             $this->_oDom = clone $this->getInitialDom();
 
             // removes items denied by user group
-            $this->checkGroups($this->_oDom);
+            $this->_checkGroups($this->_oDom);
 
             // removes items denied by user rights
-            $this->checkRights($this->_oDom);
+            $this->_checkRights($this->_oDom);
 
             // removes items marked as not visible
             $this->removeInvisibleMenuNodes($this->_oDom);
 
             // check config params
-            $this->checkDemoShopDenials($this->_oDom);
+            $this->_checkDemoShopDenials($this->_oDom);
             $this->onGettingDomXml();
-            $this->cleanEmptyParents($this->_oDom, '//SUBMENU[@id][@list]', 'TAB');
-            $this->cleanEmptyParents($this->_oDom, '//MAINMENU[@id]', 'SUBMENU');
+            $this->_cleanEmptyParents($this->_oDom, '//SUBMENU[@id][@list]', 'TAB');
+            $this->_cleanEmptyParents($this->_oDom, '//MAINMENU[@id]', 'SUBMENU');
         }
 
         return $this->_oDom;

--- a/source/Application/Controller/Admin/NewsMainAjax.php
+++ b/source/Application/Controller/Admin/NewsMainAjax.php
@@ -58,9 +58,13 @@ class NewsMainAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -92,9 +96,10 @@ class NewsMainAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -106,9 +111,9 @@ class NewsMainAjax extends ListComponentAjax
      */
     public function removeGroupFromNews()
     {
-        $aRemoveGroups = $this->getActionIds('oxobject2group.oxid');
+        $aRemoveGroups = $this->_getActionIds('oxobject2group.oxid');
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $sQ = $this->addFilter('delete oxobject2group.* ' . $this->getQuery());
+            $sQ = $this->_addFilter('delete oxobject2group.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
             $sQ = 'delete from oxobject2group where oxobject2group.oxid in (' . implode(', ', DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ') ';
@@ -121,12 +126,12 @@ class NewsMainAjax extends ListComponentAjax
      */
     public function addGroupToNews()
     {
-        $aAddGroups = $this->getActionIds('oxgroups.oxid');
+        $aAddGroups = $this->_getActionIds('oxgroups.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sGroupTable = $this->getViewName('oxgroups');
-            $aAddGroups = $this->getAll($this->addFilter("select $sGroupTable.oxid " . $this->getQuery()));
+            $aAddGroups = $this->_getAll($this->_addFilter("select $sGroupTable.oxid " . $this->getQuery()));
         }
 
         if ($soxId && $soxId != '-1' && is_array($aAddGroups)) {

--- a/source/Application/Controller/Admin/NewsText.php
+++ b/source/Application/Controller/Admin/NewsText.php
@@ -70,7 +70,7 @@ class NewsText extends AdminDetailsController
 
             $this->_aViewData['edit'] = $oNews;
         }
-        $this->_aViewData['editor'] = $this->generateTextEditor('100%', 255, $oNews, 'oxnews__oxlongdesc', 'news.tpl.css');
+        $this->_aViewData['editor'] = $this->_generateTextEditor('100%', 255, $oNews, 'oxnews__oxlongdesc', 'news.tpl.css');
 
         return 'news_text.tpl';
     }

--- a/source/Application/Controller/Admin/NewsletterMain.php
+++ b/source/Application/Controller/Admin/NewsletterMain.php
@@ -54,7 +54,7 @@ class NewsletterMain extends AdminDetailsController
         }
 
         // generate editor
-        $this->_aViewData['editor'] = $this->generateTextEditor(
+        $this->_aViewData['editor'] = $this->_generateTextEditor(
             '100%',
             255,
             $oNewsletter,

--- a/source/Application/Controller/Admin/NewsletterSelectionAjax.php
+++ b/source/Application/Controller/Admin/NewsletterSelectionAjax.php
@@ -56,9 +56,13 @@ class NewsletterSelectionAjax extends ListComponentAjax
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getQuery() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getQuery().
+     * @deprecated Transitional during #107. Modules SHOULD override _getQuery()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getQuery() to the canonical override
+      *             target and retires _getQuery(); until then, _getQuery() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getQuery() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -92,9 +96,10 @@ class NewsletterSelectionAjax extends ListComponentAjax
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getQuery()
-     *           (not the deprecated _getQuery()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getQuery(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getQuery() the canonical override target.
      */
     protected function getQuery()
     {
@@ -106,9 +111,9 @@ class NewsletterSelectionAjax extends ListComponentAjax
      */
     public function removeGroupFromNewsletter()
     {
-        $aRemoveGroups = $this->getActionIds('oxobject2group.oxid');
+        $aRemoveGroups = $this->_getActionIds('oxobject2group.oxid');
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
-            $sQ = $this->addFilter('delete oxobject2group.* ' . $this->getQuery());
+            $sQ = $this->_addFilter('delete oxobject2group.* ' . $this->getQuery());
             DatabaseProvider::getDb()->Execute($sQ);
         } elseif ($aRemoveGroups && is_array($aRemoveGroups)) {
             $sQ = 'delete from oxobject2group where oxobject2group.oxid in (' . implode(', ', DatabaseProvider::getDb()->quoteArray($aRemoveGroups)) . ') ';
@@ -121,12 +126,12 @@ class NewsletterSelectionAjax extends ListComponentAjax
      */
     public function addGroupToNewsletter()
     {
-        $aAddGroups = $this->getActionIds('oxgroups.oxid');
+        $aAddGroups = $this->_getActionIds('oxgroups.oxid');
         $soxId = Registry::getRequest()->getRequestEscapedParameter('synchoxid');
 
         if (Registry::getRequest()->getRequestEscapedParameter('all')) {
             $sGroupTable = $this->getViewName('oxgroups');
-            $aAddGroups = $this->getAll($this->addFilter("select $sGroupTable.oxid " . $this->getQuery()));
+            $aAddGroups = $this->_getAll($this->_addFilter("select $sGroupTable.oxid " . $this->getQuery()));
         }
         if ($soxId && $soxId != '-1' && is_array($aAddGroups)) {
             foreach ($aAddGroups as $sAddgroup) {

--- a/source/Application/Controller/Admin/NewsletterSend.php
+++ b/source/Application/Controller/Admin/NewsletterSend.php
@@ -205,9 +205,13 @@ class NewsletterSend extends NewsletterSelection
      * Overrides parent method to pass referred id
      *
      * @param string $sNode referred id
-     * @deprecated Use setupNavigation() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _setupNavigation().
+     * @deprecated Transitional during #107. Modules SHOULD override _setupNavigation()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes setupNavigation() to the canonical override
+      *             target and retires _setupNavigation(); until then, _setupNavigation() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _setupNavigation($sNode) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -236,9 +240,10 @@ class NewsletterSend extends NewsletterSelection
      *
      * @param string $sNode referred id
      *
-     * @internal If your override does not fully replace the behavior, call parent::setupNavigation()
-     *           (not the deprecated _setupNavigation()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _setupNavigation(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make setupNavigation() the canonical override target.
      */
     protected function setupNavigation($sNode)
     {

--- a/source/Application/Controller/Admin/ShopConfiguration.php
+++ b/source/Application/Controller/Admin/ShopConfiguration.php
@@ -147,9 +147,13 @@ class ShopConfiguration extends AdminDetailsController
      * return theme filter for config variables
      *
      * @return string
-     * @deprecated Use getModuleForConfigVars() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getModuleForConfigVars().
+     * @deprecated Transitional during #107. Modules SHOULD override _getModuleForConfigVars()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getModuleForConfigVars() to the canonical override
+      *             target and retires _getModuleForConfigVars(); until then, _getModuleForConfigVars() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getModuleForConfigVars() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -161,9 +165,10 @@ class ShopConfiguration extends AdminDetailsController
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getModuleForConfigVars()
-     *           (not the deprecated _getModuleForConfigVars()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getModuleForConfigVars(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getModuleForConfigVars() the canonical override target.
      */
     protected function getModuleForConfigVars()
     {
@@ -292,9 +297,13 @@ class ShopConfiguration extends AdminDetailsController
      * @param string $constraint serialized constraint
      *
      * @return array|null
-     * @deprecated Use parseConstraint() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _parseConstraint().
+     * @deprecated Transitional during #107. Modules SHOULD override _parseConstraint()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes parseConstraint() to the canonical override
+      *             target and retires _parseConstraint(); until then, _parseConstraint() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _parseConstraint($type, $constraint) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -312,9 +321,10 @@ class ShopConfiguration extends AdminDetailsController
      *
      * @return array|null
      *
-     * @internal If your override does not fully replace the behavior, call parent::parseConstraint()
-     *           (not the deprecated _parseConstraint()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _parseConstraint(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make parseConstraint() the canonical override target.
      */
     protected function parseConstraint($type, $constraint)
     {
@@ -328,9 +338,13 @@ class ShopConfiguration extends AdminDetailsController
      * @param mixed  $constraint constraint value
      *
      * @return string
-     * @deprecated Use serializeConstraint() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _serializeConstraint().
+     * @deprecated Transitional during #107. Modules SHOULD override _serializeConstraint()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes serializeConstraint() to the canonical override
+      *             target and retires _serializeConstraint(); until then, _serializeConstraint() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _serializeConstraint($type, $constraint) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -348,9 +362,10 @@ class ShopConfiguration extends AdminDetailsController
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::serializeConstraint()
-     *           (not the deprecated _serializeConstraint()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _serializeConstraint(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make serializeConstraint() the canonical override target.
      */
     protected function serializeConstraint($type, $constraint)
     {
@@ -454,9 +469,13 @@ class ShopConfiguration extends AdminDetailsController
      * @param array $input Array with text
      *
      * @return string
-     * @deprecated Use arrayToMultiline() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _arrayToMultiline().
+     * @deprecated Transitional during #107. Modules SHOULD override _arrayToMultiline()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes arrayToMultiline() to the canonical override
+      *             target and retires _arrayToMultiline(); until then, _arrayToMultiline() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _arrayToMultiline($input) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -470,9 +489,10 @@ class ShopConfiguration extends AdminDetailsController
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::arrayToMultiline()
-     *           (not the deprecated _arrayToMultiline()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _arrayToMultiline(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make arrayToMultiline() the canonical override target.
      */
     protected function arrayToMultiline($input)
     {
@@ -485,9 +505,13 @@ class ShopConfiguration extends AdminDetailsController
      * @param string $multiline Multiline text
      *
      * @return array|void
-     * @deprecated Use multilineToArray() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _multilineToArray().
+     * @deprecated Transitional during #107. Modules SHOULD override _multilineToArray()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes multilineToArray() to the canonical override
+      *             target and retires _multilineToArray(); until then, _multilineToArray() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _multilineToArray($multiline) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -511,9 +535,10 @@ class ShopConfiguration extends AdminDetailsController
      *
      * @return array|void
      *
-     * @internal If your override does not fully replace the behavior, call parent::multilineToArray()
-     *           (not the deprecated _multilineToArray()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _multilineToArray(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make multilineToArray() the canonical override target.
      */
     protected function multilineToArray($multiline)
     {
@@ -526,9 +551,13 @@ class ShopConfiguration extends AdminDetailsController
      * @param array $input Array to convert
      *
      * @return string|void
-     * @deprecated Use aarrayToMultiline() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _aarrayToMultiline().
+     * @deprecated Transitional during #107. Modules SHOULD override _aarrayToMultiline()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes aarrayToMultiline() to the canonical override
+      *             target and retires _aarrayToMultiline(); until then, _aarrayToMultiline() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _aarrayToMultiline($input) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -552,9 +581,10 @@ class ShopConfiguration extends AdminDetailsController
      *
      * @return string|void
      *
-     * @internal If your override does not fully replace the behavior, call parent::aarrayToMultiline()
-     *           (not the deprecated _aarrayToMultiline()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _aarrayToMultiline(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make aarrayToMultiline() the canonical override target.
      */
     protected function aarrayToMultiline($input)
     {
@@ -567,9 +597,13 @@ class ShopConfiguration extends AdminDetailsController
      * @param string $multiline Multiline text
      *
      * @return array
-     * @deprecated Use multilineToAarray() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _multilineToAarray().
+     * @deprecated Transitional during #107. Modules SHOULD override _multilineToAarray()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes multilineToAarray() to the canonical override
+      *             target and retires _multilineToAarray(); until then, _multilineToAarray() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _multilineToAarray($multiline) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -597,9 +631,10 @@ class ShopConfiguration extends AdminDetailsController
      *
      * @return array
      *
-     * @internal If your override does not fully replace the behavior, call parent::multilineToAarray()
-     *           (not the deprecated _multilineToAarray()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _multilineToAarray(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make multilineToAarray() the canonical override target.
      */
     protected function multilineToAarray($multiline)
     {

--- a/source/Application/Controller/BasketController.php
+++ b/source/Application/Controller/BasketController.php
@@ -392,7 +392,7 @@ class BasketController extends FrontendController
         if ($this->getViewConfig()->getShowGiftWrapping()) {
             $oBasket = Registry::getSession()->getBasket();
 
-            $this->setWrappingInfo($oBasket, $oRequest->getRequestEscapedParameter('wrapping'));
+            $this->_setWrappingInfo($oBasket, $oRequest->getRequestEscapedParameter('wrapping'));
 
             $oBasket->setCardMessage($oRequest->getRequestEscapedParameter('giftmessage'));
             $oBasket->setCardId($oRequest->getRequestEscapedParameter('chosencard'));

--- a/source/Application/Controller/RssController.php
+++ b/source/Application/Controller/RssController.php
@@ -88,9 +88,10 @@ class RssController extends FrontendController
      *
      * @return RssFeed
      *
-     * @internal If your override does not fully replace the behavior, call parent::getRssFeed()
-     *           (not the deprecated _getRssFeed()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getRssFeed(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getRssFeed() the canonical override target.
      */
     protected function getRssFeed()
     {
@@ -120,7 +121,7 @@ class RssController extends FrontendController
         $sCharset = Registry::getLang()->translateString('charset');
         Registry::getUtils()->setHeader('Content-Type: text/xml; charset=' . $sCharset);
         Registry::getUtils()->showMessageAndExit(
-            $this->processOutput(
+            $this->_processOutput(
                 $renderer->renderTemplate($this->_sThisTemplate, $this->_aViewData)
             )
         );
@@ -179,7 +180,7 @@ class RssController extends FrontendController
     public function topshop()
     {
         if (Registry::getConfig()->getConfigParam('bl_rssTopShop')) {
-            $this->getRssFeed()->loadTopInShop();
+            $this->_getRssFeed()->loadTopInShop();
         } else {
             error_404_handler();
         }
@@ -193,7 +194,7 @@ class RssController extends FrontendController
     public function newarts()
     {
         if (Registry::getConfig()->getConfigParam('bl_rssNewest')) {
-            $this->getRssFeed()->loadNewestArticles();
+            $this->_getRssFeed()->loadNewestArticles();
         } else {
             error_404_handler();
         }
@@ -209,7 +210,7 @@ class RssController extends FrontendController
         if (Registry::getConfig()->getConfigParam('bl_rssCategories')) {
             $oCat = oxNew(Category::class);
             if ($oCat->load(Registry::getRequest()->getRequestEscapedParameter('cat'))) {
-                $this->getRssFeed()->loadCategoryArticles($oCat);
+                $this->_getRssFeed()->loadCategoryArticles($oCat);
             }
         } else {
             error_404_handler();
@@ -229,7 +230,7 @@ class RssController extends FrontendController
             $sVendorId = Registry::getRequest()->getRequestEscapedParameter('searchvendor');
             $sManufacturerId = Registry::getRequest()->getRequestEscapedParameter('searchmanufacturer');
 
-            $this->getRssFeed()->loadSearchArticles($sSearchParameter, $sCatId, $sVendorId, $sManufacturerId);
+            $this->_getRssFeed()->loadSearchArticles($sSearchParameter, $sCatId, $sVendorId, $sManufacturerId);
         } else {
             error_404_handler();
         }
@@ -249,7 +250,7 @@ class RssController extends FrontendController
         if ($this->getViewConfig()->getShowListmania() && Registry::getConfig()->getConfigParam('bl_rssRecommLists')) {
             $oArticle = oxNew(Article::class);
             if ($oArticle->load(Registry::getRequest()->getRequestEscapedParameter('anid'))) {
-                $this->getRssFeed()->loadRecommLists($oArticle);
+                $this->_getRssFeed()->loadRecommLists($oArticle);
 
                 return;
             }
@@ -271,7 +272,7 @@ class RssController extends FrontendController
         if (Registry::getConfig()->getConfigParam('bl_rssRecommListArts')) {
             $oRecommList = oxNew(RecommendationList::class);
             if ($oRecommList->load(Registry::getRequest()->getRequestEscapedParameter('recommid'))) {
-                $this->getRssFeed()->loadRecommListArticles($oRecommList);
+                $this->_getRssFeed()->loadRecommListArticles($oRecommList);
 
                 return;
             }
@@ -287,7 +288,7 @@ class RssController extends FrontendController
     public function bargain()
     {
         if (Registry::getConfig()->getConfigParam('bl_rssBargain')) {
-            $this->getRssFeed()->loadBargain();
+            $this->_getRssFeed()->loadBargain();
         } else {
             error_404_handler();
         }
@@ -301,7 +302,7 @@ class RssController extends FrontendController
     public function getChannel()
     {
         if ($this->_oChannel === null) {
-            $this->_oChannel = $this->getRssFeed()->getChannel();
+            $this->_oChannel = $this->_getRssFeed()->getChannel();
         }
 
         return $this->_oChannel;
@@ -314,6 +315,6 @@ class RssController extends FrontendController
      */
     public function getCacheLifeTime()
     {
-        return $this->getRssFeed()->getCacheTtl();
+        return $this->_getRssFeed()->getCacheTtl();
     }
 }

--- a/source/Application/Model/SeoEncoderArticle.php
+++ b/source/Application/Model/SeoEncoderArticle.php
@@ -51,9 +51,13 @@ class SeoEncoderArticle extends SeoEncoder
      * Returns target "extension" (.html)
      *
      * @return string
-     * @deprecated Use getUrlExtension() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getUrlExtension().
+     * @deprecated Transitional during #107. Modules SHOULD override _getUrlExtension()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getUrlExtension() to the canonical override
+      *             target and retires _getUrlExtension(); until then, _getUrlExtension() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -65,9 +69,10 @@ class SeoEncoderArticle extends SeoEncoder
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getUrlExtension()
-     *           (not the deprecated _getUrlExtension()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getUrlExtension(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getUrlExtension() the canonical override target.
      */
     protected function getUrlExtension()
     {
@@ -82,9 +87,13 @@ class SeoEncoderArticle extends SeoEncoder
      * @param int                                         $iLang    user defined language id
      *
      * @return Article
-     * @deprecated Use getProductForLang() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getProductForLang().
+     * @deprecated Transitional during #107. Modules SHOULD override _getProductForLang()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getProductForLang() to the canonical override
+      *             target and retires _getProductForLang(); until then, _getProductForLang() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getProductForLang($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -107,9 +116,10 @@ class SeoEncoderArticle extends SeoEncoder
      *
      * @return Article
      *
-     * @internal If your override does not fully replace the behavior, call parent::getProductForLang()
-     *           (not the deprecated _getProductForLang()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getProductForLang(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getProductForLang() the canonical override target.
      */
     protected function getProductForLang($oArticle, $iLang)
     {
@@ -187,9 +197,13 @@ class SeoEncoderArticle extends SeoEncoder
      * Returns active list type
      *
      * @return string
-     * @deprecated Use getListType() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getListType().
+     * @deprecated Transitional during #107. Modules SHOULD override _getListType()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getListType() to the canonical override
+      *             target and retires _getListType(); until then, _getListType() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getListType() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -201,9 +215,10 @@ class SeoEncoderArticle extends SeoEncoder
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getListType()
-     *           (not the deprecated _getListType()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getListType(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getListType() the canonical override target.
      */
     protected function getListType()
     {
@@ -219,9 +234,13 @@ class SeoEncoderArticle extends SeoEncoder
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use createArticleCategoryUri() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _createArticleCategoryUri().
+     * @deprecated Transitional during #107. Modules SHOULD override _createArticleCategoryUri()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes createArticleCategoryUri() to the canonical override
+      *             target and retires _createArticleCategoryUri(); until then, _createArticleCategoryUri() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _createArticleCategoryUri($oArticle, $oCategory, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -267,9 +286,10 @@ class SeoEncoderArticle extends SeoEncoder
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::createArticleCategoryUri()
-     *           (not the deprecated _createArticleCategoryUri()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _createArticleCategoryUri(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make createArticleCategoryUri() the canonical override target.
      */
     protected function createArticleCategoryUri($oArticle, $oCategory, $iLang)
     {
@@ -326,9 +346,13 @@ class SeoEncoderArticle extends SeoEncoder
      * @param int                                         $iLang    language id
      *
      * @return Category|null
-     * @deprecated Use getCategory() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getCategory().
+     * @deprecated Transitional during #107. Modules SHOULD override _getCategory()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getCategory() to the canonical override
+      *             target and retires _getCategory(); until then, _getCategory() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getCategory($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -351,9 +375,10 @@ class SeoEncoderArticle extends SeoEncoder
      *
      * @return Category|null
      *
-     * @internal If your override does not fully replace the behavior, call parent::getCategory()
-     *           (not the deprecated _getCategory()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getCategory(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getCategory() the canonical override target.
      */
     protected function getCategory($oArticle, $iLang)
     {
@@ -367,9 +392,13 @@ class SeoEncoderArticle extends SeoEncoder
      *
      * @return Category
      * @throws DatabaseConnectionException
-     * @deprecated Use getMainCategory() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getMainCategory().
+     * @deprecated Transitional during #107. Modules SHOULD override _getMainCategory()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getMainCategory() to the canonical override
+      *             target and retires _getMainCategory(); until then, _getMainCategory() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getMainCategory($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -414,9 +443,10 @@ class SeoEncoderArticle extends SeoEncoder
      * @return Category
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getMainCategory()
-     *           (not the deprecated _getMainCategory()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getMainCategory(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getMainCategory() the canonical override target.
      */
     protected function getMainCategory($oArticle)
     {
@@ -476,9 +506,13 @@ class SeoEncoderArticle extends SeoEncoder
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use prepareArticleTitle() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _prepareArticleTitle().
+     * @deprecated Transitional during #107. Modules SHOULD override _prepareArticleTitle()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes prepareArticleTitle() to the canonical override
+      *             target and retires _prepareArticleTitle(); until then, _prepareArticleTitle() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _prepareArticleTitle($oArticle) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -518,9 +552,10 @@ class SeoEncoderArticle extends SeoEncoder
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::prepareArticleTitle()
-     *           (not the deprecated _prepareArticleTitle()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _prepareArticleTitle(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make prepareArticleTitle() the canonical override target.
      */
     protected function prepareArticleTitle($oArticle)
     {
@@ -583,9 +618,13 @@ class SeoEncoderArticle extends SeoEncoder
      * @param int                                         $iLang    language id
      *
      * @return Vendor|null
-     * @deprecated Use getVendor() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getVendor().
+     * @deprecated Transitional during #107. Modules SHOULD override _getVendor()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getVendor() to the canonical override
+      *             target and retires _getVendor(); until then, _getVendor() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getVendor($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -617,9 +656,10 @@ class SeoEncoderArticle extends SeoEncoder
      *
      * @return Vendor|null
      *
-     * @internal If your override does not fully replace the behavior, call parent::getVendor()
-     *           (not the deprecated _getVendor()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getVendor(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getVendor() the canonical override target.
      */
     protected function getVendor($oArticle, $iLang)
     {
@@ -681,9 +721,13 @@ class SeoEncoderArticle extends SeoEncoder
      * @param int                                         $iLang    language id
      *
      * @return Manufacturer|null
-     * @deprecated Use getManufacturer() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getManufacturer().
+     * @deprecated Transitional during #107. Modules SHOULD override _getManufacturer()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getManufacturer() to the canonical override
+      *             target and retires _getManufacturer(); until then, _getManufacturer() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getManufacturer($oArticle, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -716,9 +760,10 @@ class SeoEncoderArticle extends SeoEncoder
      *
      * @return Manufacturer|null
      *
-     * @internal If your override does not fully replace the behavior, call parent::getManufacturer()
-     *           (not the deprecated _getManufacturer()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getManufacturer(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getManufacturer() the canonical override target.
      */
     protected function getManufacturer($oArticle, $iLang)
     {
@@ -817,9 +862,13 @@ class SeoEncoderArticle extends SeoEncoder
      * @return string
      * @throws DatabaseConnectionException
      * @throws DatabaseErrorException
-     * @deprecated Use getAltUri() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getAltUri().
+     * @deprecated Transitional during #107. Modules SHOULD override _getAltUri()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getAltUri() to the canonical override
+      *             target and retires _getAltUri(); until then, _getAltUri() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -854,9 +903,10 @@ class SeoEncoderArticle extends SeoEncoder
      * @throws DatabaseConnectionException
      * @throws DatabaseErrorException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getAltUri()
-     *           (not the deprecated _getAltUri()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getAltUri(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getAltUri() the canonical override target.
      */
     protected function getAltUri($sObjectId, $iLang)
     {

--- a/source/Application/Model/SeoEncoderCategory.php
+++ b/source/Application/Model/SeoEncoderCategory.php
@@ -39,9 +39,13 @@ class SeoEncoderCategory extends SeoEncoder
      * Returns target "extension" (/)
      *
      * @return string
-     * @deprecated Use getUrlExtension() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getUrlExtension().
+     * @deprecated Transitional during #107. Modules SHOULD override _getUrlExtension()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getUrlExtension() to the canonical override
+      *             target and retires _getUrlExtension(); until then, _getUrlExtension() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -53,9 +57,10 @@ class SeoEncoderCategory extends SeoEncoder
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getUrlExtension()
-     *           (not the deprecated _getUrlExtension()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getUrlExtension(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getUrlExtension() the canonical override target.
      */
     protected function getUrlExtension()
     {
@@ -72,9 +77,13 @@ class SeoEncoderCategory extends SeoEncoder
      * @access protected
      *
      * @return boolean
-     * @deprecated Use categoryUrlLoader() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _categoryUrlLoader().
+     * @deprecated Transitional during #107. Modules SHOULD override _categoryUrlLoader()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes categoryUrlLoader() to the canonical override
+      *             target and retires _categoryUrlLoader(); until then, _categoryUrlLoader() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _categoryUrlLoader($oCat, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -100,9 +109,10 @@ class SeoEncoderCategory extends SeoEncoder
      *
      * @return boolean
      *
-     * @internal If your override does not fully replace the behavior, call parent::categoryUrlLoader()
-     *           (not the deprecated _categoryUrlLoader()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _categoryUrlLoader(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make categoryUrlLoader() the canonical override target.
      */
     protected function categoryUrlLoader($oCat, $iLang)
     {
@@ -316,9 +326,13 @@ class SeoEncoderCategory extends SeoEncoder
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getAltUri() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getAltUri().
+     * @deprecated Transitional during #107. Modules SHOULD override _getAltUri()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getAltUri() to the canonical override
+      *             target and retires _getAltUri(); until then, _getAltUri() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -340,9 +354,10 @@ class SeoEncoderCategory extends SeoEncoder
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getAltUri()
-     *           (not the deprecated _getAltUri()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getAltUri(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getAltUri() the canonical override target.
      */
     protected function getAltUri($sObjectId, $iLang)
     {

--- a/source/Application/Model/SeoEncoderContent.php
+++ b/source/Application/Model/SeoEncoderContent.php
@@ -38,9 +38,13 @@ class SeoEncoderContent extends SeoEncoder
      * Returns target "extension" (/)
      *
      * @return string
-     * @deprecated Use getUrlExtension() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getUrlExtension().
+     * @deprecated Transitional during #107. Modules SHOULD override _getUrlExtension()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getUrlExtension() to the canonical override
+      *             target and retires _getUrlExtension(); until then, _getUrlExtension() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -52,9 +56,10 @@ class SeoEncoderContent extends SeoEncoder
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getUrlExtension()
-     *           (not the deprecated _getUrlExtension()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getUrlExtension(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getUrlExtension() the canonical override target.
      */
     protected function getUrlExtension()
     {
@@ -155,9 +160,13 @@ class SeoEncoderContent extends SeoEncoder
      *
      * @return string
      * @throws DatabaseConnectionException
-     * @deprecated Use getAltUri() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getAltUri().
+     * @deprecated Transitional during #107. Modules SHOULD override _getAltUri()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getAltUri() to the canonical override
+      *             target and retires _getAltUri(); until then, _getAltUri() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -179,9 +188,10 @@ class SeoEncoderContent extends SeoEncoder
      * @return string
      * @throws DatabaseConnectionException
      *
-     * @internal If your override does not fully replace the behavior, call parent::getAltUri()
-     *           (not the deprecated _getAltUri()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getAltUri(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getAltUri() the canonical override target.
      */
     protected function getAltUri($sObjectId, $iLang)
     {

--- a/source/Application/Model/SeoEncoderManufacturer.php
+++ b/source/Application/Model/SeoEncoderManufacturer.php
@@ -43,9 +43,13 @@ class SeoEncoderManufacturer extends SeoEncoder
      * Returns target "extension" (/)
      *
      * @return string
-     * @deprecated Use getUrlExtension() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getUrlExtension().
+     * @deprecated Transitional during #107. Modules SHOULD override _getUrlExtension()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getUrlExtension() to the canonical override
+      *             target and retires _getUrlExtension(); until then, _getUrlExtension() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -57,9 +61,10 @@ class SeoEncoderManufacturer extends SeoEncoder
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getUrlExtension()
-     *           (not the deprecated _getUrlExtension()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getUrlExtension(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getUrlExtension() the canonical override target.
      */
     protected function getUrlExtension()
     {
@@ -181,9 +186,13 @@ class SeoEncoderManufacturer extends SeoEncoder
      * @param int    $iLang     language id
      *
      * @return string
-     * @deprecated Use getAltUri() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getAltUri().
+     * @deprecated Transitional during #107. Modules SHOULD override _getAltUri()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getAltUri() to the canonical override
+      *             target and retires _getAltUri(); until then, _getAltUri() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getAltUri($sObjectId, $iLang) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -204,9 +213,10 @@ class SeoEncoderManufacturer extends SeoEncoder
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getAltUri()
-     *           (not the deprecated _getAltUri()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getAltUri(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getAltUri() the canonical override target.
      */
     protected function getAltUri($sObjectId, $iLang)
     {

--- a/source/Application/Model/SeoEncoderVendor.php
+++ b/source/Application/Model/SeoEncoderVendor.php
@@ -44,9 +44,13 @@ class SeoEncoderVendor extends SeoEncoder
      * Returns target "extension" (/)
      *
      * @return string
-     * @deprecated Use getUrlExtension() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getUrlExtension().
+     * @deprecated Transitional during #107. Modules SHOULD override _getUrlExtension()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getUrlExtension() to the canonical override
+      *             target and retires _getUrlExtension(); until then, _getUrlExtension() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getUrlExtension() // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -58,9 +62,10 @@ class SeoEncoderVendor extends SeoEncoder
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getUrlExtension()
-     *           (not the deprecated _getUrlExtension()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getUrlExtension(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getUrlExtension() the canonical override target.
      */
     protected function getUrlExtension()
     {
@@ -183,9 +188,13 @@ class SeoEncoderVendor extends SeoEncoder
      * @param int    $languageId Language id
      *
      * @return string
-     * @deprecated Use getAltUri() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _getAltUri().
+     * @deprecated Transitional during #107. Modules SHOULD override _getAltUri()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes getAltUri() to the canonical override
+      *             target and retires _getAltUri(); until then, _getAltUri() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      */
     protected function _getAltUri($vendorId, $languageId) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
@@ -206,9 +215,10 @@ class SeoEncoderVendor extends SeoEncoder
      *
      * @return string
      *
-     * @internal If your override does not fully replace the behavior, call parent::getAltUri()
-     *           (not the deprecated _getAltUri()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _getAltUri(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make getAltUri() the canonical override target.
      */
     protected function getAltUri($vendorId, $languageId)
     {

--- a/source/Core/InputValidator.php
+++ b/source/Core/InputValidator.php
@@ -428,9 +428,13 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      * Used to collect user validation errors. This method is called from all of
      * the input checking functionality to report found error.
      *
-     * @deprecated Use addValidationError() instead. This underscore-prefixed name is retained only
-     *             for backward compatibility with module subclasses that already override
-     *             it; new code, including new modules, MUST NOT call or override _addValidationError().
+     * @deprecated Transitional during #107. Modules SHOULD override _addValidationError()
+      *             for now — internal call paths route through it. The
+      *             longer-term direction (issue #108) is a template-method
+      *             refactor that promotes addValidationError() to the canonical override
+      *             target and retires _addValidationError(); until then, _addValidationError() is the
+      *             safe override target. Plan extension work with both stages
+      *             in mind.
      * @param StandardException $error     Exception.
      *
      * @return StandardException
@@ -449,9 +453,10 @@ class InputValidator extends \OxidEsales\Eshop\Core\Base
      *
      * @return StandardException
      *
-     * @internal If your override does not fully replace the behavior, call parent::addValidationError()
-     *           (not the deprecated _addValidationError()) so downstream overrides in the class chain
-     *           are preserved. Template-method refactor tracked in o3-shop/o3-shop#108.
+     * @internal Public delegate during the #107 transition. Module subclasses
+      *           SHOULD override _addValidationError(), not this — internal call paths
+      *           bypass this name. Issue #108 will eventually invert this and
+      *           make addValidationError() the canonical override target.
      */
     public function addValidationError($fieldName, $error)
     {

--- a/tests/Unit/Application/Component/Widget/ArticleDetailsTest.php
+++ b/tests/Unit/Application/Component/Widget/ArticleDetailsTest.php
@@ -861,9 +861,9 @@ class ArticleDetailsTest extends \OxidTestCase
         $oProduct->expects($this->once())->method('getVariantSelections')->will($this->returnValue('varselections'));
 
         // no parent — production calls getParentProduct (without underscore)
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Component\Widget\ArticleDetails::class, ['getProduct', 'getParentProduct']);
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Component\Widget\ArticleDetails::class, ['getProduct', '_getParentProduct']);
         $oView->expects($this->once())->method('getProduct')->will($this->returnValue($oProduct));
-        $oView->expects($this->once())->method('getParentProduct')->will($this->returnValue(false));
+        $oView->expects($this->once())->method('_getParentProduct')->will($this->returnValue(false));
 
         $this->assertEquals('varselections', $oView->getVariantSelections());
 
@@ -874,9 +874,9 @@ class ArticleDetailsTest extends \OxidTestCase
         $oParent->expects($this->once())->method('getVariantSelections')->will($this->returnValue('parentselections'));
 
         // has parent
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Component\Widget\ArticleDetails::class, ['getProduct', 'getParentProduct']);
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Component\Widget\ArticleDetails::class, ['getProduct', '_getParentProduct']);
         $oView->expects($this->once())->method('getProduct')->will($this->returnValue($oProduct));
-        $oView->expects($this->once())->method('getParentProduct')->will($this->returnValue($oParent));
+        $oView->expects($this->once())->method('_getParentProduct')->will($this->returnValue($oParent));
 
         $this->assertEquals('parentselections', $oView->getVariantSelections());
     }

--- a/tests/Unit/Application/Controller/Admin/ActionsGroupsAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/ActionsGroupsAjaxTest.php
@@ -69,8 +69,8 @@ class ActionsGroupsAjaxTest extends \OxidTestCase
     public function testRemovePromotionGroup()
     {
         // Production calls getActionIds() (without underscore)
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ActionsGroupsAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testId1', '_testId2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ActionsGroupsAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testId1', '_testId2']));
 
         $this->assertEquals(2, oxDb::getDb()->getOne("select count(oxid) from oxobject2action where oxactionid='_testGroupDelete'"));
         $oView->removePromotionGroup();
@@ -102,10 +102,10 @@ class ActionsGroupsAjaxTest extends \OxidTestCase
     public function testAddPromotionGroup()
     {
         // Production calls getActionIds() (without underscore)
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ActionsGroupsAjax::class, ['getActionIds']);
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ActionsGroupsAjax::class, ['_getActionIds']);
         $this->setRequestParameter('synchoxid', '_testActionAdd');
 
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testGroupAdd1', '_testGroupAdd2']));
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testGroupAdd1', '_testGroupAdd2']));
 
         $this->assertEquals(0, oxDb::getDb()->getOne("select count(oxid) from oxobject2action where oxactionid='_testActionAdd'"));
         $oView->addPromotionGroup();
@@ -119,11 +119,11 @@ class ActionsGroupsAjaxTest extends \OxidTestCase
      */
     public function testAddPromotionGroupAll()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ActionsGroupsAjax::class, ['getActionIds']);
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ActionsGroupsAjax::class, ['_getActionIds']);
         $this->setRequestParameter('synchoxid', '_testActionAdd');
         $this->setRequestParameter('all', true);
 
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testGroupAdd1', '_testGroupAdd2']));
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testGroupAdd1', '_testGroupAdd2']));
 
         $this->assertEquals(0, oxDb::getDb()->getOne("select count(oxid) from oxobject2action where oxactionid='_testActionAdd'"));
         $oView->addPromotionGroup();

--- a/tests/Unit/Application/Controller/Admin/ActionsMainAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/ActionsMainAjaxTest.php
@@ -209,8 +209,8 @@ class ActionsMainAjaxTest extends \OxidTestCase
     public function testRemoveArtFromAct()
     {
         // Production calls getActionIds() (without underscore)
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ActionsMainAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ActionsMainAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
         $this->assertEquals(2, oxDb::getDb()->getOne("select count(oxid) from oxactions2article where oxactionid='_testActionAdd'"));
         $oView->removeartfromact();
         $this->assertEquals(0, oxDb::getDb()->getOne("select count(oxid) from oxactions2article where oxactionid='_testActionAdd'"));
@@ -267,8 +267,8 @@ class ActionsMainAjaxTest extends \OxidTestCase
         $this->assertEquals(0, oxDb::getDb()->getOne("select count(oxid) from oxactions2article where oxactionid='$sSynchoxid'"));
 
         // Production calls getActionIds() (without underscore)
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ActionsMainAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ActionsMainAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addarttoact();
         $this->assertEquals(2, oxDb::getDb()->getOne("select count(oxid) from oxactions2article where oxactionid='$sSynchoxid'"));

--- a/tests/Unit/Application/Controller/Admin/ActionsMainTest.php
+++ b/tests/Unit/Application/Controller/Admin/ActionsMainTest.php
@@ -112,9 +112,9 @@ class ActionsMainTest extends \OxidTestCase
         $oPromotion->load($sPromotion);
 
         // testing.. Production calls createCategoryTree (without underscore)
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ActionsMain::class, ['getViewDataElement', 'createCategoryTree']);
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ActionsMain::class, ['getViewDataElement', '_createCategoryTree']);
         $oView->expects($this->once())->method('getViewDataElement')->will($this->returnValue($oPromotion));
-        $oView->expects($this->once())->method('createCategoryTree');
+        $oView->expects($this->once())->method('_createCategoryTree');
         $sTplName = $oView->render();
 
         $this->assertEquals('popups/actions_article.tpl', $sTplName);
@@ -170,9 +170,9 @@ class ActionsMainTest extends \OxidTestCase
         $oPromotion->load($sPromotion);
 
         // testing.. Production calls generateTextEditor (without underscore)
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ActionsMain::class, ['getViewDataElement', 'generateTextEditor']);
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ActionsMain::class, ['getViewDataElement', '_generateTextEditor']);
         $oView->expects($this->once())->method('getViewDataElement')->will($this->returnValue($oPromotion));
-        $oView->expects($this->once())->method('generateTextEditor')->will($this->returnValue('sHtmlEditor'));
+        $oView->expects($this->once())->method('_generateTextEditor')->will($this->returnValue('sHtmlEditor'));
         $sTplName = $oView->render();
 
         $this->assertEquals('actions_main.tpl', $sTplName);
@@ -231,9 +231,9 @@ class ActionsMainTest extends \OxidTestCase
         $oPromotion->oxactions__oxtype = new oxField(2);
 
         // testing.. Production calls generateTextEditor (without underscore)
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ActionsMain::class, ['getViewDataElement', 'generateTextEditor']);
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ActionsMain::class, ['getViewDataElement', '_generateTextEditor']);
         $oView->expects($this->once())->method('getViewDataElement')->with($this->equalTo('edit'))->will($this->returnValue($oPromotion));
-        $oView->expects($this->once())->method('generateTextEditor')->with($this->equalTo('100%'), $this->equalTo(300), $this->equalTo($oPromotion), $this->equalTo('oxactions__oxlongdesc'), $this->equalTo('details.tpl.css'));
+        $oView->expects($this->once())->method('_generateTextEditor')->with($this->equalTo('100%'), $this->equalTo(300), $this->equalTo($oPromotion), $this->equalTo('oxactions__oxlongdesc'), $this->equalTo('details.tpl.css'));
 
         $sTplName = $oView->render();
 

--- a/tests/Unit/Application/Controller/Admin/AdminDetailsTest.php
+++ b/tests/Unit/Application/Controller/Admin/AdminDetailsTest.php
@@ -54,8 +54,8 @@ class AdminDetailsTest extends \OxidTestCase
         $sEditorHtml = "<textarea  id='editor_sField' name='sField' style='width:100px; height:100px;'>sEditObjectValue</textarea>";
 
         // Production calls getEditValue() (without underscore)
-        $oAdminDetails = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\AdminDetailsController::class, ['getEditValue']);
-        $oAdminDetails->expects($this->once())->method('getEditValue')->with($this->equalTo($oObject), $this->equalTo('sField'))->will($this->returnValue('sEditObjectValue'));
+        $oAdminDetails = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\AdminDetailsController::class, ['_getEditValue']);
+        $oAdminDetails->expects($this->once())->method('_getEditValue')->with($this->equalTo($oObject), $this->equalTo('sField'))->will($this->returnValue('sEditObjectValue'));
         $this->assertEquals($sEditorHtml, $oAdminDetails->UNITgetPlainEditor(100, 100, $oObject, 'sField'));
     }
 

--- a/tests/Unit/Application/Controller/Admin/AdminViewTest.php
+++ b/tests/Unit/Application/Controller/Admin/AdminViewTest.php
@@ -85,14 +85,15 @@ class AdminViewTest extends \OxidTestCase
      */
     public function testGetServiceUrl()
     {
-        // getServiceUrl() calls getServiceProtocol() (without underscore) and ShopVersion::getVersion().
-        // Mock getServiceProtocol on the view, and use the real ShopVersion.
+        // getServiceUrl() calls _getServiceProtocol() (the underscore form post-#107
+        // call-site sweep) and ShopVersion::getVersion(). Mock _getServiceProtocol on
+        // the view, and use the real ShopVersion.
         $sPref = $this->getConfig()->getEdition();
         $sVersion = \OxidEsales\Eshop\Core\ShopVersion::getVersion();
 
         $this->getProxyClass(AdminController::class);
-        $oAdminView = $this->getMock('OxidEsales_Eshop_Application_Controller_Admin_AdminControllerProxy', ['getServiceProtocol'], [], '', false);
-        $oAdminView->expects($this->any())->method('getServiceProtocol')->will($this->returnValue('testprotocol'));
+        $oAdminView = $this->getMock('OxidEsales_Eshop_Application_Controller_Admin_AdminControllerProxy', ['_getServiceProtocol'], [], '', false);
+        $oAdminView->expects($this->any())->method('_getServiceProtocol')->will($this->returnValue('testprotocol'));
 
         $this->getSession()->setVariable('tpllanguage', 'de');
 

--- a/tests/Unit/Application/Controller/Admin/AjaxListComponentTest.php
+++ b/tests/Unit/Application/Controller/Admin/AjaxListComponentTest.php
@@ -50,8 +50,8 @@ class AjaxListComponentTest extends OxidTestCase
             ['oxid', 'oxarticles', 0, 0, 1],
         ];
 
-        $oComponent = $this->getMock(ListComponentAjax::class, ['getColNames']);
-        $oComponent->expects($this->once())->method('getColNames')->will($this->returnValue($aColNames));
+        $oComponent = $this->getMock(ListComponentAjax::class, ['_getColNames']);
+        $oComponent->expects($this->once())->method('_getColNames')->will($this->returnValue($aColNames));
         $this->assertEquals('testValue', $oComponent->UNITgetActionIds('oxarticles.oxid'));
     }
 
@@ -87,8 +87,8 @@ class AjaxListComponentTest extends OxidTestCase
     {
         $sQ = ' testQ';
 
-        $oComponent = $this->getMock(ListComponentAjax::class, ['getQueryCols']);
-        $oComponent->expects($this->once())->method('getQueryCols')->will($this->returnValue('testColumns'));
+        $oComponent = $this->getMock(ListComponentAjax::class, ['_getQueryCols']);
+        $oComponent->expects($this->once())->method('_getQueryCols')->will($this->returnValue('testColumns'));
         $this->assertEquals("select testColumns{$sQ}", $oComponent->UNITgetDataQuery($sQ));
     }
 
@@ -112,12 +112,12 @@ class AjaxListComponentTest extends OxidTestCase
      */
     public function testProcessRequestFunctionDefined()
     {
-        $oComponent = $this->getMock(ListComponentAjax::class, ['testFnc', '_getQuery', 'getDataQuery', 'getCountQuery', 'outputResponse', 'getData']);
+        $oComponent = $this->getMock(ListComponentAjax::class, ['testFnc', '_getQuery', '_getDataQuery', '_getCountQuery', '_outputResponse', 'getData']);
         $oComponent->expects($this->once())->method('testFnc');
         $oComponent->expects($this->never())->method('_getQuery');
-        $oComponent->expects($this->never())->method('getDataQuery');
-        $oComponent->expects($this->never())->method('getCountQuery');
-        $oComponent->expects($this->never())->method('outputResponse');
+        $oComponent->expects($this->never())->method('_getDataQuery');
+        $oComponent->expects($this->never())->method('_getCountQuery');
+        $oComponent->expects($this->never())->method('_outputResponse');
         $oComponent->expects($this->never())->method('getData');
         $oComponent->processRequest('testFnc');
     }
@@ -129,12 +129,12 @@ class AjaxListComponentTest extends OxidTestCase
      */
     public function testProcessRequest()
     {
-        $oComponent = $this->getMock(ListComponentAjax::class, ['testFnc', '_getQuery', 'getDataQuery', 'getCountQuery', 'outputResponse', 'getData']);
+        $oComponent = $this->getMock(ListComponentAjax::class, ['testFnc', '_getQuery', '_getDataQuery', '_getCountQuery', '_outputResponse', 'getData']);
         $oComponent->expects($this->never())->method('testFnc');
         $oComponent->expects($this->once())->method('_getQuery');
-        $oComponent->expects($this->once())->method('getDataQuery');
-        $oComponent->expects($this->once())->method('getCountQuery');
-        $oComponent->expects($this->once())->method('outputResponse');
+        $oComponent->expects($this->once())->method('_getDataQuery');
+        $oComponent->expects($this->once())->method('_getCountQuery');
+        $oComponent->expects($this->once())->method('_outputResponse');
         $oComponent->expects($this->once())->method('getData');
         $oComponent->processRequest();
     }
@@ -148,8 +148,8 @@ class AjaxListComponentTest extends OxidTestCase
     {
         $this->setRequestParameter('sort', '_1');
 
-        $oComponent = $this->getMock(ListComponentAjax::class, ['getVisibleColNames']);
-        $oComponent->expects($this->once())->method('getVisibleColNames')->will($this->returnValue([0, 1]));
+        $oComponent = $this->getMock(ListComponentAjax::class, ['_getVisibleColNames']);
+        $oComponent->expects($this->once())->method('_getVisibleColNames')->will($this->returnValue([0, 1]));
         $this->assertEquals('1', $oComponent->UNITgetSortCol());
     }
 
@@ -199,8 +199,8 @@ class AjaxListComponentTest extends OxidTestCase
             ['oxid', 'oxarticles', 0, 0, 1],
         ];
 
-        $oComponent = $this->getMock(ListComponentAjax::class, ['getColNames']);
-        $oComponent->expects($this->once())->method('getColNames')->will($this->returnValue($aColNames));
+        $oComponent = $this->getMock(ListComponentAjax::class, ['_getColNames']);
+        $oComponent->expects($this->once())->method('_getColNames')->will($this->returnValue($aColNames));
         $this->assertEquals([6 => ['oxid', 'oxarticles', 0, 0, 1]], $oComponent->UNITgetIdentColNames());
     }
 
@@ -223,8 +223,8 @@ class AjaxListComponentTest extends OxidTestCase
             ['oxid', 'oxarticles', 0, 0, 1],
         ];
 
-        $oComponent = $this->getMock(ListComponentAjax::class, ['getColNames']);
-        $oComponent->expects($this->once())->method('getColNames')->will($this->returnValue($aColNames));
+        $oComponent = $this->getMock(ListComponentAjax::class, ['_getColNames']);
+        $oComponent->expects($this->once())->method('_getColNames')->will($this->returnValue($aColNames));
         $this->assertEquals([1 => ['oxtitle', 'oxarticles', 1, 1, 0], 2 => ['oxean', 'oxarticles', 1, 0, 0]], $oComponent->UNITgetVisibleColNames());
     }
 
@@ -247,8 +247,8 @@ class AjaxListComponentTest extends OxidTestCase
             ['oxid', 'oxarticles', 0, 0, 1],
         ];
 
-        $oComponent = $this->getMock(ListComponentAjax::class, ['getColNames']);
-        $oComponent->expects($this->once())->method('getColNames')->will($this->returnValue($aColNames));
+        $oComponent = $this->getMock(ListComponentAjax::class, ['_getColNames']);
+        $oComponent->expects($this->once())->method('_getColNames')->will($this->returnValue($aColNames));
 
         unset($aColNames[6]);
         $this->assertEquals($aColNames, $oComponent->UNITgetVisibleColNames());
@@ -275,8 +275,8 @@ class AjaxListComponentTest extends OxidTestCase
         $sTableName = getViewName('oxarticles');
         $sQ = " $sTableName.oxartnum as _0, $sTableName.oxtitle as _1, $sTableName.oxean as _2, $sTableName.oxmpn as _3, $sTableName.oxprice as _4, $sTableName.oxstock as _5, $sTableName.oxid as _6 ";
 
-        $oComponent = $this->getMock(ListComponentAjax::class, ['getColNames']);
-        $oComponent->expects($this->any())->method('getColNames')->will($this->returnValue($aColNames));
+        $oComponent = $this->getMock(ListComponentAjax::class, ['_getColNames']);
+        $oComponent->expects($this->any())->method('_getColNames')->will($this->returnValue($aColNames));
         $this->assertEquals($sQ, $oComponent->UNITgetQueryCols());
     }
 
@@ -287,8 +287,8 @@ class AjaxListComponentTest extends OxidTestCase
      */
     public function testGetSorting()
     {
-        $oComponent = $this->getMock(ListComponentAjax::class, ['getSortCol', 'getSortDir']);
-        $oComponent->expects($this->once())->method('getSortCol')->will($this->returnValue('col'));
+        $oComponent = $this->getMock(ListComponentAjax::class, ['_getSortCol', 'getSortDir']);
+        $oComponent->expects($this->once())->method('_getSortCol')->will($this->returnValue('col'));
         $oComponent->expects($this->once())->method('getSortDir')->will($this->returnValue('dir'));
         $this->assertEquals(' order by _col dir ', $oComponent->UNITgetSorting());
     }
@@ -333,8 +333,8 @@ class AjaxListComponentTest extends OxidTestCase
         $sTableName = getViewName('oxarticles');
         $sQ = "$sTableName.oxartnum like '%a%'  and $sTableName.oxtitle like '%b%'  and $sTableName.oxmpn like '%0%' ";
 
-        $oComponent = $this->getMock(ListComponentAjax::class, ['getColNames']);
-        $oComponent->expects($this->any())->method('getColNames')->will($this->returnValue($aColNames));
+        $oComponent = $this->getMock(ListComponentAjax::class, ['_getColNames']);
+        $oComponent->expects($this->any())->method('_getColNames')->will($this->returnValue($aColNames));
         $this->assertEquals($sQ, $oComponent->UNITgetFilter());
     }
 
@@ -432,8 +432,8 @@ class AjaxListComponentTest extends OxidTestCase
         $aData['records'][0] = [0 => 'a', 1 => 'b'];
         $aData['records'][1] = [0 => 'c', 1 => 'd'];
 
-        $oComponent = $this->getMock(ListComponentAjax::class, ['output']);
-        $oComponent->expects($this->once())->method('output')->with($this->equalTo(json_encode($aData)));
+        $oComponent = $this->getMock(ListComponentAjax::class, ['_output']);
+        $oComponent->expects($this->once())->method('_output')->with($this->equalTo(json_encode($aData)));
         $oComponent->UNIToutputResponse($aData);
     }
 
@@ -446,15 +446,15 @@ class AjaxListComponentTest extends OxidTestCase
     {
         $this->getConfig()->setConfigParam('iDebug', 1);
 
-        $oComponent = $this->getMock(ListComponentAjax::class, ['addFilter', 'getStartIndex', 'getSortCol', 'getSortDir', 'getTotalCount', 'getSorting', 'getLimit', 'getDataFields']);
-        $oComponent->expects($this->exactly(2))->method('addFilter')->will($this->returnValue('_addFilter'));
+        $oComponent = $this->getMock(ListComponentAjax::class, ['_addFilter', 'getStartIndex', '_getSortCol', 'getSortDir', 'getTotalCount', '_getSorting', '_getLimit', '_getDataFields']);
+        $oComponent->expects($this->exactly(2))->method('_addFilter')->will($this->returnValue('_addFilter'));
         $oComponent->expects($this->once())->method('getStartIndex')->will($this->returnValue('_getStartIndex'));
-        $oComponent->expects($this->once())->method('getSortCol')->will($this->returnValue('_getSortCol'));
+        $oComponent->expects($this->once())->method('_getSortCol')->will($this->returnValue('_getSortCol'));
         $oComponent->expects($this->once())->method('getSortDir')->will($this->returnValue('_getSortDir'));
         $oComponent->expects($this->once())->method('getTotalCount')->will($this->returnValue('_getTotalCount'));
-        $oComponent->expects($this->once())->method('getSorting')->will($this->returnValue('_getSorting'));
-        $oComponent->expects($this->once())->method('getLimit')->will($this->returnValue('_getLimit'));
-        $oComponent->expects($this->once())->method('getDataFields')->will($this->returnValue('_getDataFields'));
+        $oComponent->expects($this->once())->method('_getSorting')->will($this->returnValue('_getSorting'));
+        $oComponent->expects($this->once())->method('_getLimit')->will($this->returnValue('_getLimit'));
+        $oComponent->expects($this->once())->method('_getDataFields')->will($this->returnValue('_getDataFields'));
 
         $aResponse = [];
         $aResponse['startIndex'] = '_getStartIndex';

--- a/tests/Unit/Application/Controller/Admin/ArticleAttributeAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/ArticleAttributeAjaxTest.php
@@ -118,8 +118,8 @@ class ArticleAttributeAjaxTest extends \OxidTestCase
      */
     public function testRemoveAttr()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleAttributeAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testAttribute1', '_testAttribute2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleAttributeAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testAttribute1', '_testAttribute2']));
 
         $this->assertEquals(2, oxDb::getDb()->getOne("select count(oxid) from oxobject2attribute where oxobjectid='_testObjectId'"));
         $oView->removeAttr();
@@ -150,11 +150,11 @@ class ArticleAttributeAjaxTest extends \OxidTestCase
      */
     public function testAddAttr()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleAttributeAjax::class, ['getActionIds']);
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleAttributeAjax::class, ['_getActionIds']);
         $sSynchOxid = '_testObjectIdAdd1';
         $this->setRequestParameter('synchoxid', $sSynchOxid);
 
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testAttributeAdd1', '_testAttributeAdd2']));
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testAttributeAdd1', '_testAttributeAdd2']));
 
         $this->assertEquals(0, oxDb::getDb()->getOne("select count(oxid) from oxobject2attribute where oxobjectid='$sSynchOxid'"));
         $oView->addAttr();

--- a/tests/Unit/Application/Controller/Admin/ArticleCrosssellingAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/ArticleCrosssellingAjaxTest.php
@@ -167,8 +167,8 @@ class ArticleCrosssellingAjaxTest extends \OxidTestCase
      */
     public function testRemoveArticleCross()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleCrosssellingAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testCrosssellingOxid1', '_testCrosssellingOxid2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleCrosssellingAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testCrosssellingOxid1', '_testCrosssellingOxid2']));
 
         $this->assertEquals(2, oxDb::getDb()->getOne("select count(oxid) from oxobject2article where oxobjectid='_testCrosselling'"));
         $oView->removeArticleCross();
@@ -202,8 +202,8 @@ class ArticleCrosssellingAjaxTest extends \OxidTestCase
 
         $this->assertEquals(0, oxDb::getDb()->getOne("select count(oxid) from oxobject2article where oxarticlenid='$sSynchoxid'"));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleCrosssellingAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testObjectId1', '_testObjectId2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleCrosssellingAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testObjectId1', '_testObjectId2']));
 
         $oView->addArticleCross();
         $this->assertEquals(2, oxDb::getDb()->getOne("select count(oxid) from oxobject2article where oxarticlenid='$sSynchoxid'"));

--- a/tests/Unit/Application/Controller/Admin/ArticleExtendAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/ArticleExtendAjaxTest.php
@@ -227,8 +227,8 @@ class ArticleExtendAjaxTest extends \OxidTestCase
     {
         $sOxid = '_testObjectRemove';
         $this->setRequestParameter('oxid', $sOxid);
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleExtendAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testCategory1', '_testCategory2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleExtendAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testCategory1', '_testCategory2']));
         $this->assertEquals(2, oxDb::getDb()->getOne("select count(oxid) from oxobject2category where oxobjectid='$sOxid'"));
 
         $oView->removeCat();
@@ -262,8 +262,8 @@ class ArticleExtendAjaxTest extends \OxidTestCase
     {
         $sSynchoxid = '_testObjectAdd';
         $this->setRequestParameter('synchoxid', $sSynchoxid);
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleExtendAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testCategoryAdd1', '_testCategoryAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleExtendAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testCategoryAdd1', '_testCategoryAdd2']));
         $this->assertEquals(0, oxDb::getDb()->getOne("select count(oxid) from oxobject2category where oxobjectid='$sSynchoxid'"));
 
         $oView->addCat();

--- a/tests/Unit/Application/Controller/Admin/ArticleMainTest.php
+++ b/tests/Unit/Application/Controller/Admin/ArticleMainTest.php
@@ -75,20 +75,23 @@ class ArticleMainTest extends \OxidTestCase
         oxTestModules::addFunction('oxarticle', 'save', '{ return true; }');
         $this->getConfig()->setConfigParam('blDisableDublArtOnCopy', true);
 
-        $aTasks = ['copyCategories', 'copyAttributes', 'copySelectlists',
-                        'copyCrossseling', 'copyAccessoires', 'copyStaffelpreis',
-                        'copyArtExtends'];
+        // Production code in ArticleMain::copyArticle() now calls the underscore
+        // form for the copy* hooks (post-#107 call-site sweep). resetContentCache
+        // remains the public form because its shim pair is inverted (not swept).
+        $aTasks = ['_copyCategories', '_copyAttributes', '_copySelectlists',
+                        '_copyCrossseling', '_copyAccessoires', '_copyStaffelpreis',
+                        '_copyArtExtends'];
 
         $aTasks[] = 'resetContentCache';
 
         $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleMain::class, $aTasks);
-        $oView->expects($this->once())->method('copyCategories');
-        $oView->expects($this->once())->method('copyAttributes');
-        $oView->expects($this->once())->method('copySelectlists');
-        $oView->expects($this->once())->method('copyCrossseling');
-        $oView->expects($this->once())->method('copyAccessoires');
-        $oView->expects($this->once())->method('copyStaffelpreis');
-        $oView->expects($this->once())->method('copyArtExtends');
+        $oView->expects($this->once())->method('_copyCategories');
+        $oView->expects($this->once())->method('_copyAttributes');
+        $oView->expects($this->once())->method('_copySelectlists');
+        $oView->expects($this->once())->method('_copyCrossseling');
+        $oView->expects($this->once())->method('_copyAccessoires');
+        $oView->expects($this->once())->method('_copyStaffelpreis');
+        $oView->expects($this->once())->method('_copyArtExtends');
 
         $oView->expects($this->once())->method('resetContentCache');
 

--- a/tests/Unit/Application/Controller/Admin/ArticlePicturesTest.php
+++ b/tests/Unit/Application/Controller/Admin/ArticlePicturesTest.php
@@ -164,8 +164,8 @@ class ArticlePicturesTest extends \OxidTestCase
         $this->setRequestParameter('oxid', '_testArtId');
         $this->setRequestParameter('masterPicIndex', '2');
 
-        $oArtPic = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticlePictures::class, ['resetMasterPicture']);
-        $oArtPic->expects($this->once())->method('resetMasterPicture');
+        $oArtPic = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticlePictures::class, ['_resetMasterPicture']);
+        $oArtPic->expects($this->once())->method('_resetMasterPicture');
 
         $this->_oArticle->save();
 
@@ -254,12 +254,12 @@ class ArticlePicturesTest extends \OxidTestCase
 
         oxTestModules::addModuleObject('oxPictureHandler', $oPicHandler);
 
-        $oArtPic = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticlePictures::class, ['cleanupCustomFields']);
-        $oArtPic->expects($this->never())->method('cleanupCustomFields');
+        $oArtPic = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticlePictures::class, ['_cleanupCustomFields']);
+        $oArtPic->expects($this->never())->method('_cleanupCustomFields');
         $oArtPic->UNITresetMasterPicture($oArticle, 2);
 
-        $oArtPic = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticlePictures::class, ['cleanupCustomFields']);
-        $oArtPic->expects($this->once())->method('cleanupCustomFields');
+        $oArtPic = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticlePictures::class, ['_cleanupCustomFields']);
+        $oArtPic->expects($this->once())->method('_cleanupCustomFields');
         $oArtPic->UNITresetMasterPicture($oArticle, 1);
     }
 

--- a/tests/Unit/Application/Controller/Admin/ArticleSelectionAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/ArticleSelectionAjaxTest.php
@@ -135,8 +135,8 @@ class ArticleSelectionAjaxTest extends \OxidTestCase
     {
         $oDb = oxDb::getDb();
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleSelectionAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testOxid1', '_testOxid2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleSelectionAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testOxid1', '_testOxid2']));
 
         $this->assertEquals(2, $oDb->getOne("select count(oxid) from oxobject2selectlist where oxobjectid='_testRemove'"));
         $oView->removeSel();
@@ -173,8 +173,8 @@ class ArticleSelectionAjaxTest extends \OxidTestCase
         $sSynchoxid = '_testAdd';
         $this->setRequestParameter('synchoxid', $sSynchoxid);
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleSelectionAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testAdd1', '_testAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleSelectionAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testAdd1', '_testAdd2']));
 
         $this->assertEquals(0, $oDb->getOne("select count(oxid) from oxobject2selectlist where oxobjectid='_testAdd'"));
         $oView->addSel();

--- a/tests/Unit/Application/Controller/Admin/ArticleSeoTest.php
+++ b/tests/Unit/Application/Controller/Admin/ArticleSeoTest.php
@@ -405,9 +405,9 @@ class ArticleSeoTest extends \OxidTestCase
         $product = oxNew('oxArticle');
         $product->load($productId);
 
-        $view = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleSeo::class, ['getEditObjectId', 'getCategoryList', 'getVendorList', 'getManufacturerList', 'getTagList']);
+        $view = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ArticleSeo::class, ['getEditObjectId', '_getCategoryList', 'getVendorList', 'getManufacturerList', 'getTagList']);
         $view->expects($this->any())->method('getEditObjectId')->will($this->returnValue($productId));
-        $view->expects($this->any())->method('getCategoryList')->will($this->returnValue('CategoryList'));
+        $view->expects($this->any())->method('_getCategoryList')->will($this->returnValue('CategoryList'));
         $view->expects($this->any())->method('getVendorList')->will($this->returnValue('VendorList'));
         $view->expects($this->any())->method('getManufacturerList')->will($this->returnValue('ManufacturerList'));
         $view->expects($this->any())->method('getTagList')->will($this->returnValue('TagList'));

--- a/tests/Unit/Application/Controller/Admin/AttributeCategoryAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/AttributeCategoryAjaxTest.php
@@ -108,8 +108,8 @@ class AttributeCategoryAjaxTest extends \OxidTestCase
     {
         $oDb = oxDb::getDb();
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\AttributeCategoryAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testOxid1', '_testOxid2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\AttributeCategoryAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testOxid1', '_testOxid2']));
 
         $this->assertEquals(2, $oDb->getOne("select count(oxid) from oxcategory2attribute where oxobjectid='_testRemove'"));
         $oView->removeCatFromAttr();
@@ -141,11 +141,11 @@ class AttributeCategoryAjaxTest extends \OxidTestCase
      */
     public function testAddCatToAttr()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\AttributeCategoryAjax::class, ['getActionIds']);
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\AttributeCategoryAjax::class, ['_getActionIds']);
         $sSynchoxid = '_testAttribute';
         $this->setRequestParameter('synchoxid', $sSynchoxid);
 
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testAdd1', '_testAdd2']));
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testAdd1', '_testAdd2']));
 
         $this->assertEquals(0, oxDb::getDb()->getOne("select count(oxid) from oxcategory2attribute where oxattrid='$sSynchoxid'"));
         $oView->addCatToAttr();

--- a/tests/Unit/Application/Controller/Admin/AttributeMainAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/AttributeMainAjaxTest.php
@@ -211,8 +211,8 @@ class AttributeMainAjaxTest extends \OxidTestCase
      */
     public function testRemoveAttrArticle()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\AttributeMainAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testOxid1', '_testOxid2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\AttributeMainAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testOxid1', '_testOxid2']));
         $this->assertEquals(2, oxDb::getDb()->getOne("select count(oxid) from oxobject2attribute where oxobjectid='_testObjectRemove'"));
 
         $oView->removeAttrArticle();
@@ -246,8 +246,8 @@ class AttributeMainAjaxTest extends \OxidTestCase
         $sSynchoxid = '_testAttribute';
         $this->setRequestParameter('synchoxid', $sSynchoxid);
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\AttributeMainAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testOxidAdd1', '_testOxidAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\AttributeMainAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testOxidAdd1', '_testOxidAdd2']));
 
         $this->assertEquals(0, oxDb::getDb()->getOne("select count(oxid) from oxobject2attribute where oxattrid='$sSynchoxid'"));
 

--- a/tests/Unit/Application/Controller/Admin/AttributeOrderAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/AttributeOrderAjaxTest.php
@@ -100,8 +100,8 @@ class AttributeOrderAjaxTest extends \OxidTestCase
         $aData = ['startIndex' => 0, 'sort' => '_0', 'dir' => 'asc', 'countsql' => "select count( * )  from $sViewTable left join oxcategory2attribute on oxcategory2attribute.oxattrid = $sViewTable.oxid where oxobjectid = '' ", 'records' => [], 'totalRecords' => 0];
 
         // Production calls outputResponse() (without underscore), not _output()
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\AttributeOrderAjax::class, ['outputResponse']);
-        $oView->expects($this->once())->method('outputResponse')->with($this->equalTo($aData));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\AttributeOrderAjax::class, ['_outputResponse']);
+        $oView->expects($this->once())->method('_outputResponse')->with($this->equalTo($aData));
         $oView->setsorting();
     }
 
@@ -122,8 +122,8 @@ class AttributeOrderAjaxTest extends \OxidTestCase
         $aData = ['startIndex' => 0, 'sort' => '_0', 'dir' => 'asc', 'countsql' => "select count( * )  from $sViewTable left join oxcategory2attribute on oxcategory2attribute.oxattrid = $sViewTable.oxid where oxobjectid = '$sOxid' ", 'records' => [], 'totalRecords' => 0];
 
         // Production calls outputResponse() (without underscore), not _output()
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\AttributeOrderAjax::class, ['outputResponse']);
-        $oView->expects($this->any())->method('outputResponse')->with($this->equalTo($aData));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\AttributeOrderAjax::class, ['_outputResponse']);
+        $oView->expects($this->any())->method('_outputResponse')->with($this->equalTo($aData));
         $oView->setsorting();
         $this->assertEquals(1, oxDb::getDb()->getOne("select sum(oxsort) from oxcategory2attribute where oxobjectid='_testObject'"));
     }

--- a/tests/Unit/Application/Controller/Admin/CategoryMainAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/CategoryMainAjaxTest.php
@@ -162,8 +162,8 @@ class CategoryMainAjaxTest extends \OxidTestCase
     {
         $sOxid = '_testCategory';
         $this->setRequestParameter('oxid', $sOxid);
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\CategoryMainAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testObjectRemove1']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\CategoryMainAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testObjectRemove1']));
         $this->assertEquals(3, oxDb::getDb()->getOne("select count(oxid) from oxobject2category where oxcatnid='$sOxid'"));
 
         $oView->removeArticle();
@@ -197,8 +197,8 @@ class CategoryMainAjaxTest extends \OxidTestCase
     {
         $sSynchoxid = '_testCategory';
         $this->setRequestParameter('synchoxid', $sSynchoxid);
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\CategoryMainAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testArticleAdd1', '_testArticleAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\CategoryMainAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testArticleAdd1', '_testArticleAdd2']));
         $this->assertEquals(3, oxDb::getDb()->getOne("select count(oxid) from oxobject2category where oxcatnid='$sSynchoxid'"));
 
         $oView->addArticle();

--- a/tests/Unit/Application/Controller/Admin/CategoryUpdateTest.php
+++ b/tests/Unit/Application/Controller/Admin/CategoryUpdateTest.php
@@ -40,8 +40,8 @@ class CategoryUpdateTest extends \OxidTestCase
         $oCategoryList = $this->getMock(\OxidEsales\Eshop\Application\Model\CategoryList::class, ['getUpdateInfo']);
         $oCategoryList->expects($this->once())->method('getUpdateInfo');
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\CategoryUpdate::class, ['getCategoryList']);
-        $oView->expects($this->once())->method('getCategoryList')->will($this->returnValue($oCategoryList));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\CategoryUpdate::class, ['_getCategoryList']);
+        $oView->expects($this->once())->method('_getCategoryList')->will($this->returnValue($oCategoryList));
         $oView->getCatListUpdateInfo();
     }
 

--- a/tests/Unit/Application/Controller/Admin/ContentMainTest.php
+++ b/tests/Unit/Application/Controller/Admin/ContentMainTest.php
@@ -75,8 +75,8 @@ class ContentMainTest extends \OxidTestCase
 
         // testing..
         try {
-            $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ContentMain::class, ['checkIdent']);
-            $oView->expects($this->once())->method('checkIdent')->will($this->returnValue(false));
+            $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ContentMain::class, ['_checkIdent']);
+            $oView->expects($this->once())->method('_checkIdent')->will($this->returnValue(false));
             $oView->save();
         } catch (Exception $oExcp) {
             $this->assertEquals('save', $oExcp->getMessage(), 'Error in Content_Main::Save()');

--- a/tests/Unit/Application/Controller/Admin/DeliveryArticlesAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/DeliveryArticlesAjaxTest.php
@@ -219,8 +219,8 @@ class DeliveryArticlesAjaxTest extends \OxidTestCase
      */
     public function testRemoveArtFromDel()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryArticlesAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testDelivery1', '_testDelivery2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryArticlesAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testDelivery1', '_testDelivery2']));
 
         $sSql = "select count(oxid) from oxobject2delivery where oxid in ('_testDelivery1', '_testDelivery2')";
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -259,8 +259,8 @@ class DeliveryArticlesAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2delivery where oxdeliveryid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryArticlesAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryArticlesAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addArtToDel();
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -283,8 +283,8 @@ class DeliveryArticlesAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2delivery where oxdeliveryid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryArticlesAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryArticlesAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addArtToDel();
         $this->assertEquals($iCount, oxDb::getDb()->getOne($sSql));

--- a/tests/Unit/Application/Controller/Admin/DeliveryCategoriesAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/DeliveryCategoriesAjaxTest.php
@@ -149,8 +149,8 @@ class DeliveryCategoriesAjaxTest extends \OxidTestCase
      */
     public function testRemoveCatFromDel()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryCategoriesAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testDeliveryCat1', '_testDeliveryCat2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryCategoriesAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testDeliveryCat1', '_testDeliveryCat2']));
 
         $sSql = "select count(oxid) from oxobject2delivery where oxid in ('_testDeliveryCat1', '_testDeliveryCat2')";
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -189,8 +189,8 @@ class DeliveryCategoriesAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2delivery where oxdeliveryid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryCategoriesAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryCategoriesAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addCatToDel();
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -213,8 +213,8 @@ class DeliveryCategoriesAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2delivery where oxdeliveryid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryCategoriesAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryCategoriesAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addCatToDel();
         $this->assertEquals($iCount, oxDb::getDb()->getOne($sSql));

--- a/tests/Unit/Application/Controller/Admin/DeliveryGroupsAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/DeliveryGroupsAjaxTest.php
@@ -143,8 +143,8 @@ class DeliveryGroupsAjaxTest extends \OxidTestCase
      */
     public function testRemoveGroupFromDel()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryGroupsAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testDeliveryGroup1', '_testDeliveryGroup2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryGroupsAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testDeliveryGroup1', '_testDeliveryGroup2']));
 
         $sSql = "select count(oxid) from oxobject2delivery where oxid in ('_testDeliveryGroup1', '_testDeliveryGroup2')";
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -183,8 +183,8 @@ class DeliveryGroupsAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2delivery where oxdeliveryid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryGroupsAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryGroupsAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addGroupToDel();
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -207,8 +207,8 @@ class DeliveryGroupsAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2delivery where oxdeliveryid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryGroupsAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryGroupsAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addGroupToDel();
         $this->assertEquals($iCount, oxDb::getDb()->getOne($sSql));

--- a/tests/Unit/Application/Controller/Admin/DeliveryMainAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/DeliveryMainAjaxTest.php
@@ -143,8 +143,8 @@ class DeliveryMainAjaxTest extends \OxidTestCase
      */
     public function testRemoveCountryFromDel()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryMainAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testDeliveryCountry1', '_testDeliveryCountry2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryMainAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testDeliveryCountry1', '_testDeliveryCountry2']));
 
         $sSql = "select count(oxid) from oxobject2delivery where oxid in ('_testDeliveryCountry1', '_testDeliveryCountry2')";
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -183,8 +183,8 @@ class DeliveryMainAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2delivery where oxdeliveryid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryMainAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryMainAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addCountryToDel();
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -207,8 +207,8 @@ class DeliveryMainAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2delivery where oxdeliveryid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryMainAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryMainAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addCountryToDel();
         $this->assertEquals($iCount, oxDb::getDb()->getOne($sSql));

--- a/tests/Unit/Application/Controller/Admin/DeliveryUsersAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/DeliveryUsersAjaxTest.php
@@ -192,8 +192,8 @@ class DeliveryUsersAjaxTest extends \OxidTestCase
      */
     public function testRemoveUserFromDel()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryUsersAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testDeliveryUser1', '_testDeliveryUser2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryUsersAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testDeliveryUser1', '_testDeliveryUser2']));
 
         $sSql = "select count(oxid) from oxobject2delivery where oxid in ('_testDeliveryUser1', '_testDeliveryUser2')";
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -232,8 +232,8 @@ class DeliveryUsersAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2delivery where oxdeliveryid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryUsersAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryUsersAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addUserToDel();
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -256,8 +256,8 @@ class DeliveryUsersAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2delivery where oxdeliveryid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryUsersAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliveryUsersAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addUserToDel();
         $this->assertEquals($iCount, oxDb::getDb()->getOne($sSql));

--- a/tests/Unit/Application/Controller/Admin/DeliverysetCountryAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/DeliverysetCountryAjaxTest.php
@@ -158,8 +158,8 @@ class DeliverysetCountryAjaxTest extends \OxidTestCase
      */
     public function testRemoveCountryFromSet()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetCountryAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testDeliverysetCountry1', '_testDeliverysetCountry2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetCountryAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testDeliverysetCountry1', '_testDeliverysetCountry2']));
 
         $sSql = "select count(oxid) from oxobject2delivery where oxid in ('_testDeliverysetCountry1', '_testDeliverysetCountry2')";
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -198,8 +198,8 @@ class DeliverysetCountryAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2delivery where oxdeliveryid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetCountryAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetCountryAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addCountryToSet();
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -222,8 +222,8 @@ class DeliverysetCountryAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2delivery where oxdeliveryid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetCountryAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetCountryAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addCountryToSet();
         $this->assertEquals($iCount, oxDb::getDb()->getOne($sSql));

--- a/tests/Unit/Application/Controller/Admin/DeliverysetGroupsAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/DeliverysetGroupsAjaxTest.php
@@ -158,8 +158,8 @@ class DeliverysetGroupsAjaxTest extends \OxidTestCase
      */
     public function testRemoveGroupFromSet()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetGroupsAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testDeliverysetGroup1', '_testDeliverysetGroup2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetGroupsAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testDeliverysetGroup1', '_testDeliverysetGroup2']));
 
         $sSql = "select count(oxid) from oxobject2delivery where oxid in ('_testDeliverysetGroup1', '_testDeliverysetGroup2')";
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -198,8 +198,8 @@ class DeliverysetGroupsAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2delivery where oxdeliveryid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetGroupsAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetGroupsAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addGroupToSet();
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -222,8 +222,8 @@ class DeliverysetGroupsAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2delivery where oxdeliveryid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetGroupsAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetGroupsAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addGroupToSet();
         $this->assertEquals($iCount, oxDb::getDb()->getOne($sSql));

--- a/tests/Unit/Application/Controller/Admin/DeliverysetMainAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/DeliverysetMainAjaxTest.php
@@ -128,8 +128,8 @@ class DeliverysetMainAjaxTest extends \OxidTestCase
      */
     public function testRemoveFromSet()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetMainAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testDeliverysetMain1', '_testDeliverysetMain2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetMainAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testDeliverysetMain1', '_testDeliverysetMain2']));
 
         $sSql = "select count(oxid) from oxdel2delset where oxid in ('_testDeliverysetMain1', '_testDeliverysetMain2')";
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -169,8 +169,8 @@ class DeliverysetMainAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxdel2delset where oxdelsetid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetMainAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetMainAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addToSet();
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -193,8 +193,8 @@ class DeliverysetMainAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxdel2delset where oxdelsetid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetMainAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetMainAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addToSet();
         $this->assertEquals($iCount, oxDb::getDb()->getOne($sSql));

--- a/tests/Unit/Application/Controller/Admin/DeliverysetPaymentAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/DeliverysetPaymentAjaxTest.php
@@ -143,8 +143,8 @@ class DeliverysetPaymentAjaxTest extends \OxidTestCase
      */
     public function testRemovePayFromSet()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetPaymentAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testDeliverysetPayment1', '_testDeliverysetPayment2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetPaymentAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testDeliverysetPayment1', '_testDeliverysetPayment2']));
 
         $sSql = "select count(oxid) from oxobject2payment where oxid in ('_testDeliverysetPayment1', '_testDeliverysetPayment2')";
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -183,8 +183,8 @@ class DeliverysetPaymentAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2payment where oxobjectid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetPaymentAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetPaymentAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addPayToSet();
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -207,8 +207,8 @@ class DeliverysetPaymentAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2payment where oxobjectid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetPaymentAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetPaymentAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addPayToSet();
         $this->assertEquals($iCount, oxDb::getDb()->getOne($sSql));

--- a/tests/Unit/Application/Controller/Admin/DeliverysetUsersAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/DeliverysetUsersAjaxTest.php
@@ -176,8 +176,8 @@ class DeliverysetUsersAjaxTest extends \OxidTestCase
      */
     public function testRemoveUserFromSet()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetUsersAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testDeliveryUser1', '_testDeliveryUser2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetUsersAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testDeliveryUser1', '_testDeliveryUser2']));
 
         $sSql = "select count(oxid) from oxobject2delivery where oxid in ('_testDeliveryUser1', '_testDeliveryUser2')";
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -216,8 +216,8 @@ class DeliverysetUsersAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2delivery where oxdeliveryid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetUsersAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetUsersAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addUserToSet();
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -240,8 +240,8 @@ class DeliverysetUsersAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2delivery where oxdeliveryid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetUsersAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DeliverySetUsersAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testActionAdd1', '_testActionAdd2']));
 
         $oView->addUserToSet();
         $this->assertEquals($iCount, oxDb::getDb()->getOne($sSql));

--- a/tests/Unit/Application/Controller/Admin/DiscountArticlesAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/DiscountArticlesAjaxTest.php
@@ -116,8 +116,8 @@ class DiscountArticlesAjaxTest extends \OxidTestCase
      */
     public function testRemoveDiscArt()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountArticlesAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testO2DRemove1', '_testO2DRemove2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountArticlesAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testO2DRemove1', '_testO2DRemove2']));
         $this->assertEquals(3, oxDb::getDb()->getOne("select count(oxid) from oxobject2discount where oxdiscountid='_testDiscount'"));
 
         $oView->removeDiscArt();
@@ -151,8 +151,8 @@ class DiscountArticlesAjaxTest extends \OxidTestCase
     {
         $sSynchoxid = '_testDiscount';
         $this->setRequestParameter('synchoxid', $sSynchoxid);
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountArticlesAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testArticleAdd1', '_testArticleAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountArticlesAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testArticleAdd1', '_testArticleAdd2']));
         $this->assertEquals(3, oxDb::getDb()->getOne("select count(oxid) from oxobject2discount where oxdiscountid='_testDiscount'"));
 
         $oView->addDiscArt();

--- a/tests/Unit/Application/Controller/Admin/DiscountCategoriesAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/DiscountCategoriesAjaxTest.php
@@ -119,8 +119,8 @@ class DiscountCategoriesAjaxTest extends \OxidTestCase
      */
     public function testRemoveDiscCat()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountCategoriesAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testO2DRemove1', '_testO2DRemove2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountCategoriesAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testO2DRemove1', '_testO2DRemove2']));
         $this->assertEquals(3, oxDb::getDb()->getOne("select count(oxid) from oxobject2discount where oxdiscountid='_testDiscount'"));
 
         $oView->removeDiscCat();
@@ -154,8 +154,8 @@ class DiscountCategoriesAjaxTest extends \OxidTestCase
     {
         $sSynchoxid = '_testDiscount';
         $this->setRequestParameter('synchoxid', $sSynchoxid);
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountCategoriesAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testCatAdd1', '_testCatAdd1']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountCategoriesAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testCatAdd1', '_testCatAdd1']));
         $this->assertEquals(3, oxDb::getDb()->getOne("select count(oxid) from oxobject2discount where oxdiscountid='_testDiscount'"));
 
         $oView->addDiscCat();

--- a/tests/Unit/Application/Controller/Admin/DiscountGroupsAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/DiscountGroupsAjaxTest.php
@@ -114,8 +114,8 @@ class DiscountGroupsAjaxTest extends \OxidTestCase
      */
     public function testRemoveDiscGroup()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountGroupsAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testO2DRemove1', '_testO2DRemove2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountGroupsAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testO2DRemove1', '_testO2DRemove2']));
         $this->assertEquals(3, oxDb::getDb()->getOne("select count(oxid) from oxobject2discount where oxdiscountid='_testDiscount'"));
 
         $oView->removeDiscGroup();
@@ -149,8 +149,8 @@ class DiscountGroupsAjaxTest extends \OxidTestCase
     {
         $sSynchoxid = '_testDiscount';
         $this->setRequestParameter('synchoxid', $sSynchoxid);
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountGroupsAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['oxidmiddlecust', 'oxidgoodcust']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountGroupsAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['oxidmiddlecust', 'oxidgoodcust']));
         $this->assertEquals(3, oxDb::getDb()->getOne("select count(oxid) from oxobject2discount where oxdiscountid='_testDiscount'"));
 
         $oView->addDiscGroup();

--- a/tests/Unit/Application/Controller/Admin/DiscountMainAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/DiscountMainAjaxTest.php
@@ -110,8 +110,8 @@ class DiscountMainAjaxTest extends \OxidTestCase
      */
     public function testRemoveDiscCountry()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountMainAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testO2DRemove1', '_testO2DRemove2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountMainAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testO2DRemove1', '_testO2DRemove2']));
         $this->assertEquals(3, oxDb::getDb()->getOne("select count(oxid) from oxobject2discount where oxdiscountid='_testDiscount'"));
 
         $oView->removeDiscCountry();
@@ -145,8 +145,8 @@ class DiscountMainAjaxTest extends \OxidTestCase
     {
         $sSynchoxid = '_testDiscount';
         $this->setRequestParameter('synchoxid', $sSynchoxid);
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountMainAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['oxidmiddlecust', 'oxidgoodcust']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountMainAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['oxidmiddlecust', 'oxidgoodcust']));
         $this->assertEquals(3, oxDb::getDb()->getOne("select count(oxid) from oxobject2discount where oxdiscountid='_testDiscount'"));
 
         $oView->addDiscCountry();

--- a/tests/Unit/Application/Controller/Admin/DiscountUsersAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/DiscountUsersAjaxTest.php
@@ -109,8 +109,8 @@ class DiscountUsersAjaxTest extends \OxidTestCase
      */
     public function testRemoveDiscUser()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountUsersAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testO2DRemove1', '_testO2DRemove2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountUsersAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testO2DRemove1', '_testO2DRemove2']));
         $this->assertEquals(3, oxDb::getDb()->getOne("select count(oxid) from oxobject2discount where oxdiscountid='_testDiscount'"));
 
         $oView->removeDiscUser();
@@ -140,8 +140,8 @@ class DiscountUsersAjaxTest extends \OxidTestCase
     {
         $sSynchoxid = '_testDiscount';
         $this->setRequestParameter('synchoxid', $sSynchoxid);
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountUsersAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testNewUser1', '_testNewUser2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DiscountUsersAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testNewUser1', '_testNewUser2']));
         $this->assertEquals(3, oxDb::getDb()->getOne("select count(oxid) from oxobject2discount where oxdiscountid='_testDiscount'"));
 
         $oView->addDiscUser();

--- a/tests/Unit/Application/Controller/Admin/DynExportBaseTest.php
+++ b/tests/Unit/Application/Controller/Admin/DynExportBaseTest.php
@@ -417,8 +417,8 @@ class DynExportBaseTest extends \OxidTestCase
     public function testGetOneArticle()
     {
         $blContinue = null;
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DynamicExportBaseController::class, ['initArticle', 'getHeapTableName', 'setCampaignDetailLink']);
-        $oView->expects($this->once())->method('initArticle')->with($this->equalTo('oxarticles'), $this->equalTo(0))->will($this->returnValue(oxNew('oxarticle')));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DynamicExportBaseController::class, ['_initArticle', 'getHeapTableName', 'setCampaignDetailLink']);
+        $oView->expects($this->once())->method('_initArticle')->with($this->equalTo('oxarticles'), $this->equalTo(0))->will($this->returnValue(oxNew('oxarticle')));
         $oView->expects($this->once())->method('getHeapTableName')->will($this->returnValue('oxarticles'));
         $oView->expects($this->once())->method('setCampaignDetailLink')->with($this->isInstanceOf('\OxidEsales\EshopCommunity\Application\Model\Article'))->will($this->returnValue(oxNew('oxarticle')));
 

--- a/tests/Unit/Application/Controller/Admin/DynscreenListTest.php
+++ b/tests/Unit/Application/Controller/Admin/DynscreenListTest.php
@@ -33,9 +33,10 @@ class DynscreenListTest extends \OxidTestCase
      */
     public function testRender()
     {
-        // testing..
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DynamicScreenList::class, ['setupNavigation']);
-        $oView->expects($this->once())->method('setupNavigation');
+        // Post-#107 call-site sweep: AdminListController::render() now calls
+        // $this->_setupNavigation() (the BC anchor). Mock the underscore name.
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DynamicScreenList::class, ['_setupNavigation']);
+        $oView->expects($this->once())->method('_setupNavigation');
         $this->assertEquals('dynscreen_list.tpl', $oView->render());
     }
 }

--- a/tests/Unit/Application/Controller/Admin/DynscreenTest.php
+++ b/tests/Unit/Application/Controller/Admin/DynscreenTest.php
@@ -75,9 +75,9 @@ class DynscreenTest extends \OxidTestCase
      */
     public function testRender()
     {
-        // testing..
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DynamicScreenController::class, ['setupNavigation']);
-        $oView->expects($this->once())->method('setupNavigation');
+        // Post-#107 call-site sweep: render() now calls $this->_setupNavigation().
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\DynamicScreenController::class, ['_setupNavigation']);
+        $oView->expects($this->once())->method('_setupNavigation');
         $this->assertEquals('dynscreen.tpl', $oView->render());
     }
 }

--- a/tests/Unit/Application/Controller/Admin/GenImportMainTest.php
+++ b/tests/Unit/Application/Controller/Admin/GenImportMainTest.php
@@ -99,8 +99,8 @@ class GenImportMainTest extends \OxidTestCase
         $this->assertTrue(file_exists($sFilePath));
 
         // testing..
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\GenericImportMain::class, ['getUploadedCsvFilePath']);
-        $oView->expects($this->once())->method('getUploadedCsvFilePath')->will($this->returnValue($sFilePath));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\GenericImportMain::class, ['_getUploadedCsvFilePath']);
+        $oView->expects($this->once())->method('_getUploadedCsvFilePath')->will($this->returnValue($sFilePath));
         $oView->UNITdeleteCsvFile();
 
         $this->assertFalse(file_exists($sFilePath));
@@ -115,9 +115,9 @@ class GenImportMainTest extends \OxidTestCase
     {
         $this->setRequestParameter('blContainsHeader', false);
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\GenericImportMain::class, ['getUploadedCsvFilePath', 'getCsvFirstRow']);
-        $oView->expects($this->once())->method('getUploadedCsvFilePath')->will($this->returnValue(false));
-        $oView->expects($this->once())->method('getCsvFirstRow')->will($this->returnValue([1, 2, 3]));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\GenericImportMain::class, ['_getUploadedCsvFilePath', '_getCsvFirstRow']);
+        $oView->expects($this->once())->method('_getUploadedCsvFilePath')->will($this->returnValue(false));
+        $oView->expects($this->once())->method('_getCsvFirstRow')->will($this->returnValue([1, 2, 3]));
         $this->assertEquals([2 => 'Column 1', 3 => 'Column 2', 4 => 'Column 3'], $oView->UNITgetCsvFieldsNames());
     }
 
@@ -130,9 +130,9 @@ class GenImportMainTest extends \OxidTestCase
     {
         $this->setRequestParameter('blContainsHeader', true);
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\GenericImportMain::class, ['getUploadedCsvFilePath', 'getCsvFirstRow']);
-        $oView->expects($this->once())->method('getUploadedCsvFilePath')->will($this->returnValue(false));
-        $oView->expects($this->once())->method('getCsvFirstRow')->will($this->returnValue([1, 2, 3]));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\GenericImportMain::class, ['_getUploadedCsvFilePath', '_getCsvFirstRow']);
+        $oView->expects($this->once())->method('_getUploadedCsvFilePath')->will($this->returnValue(false));
+        $oView->expects($this->once())->method('_getCsvFirstRow')->will($this->returnValue([1, 2, 3]));
         $this->assertEquals([1, 2, 3], $oView->UNITgetCsvFieldsNames());
     }
 
@@ -150,10 +150,10 @@ class GenImportMainTest extends \OxidTestCase
         fclose($rFile);
 
         // testing..
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\GenericImportMain::class, ['getCsvFieldsTerminator', 'getCsvFieldsEncloser', 'getUploadedCsvFilePath']);
-        $oView->expects($this->once())->method('getCsvFieldsTerminator')->will($this->returnValue(';'));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\GenericImportMain::class, ['_getCsvFieldsTerminator', 'getCsvFieldsEncloser', '_getUploadedCsvFilePath']);
+        $oView->expects($this->once())->method('_getCsvFieldsTerminator')->will($this->returnValue(';'));
         $oView->expects($this->once())->method('getCsvFieldsEncloser')->will($this->returnValue('"'));
-        $oView->expects($this->once())->method('getUploadedCsvFilePath')->will($this->returnValue($sFilePath));
+        $oView->expects($this->once())->method('_getUploadedCsvFilePath')->will($this->returnValue($sFilePath));
         $this->assertEquals(['test1', 'test2', 'test3'], $oView->UNITgetCsvFirstRow());
     }
 
@@ -188,8 +188,8 @@ class GenImportMainTest extends \OxidTestCase
         // defining parameters
         $iNavStep = 2;
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\GenericImportMain::class, ['getUploadedCsvFilePath']);
-        $oView->expects($this->once())->method('getUploadedCsvFilePath')->will($this->returnValue(false));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\GenericImportMain::class, ['_getUploadedCsvFilePath']);
+        $oView->expects($this->once())->method('_getUploadedCsvFilePath')->will($this->returnValue(false));
         $this->assertEquals(1, $oView->UNITcheckErrors($iNavStep));
     }
 

--- a/tests/Unit/Application/Controller/Admin/LanguageMainTest.php
+++ b/tests/Unit/Application/Controller/Admin/LanguageMainTest.php
@@ -68,9 +68,9 @@ class LanguageMainTest extends \OxidTestCase
 
         $this->getConfig()->setConfigParam('blAllowSharedEdit', true);
 
-        $oMainLang = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\LanguageMain::class, ['validateInput', 'getLanguages'], [], '', false);
-        $oMainLang->expects($this->once())->method('getLanguages')->will($this->returnValue($aDefaultLangData));
-        $oMainLang->expects($this->once())->method('validateInput')->will($this->returnValue(true));
+        $oMainLang = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\LanguageMain::class, ['_validateInput', '_getLanguages'], [], '', false);
+        $oMainLang->expects($this->once())->method('_getLanguages')->will($this->returnValue($aDefaultLangData));
+        $oMainLang->expects($this->once())->method('_validateInput')->will($this->returnValue(true));
 
         $oMainLang->save();
     }
@@ -101,11 +101,11 @@ class LanguageMainTest extends \OxidTestCase
 
         $this->getConfig()->setConfigParam('blAllowSharedEdit', true);
 
-        $oMainLang = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\LanguageMain::class, ['validateInput', 'checkMultilangFieldsExistsInDb', 'addNewMultilangFieldsToDb', 'getLanguages'], [], '', false);
-        $oMainLang->expects($this->once())->method('getLanguages')->will($this->returnValue($aLangData));
-        $oMainLang->expects($this->once())->method('validateInput')->will($this->returnValue(true));
-        $oMainLang->expects($this->once())->method('checkMultilangFieldsExistsInDb')->with($this->equalTo('fr'))->will($this->returnValue(false));
-        $oMainLang->expects($this->once())->method('addNewMultilangFieldsToDb');
+        $oMainLang = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\LanguageMain::class, ['_validateInput', '_checkMultilangFieldsExistsInDb', '_addNewMultilangFieldsToDb', '_getLanguages'], [], '', false);
+        $oMainLang->expects($this->once())->method('_getLanguages')->will($this->returnValue($aLangData));
+        $oMainLang->expects($this->once())->method('_validateInput')->will($this->returnValue(true));
+        $oMainLang->expects($this->once())->method('_checkMultilangFieldsExistsInDb')->with($this->equalTo('fr'))->will($this->returnValue(false));
+        $oMainLang->expects($this->once())->method('_addNewMultilangFieldsToDb');
 
         $oMainLang->save();
     }
@@ -407,8 +407,8 @@ class LanguageMainTest extends \OxidTestCase
         $this->setRequestParameter('oxid', '-1');
         $this->setRequestParameter('editval', ['abbr' => 'en']);
 
-        $oMainLang = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\LanguageMain::class, ['checkLangExists']);
-        $oMainLang->expects($this->once())->method('checkLangExists')->with($this->equalTo('en'))->will($this->returnValue(true));
+        $oMainLang = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\LanguageMain::class, ['_checkLangExists']);
+        $oMainLang->expects($this->once())->method('_checkLangExists')->with($this->equalTo('en'))->will($this->returnValue(true));
 
         $this->assertFalse($oMainLang->UNITvalidateInput());
 
@@ -468,8 +468,8 @@ class LanguageMainTest extends \OxidTestCase
         $this->setRequestParameter('oxid', '-1');
         $this->setRequestParameter('editval', ['abbr' => 'ch-xx']);
 
-        $mainLanguage = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\LanguageMain::class, ['checkLangExists']);
-        $mainLanguage->expects($this->once())->method('checkLangExists')->with($this->equalTo('ch-xx'))->will($this->returnValue(false));
+        $mainLanguage = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\LanguageMain::class, ['_checkLangExists']);
+        $mainLanguage->expects($this->once())->method('_checkLangExists')->with($this->equalTo('ch-xx'))->will($this->returnValue(false));
 
         $this->assertFalse($mainLanguage->UNITvalidateInput());
 

--- a/tests/Unit/Application/Controller/Admin/ListUserTest.php
+++ b/tests/Unit/Application/Controller/Admin/ListUserTest.php
@@ -36,8 +36,8 @@ class ListUserTest extends \OxidTestCase
     public function testGetViewListSize()
     {
         // Production calls getUserDefListSize() (without underscore)
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ListUser::class, ['getUserDefListSize']);
-        $oView->expects($this->once())->method('getUserDefListSize')->will($this->returnValue(999));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ListUser::class, ['_getUserDefListSize']);
+        $oView->expects($this->once())->method('_getUserDefListSize')->will($this->returnValue(999));
         $this->assertEquals(999, $oView->UNITgetViewListSize());
     }
 

--- a/tests/Unit/Application/Controller/Admin/LoginTest.php
+++ b/tests/Unit/Application/Controller/Admin/LoginTest.php
@@ -160,8 +160,8 @@ class LoginTest extends \OxidTestCase
 
         $aLanguages[] = $oLang;
 
-        $oLogin = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\LoginController::class, ['getBrowserLanguage']);
-        $oLogin->expects($this->once())->method('getBrowserLanguage')->will($this->returnValue('de'));
+        $oLogin = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\LoginController::class, ['_getBrowserLanguage']);
+        $oLogin->expects($this->once())->method('_getBrowserLanguage')->will($this->returnValue('de'));
 
         $this->assertEquals($aLanguages, $oLogin->UNITgetAvailableLanguages());
     }
@@ -193,8 +193,8 @@ class LoginTest extends \OxidTestCase
 
         $aLanguages[] = $oLang;
 
-        $oLogin = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\LoginController::class, ['getBrowserLanguage']);
-        $oLogin->expects($this->once())->method('getBrowserLanguage')->will($this->returnValue('en'));
+        $oLogin = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\LoginController::class, ['_getBrowserLanguage']);
+        $oLogin->expects($this->once())->method('_getBrowserLanguage')->will($this->returnValue('en'));
 
         $this->assertEquals($aLanguages, $oLogin->UNITgetAvailableLanguages());
     }
@@ -227,8 +227,8 @@ class LoginTest extends \OxidTestCase
         $aLanguages[] = $oLang;
 
         // browser lang does not affect selected lang when cookie is set
-        $oLogin = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\LoginController::class, ['getBrowserLanguage']);
-        $oLogin->expects($this->once())->method('getBrowserLanguage')->will($this->returnValue('en'));
+        $oLogin = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\LoginController::class, ['_getBrowserLanguage']);
+        $oLogin->expects($this->once())->method('_getBrowserLanguage')->will($this->returnValue('en'));
 
         // DE lang id
         $_COOKIE['oxidadminlanguage'] = 0;
@@ -340,10 +340,10 @@ class LoginTest extends \OxidTestCase
 
         $this->getConfig()->setConfigParam('blDemoShop', true);
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\LoginController::class, ['getViewConfig', 'addTplParam', 'getAvailableLanguages'], [], '', false);
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\LoginController::class, ['getViewConfig', 'addTplParam', '_getAvailableLanguages'], [], '', false);
         $oView->expects($this->atLeastOnce())->method('getViewConfig')->will($this->returnValue($oViewConfig));
         $oView->expects($this->atLeastOnce())->method('addTplParam');
-        $oView->expects($this->once())->method('getAvailableLanguages')->will($this->returnValue($aLanguages));
+        $oView->expects($this->once())->method('_getAvailableLanguages')->will($this->returnValue($aLanguages));
 
         $this->assertEquals('login.tpl', $oView->render());
     }

--- a/tests/Unit/Application/Controller/Admin/ManufacturerMainAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/ManufacturerMainAjaxTest.php
@@ -207,8 +207,8 @@ class ManufacturerMainAjaxTest extends \OxidTestCase
      */
     public function testRemoveManufacturer()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ManufacturerMainAjax::class, ['getActionIds', 'resetCounter']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testArticle1', '_testArticle2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ManufacturerMainAjax::class, ['_getActionIds', 'resetCounter']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testArticle1', '_testArticle2']));
         $oView->expects($this->once())->method('resetCounter')->with($this->equalTo('manufacturerArticle'));
         $this->assertEquals(2, oxDb::getDb()->getOne('select count(oxid) from ' . $this->getArticleViewTable() . " where oxmanufacturerid in('_testRemove1', '_testRemove2')"));
         $oView->removeManufacturer();
@@ -244,8 +244,8 @@ class ManufacturerMainAjaxTest extends \OxidTestCase
         $sSynchoxid = '_testAddManufacturer';
         $this->setRequestParameter('synchoxid', $sSynchoxid);
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ManufacturerMainAjax::class, ['getActionIds', 'resetCounter']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testArticle1', '_testArticle2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\ManufacturerMainAjax::class, ['_getActionIds', 'resetCounter']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testArticle1', '_testArticle2']));
         $oView->expects($this->once())->method('resetCounter')->with($this->equalTo('manufacturerArticle'));
 
         $this->assertEquals(0, oxDb::getDb()->getOne('select count(oxid) from ' . $this->getArticleViewTable() . " where oxmanufacturerid = '" . $sSynchoxid . "'"));

--- a/tests/Unit/Application/Controller/Admin/NavigationTest.php
+++ b/tests/Unit/Application/Controller/Admin/NavigationTest.php
@@ -92,9 +92,9 @@ class NavigationTest extends \OxidTestCase
         $oNavigation->expects($this->any())->method('getListNodes')->will($this->returnValue('testNodes'));
 
         // testing..
-        $oView = $this->getMock(NavigationController::class, ['getNavigation', 'doStartUpChecks']);
+        $oView = $this->getMock(NavigationController::class, ['getNavigation', '_doStartUpChecks']);
         $oView->expects($this->once())->method('getNavigation')->will($this->returnValue($oNavigation));
-        $oView->expects($this->once())->method('doStartUpChecks')->will($this->returnValue('check'));
+        $oView->expects($this->once())->method('_doStartUpChecks')->will($this->returnValue('check'));
         $this->assertEquals('home.tpl', $oView->render());
 
         // checking vew data
@@ -128,9 +128,9 @@ class NavigationTest extends \OxidTestCase
         $oNavigation->expects($this->any())->method('getListNodes')->will($this->returnValue('testNodes'));
 
         // testing..
-        $oView = $this->getMock(NavigationController::class, ['getNavigation', 'doStartUpChecks']);
+        $oView = $this->getMock(NavigationController::class, ['getNavigation', '_doStartUpChecks']);
         $oView->expects($this->once())->method('getNavigation')->will($this->returnValue($oNavigation));
-        $oView->expects($this->never())->method('doStartUpChecks')->will($this->returnValue('check'));
+        $oView->expects($this->never())->method('_doStartUpChecks')->will($this->returnValue('check'));
         $this->assertEquals('home.tpl', $oView->render());
 
         // checking vew data

--- a/tests/Unit/Application/Controller/Admin/NavigationTreeTest.php
+++ b/tests/Unit/Application/Controller/Admin/NavigationTreeTest.php
@@ -160,15 +160,20 @@ class NavigationTreeTest extends \OxidTestCase
      */
     public function testGetDomXml()
     {
-        $aTestMethods = ['getInitialDom', 'checkGroups', 'checkRights', 'checkDemoShopDenials', 'cleanEmptyParents', 'removeInvisibleMenuNodes'];
+        // Post-#107 call-site sweep: getDomXml() now calls the underscore form
+        // for helper methods on correctly-directioned shim pairs
+        // (_checkGroups / _checkRights / _checkDemoShopDenials / _cleanEmptyParents
+        // / _removeInvisibleMenuNodes). getInitialDom is preserved as bare form
+        // because its shim pair is inverted (impl on the public name).
+        $aTestMethods = ['getInitialDom', '_checkGroups', '_checkRights', '_checkDemoShopDenials', '_cleanEmptyParents', 'removeInvisibleMenuNodes'];
 
         $oNavTree = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NavigationTree::class, $aTestMethods);
         $oNavTree->expects($this->once())->method('getInitialDom')->will($this->returnValue(new stdClass()));
-        $oNavTree->expects($this->once())->method('checkGroups');
-        $oNavTree->expects($this->once())->method('checkRights');
-        $oNavTree->expects($this->once())->method('checkDemoShopDenials');
+        $oNavTree->expects($this->once())->method('_checkGroups');
+        $oNavTree->expects($this->once())->method('_checkRights');
+        $oNavTree->expects($this->once())->method('_checkDemoShopDenials');
         $oNavTree->expects($this->once())->method('removeInvisibleMenuNodes');
-        $oNavTree->expects($this->exactly(2))->method('cleanEmptyParents');
+        $oNavTree->expects($this->exactly(2))->method('_cleanEmptyParents');
 
         $oNavTree->getDomXml();
     }
@@ -1061,8 +1066,8 @@ class NavigationTreeTest extends \OxidTestCase
         $oDomElemFrom = new stdClass();
         $oDomElemFrom->childNodes = [$oNode1, $oNode2];
 
-        $oTree = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NavigationTree::class, ['copyAttributes']);
-        $oTree->expects($this->once())->method('copyAttributes');
+        $oTree = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NavigationTree::class, ['_copyAttributes']);
+        $oTree->expects($this->once())->method('_copyAttributes');
         $oTree->UNITmergeNodes($oDomElemTo, $oDomElemFrom, $oXPathTo, $oDomDocTo, $sQueryStart);
     }
 

--- a/tests/Unit/Application/Controller/Admin/NewsMainAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/NewsMainAjaxTest.php
@@ -127,8 +127,8 @@ class NewsMainAjaxTest extends \OxidTestCase
      */
     public function testRemoveGroupFromNews()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NewsMainAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testPayRemove1', '_testPayRemove2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NewsMainAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testPayRemove1', '_testPayRemove2']));
 
         $sSql = "select count(oxid) from oxobject2group where oxid in ('_testPayRemove1', '_testPayRemove2')";
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -167,8 +167,8 @@ class NewsMainAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2group where oxobjectid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NewsMainAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testGroupAdd1', '_testGroupAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NewsMainAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testGroupAdd1', '_testGroupAdd2']));
 
         $oView->addGroupToNews();
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -191,8 +191,8 @@ class NewsMainAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2group where oxobjectid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NewsMainAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testGroupAdd1', '_testGroupAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NewsMainAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testGroupAdd1', '_testGroupAdd2']));
 
         $oView->addGroupToNews();
         $this->assertEquals($iCount, oxDb::getDb()->getOne($sSql));

--- a/tests/Unit/Application/Controller/Admin/NewsletterSelectionAjaxTest.php
+++ b/tests/Unit/Application/Controller/Admin/NewsletterSelectionAjaxTest.php
@@ -139,8 +139,8 @@ class NewsletterSelectionAjaxTest extends \OxidTestCase
      */
     public function testRemoveGroupFromNewsletter()
     {
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NewsletterSelectionAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testGroupRemove1', '_testGroupRemove2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NewsletterSelectionAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testGroupRemove1', '_testGroupRemove2']));
 
         $sSql = "select count(oxid) from oxobject2group where oxid in ('_testGroupRemove1', '_testGroupRemove2')";
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -179,8 +179,8 @@ class NewsletterSelectionAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2group where oxobjectid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NewsletterSelectionAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testGroupAdd1', '_testGroupAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NewsletterSelectionAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testGroupAdd1', '_testGroupAdd2']));
 
         $oView->addGroupToNewsletter();
         $this->assertEquals(2, oxDb::getDb()->getOne($sSql));
@@ -203,8 +203,8 @@ class NewsletterSelectionAjaxTest extends \OxidTestCase
         $sSql = "select count(oxid) from oxobject2group where oxobjectid='$sSynchoxid'";
         $this->assertEquals(0, oxDb::getDb()->getOne($sSql));
 
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NewsletterSelectionAjax::class, ['getActionIds']);
-        $oView->expects($this->any())->method('getActionIds')->will($this->returnValue(['_testGroupAdd1', '_testGroupAdd2']));
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NewsletterSelectionAjax::class, ['_getActionIds']);
+        $oView->expects($this->any())->method('_getActionIds')->will($this->returnValue(['_testGroupAdd1', '_testGroupAdd2']));
 
         $oView->addGroupToNewsletter();
         $this->assertEquals($iCount, oxDb::getDb()->getOne($sSql));

--- a/tests/Unit/Application/Controller/Admin/NewsletterSendTest.php
+++ b/tests/Unit/Application/Controller/Admin/NewsletterSendTest.php
@@ -85,8 +85,8 @@ class NewsletterSendTest extends \OxidTestCase
         $oNewsSubscribed->save();
 
         // testing..
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NewsletterSend::class, ['setupNavigation']);
-        $oView->expects($this->once())->method('setupNavigation');
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NewsletterSend::class, ['_setupNavigation']);
+        $oView->expects($this->once())->method('_setupNavigation');
         $this->assertEquals('newsletter_send.tpl', $oView->render());
 
         $aViewData = $oView->getViewData();
@@ -124,8 +124,8 @@ class NewsletterSendTest extends \OxidTestCase
         $oNewsSubscribed->save();
 
         // testing..
-        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NewsletterSend::class, ['setupNavigation', 'getUserCount']);
-        $oView->expects($this->exactly(2))->method('setupNavigation');
+        $oView = $this->getMock(\OxidEsales\Eshop\Application\Controller\Admin\NewsletterSend::class, ['_setupNavigation', 'getUserCount']);
+        $oView->expects($this->exactly(2))->method('_setupNavigation');
         $oView->expects($this->exactly(2))->method('getUserCount')->will($this->returnValue(2));
         $this->assertEquals('newsletter_send.tpl', $oView->render());
 

--- a/tests/Unit/Application/Controller/CmpBasketTest.php
+++ b/tests/Unit/Application/Controller/CmpBasketTest.php
@@ -30,8 +30,8 @@ class CmpBasketTest extends \OxidTestCase
     public function testToBasketReturnsNull()
     {
         /** @var oxcmp_basket|PHPUnit\Framework\MockObject\MockObject $o */
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\BasketComponent::class, ['getItems']);
-        $o->expects($this->once())->method('getItems')->will($this->returnValue(false));
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\BasketComponent::class, ['_getItems']);
+        $o->expects($this->once())->method('_getItems')->will($this->returnValue(false));
 
         oxTestModules::addFunction('oxUtils', 'isSearchEngine', '{return true;}');
         $this->assertSame(null, $o->tobasket());
@@ -61,9 +61,9 @@ class CmpBasketTest extends \OxidTestCase
         $oBItem->expects($this->once())->method('getdBundledAmount')->will($this->returnValue('ret:getdBundledAmount'));
 
         /** @var oxcmp_basket|PHPUnit\Framework\MockObject\MockObject $o */
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\BasketComponent::class, ['getItems', 'setLastCallFnc', '_addItems']);
-        $o->expects($this->once())->method('getItems')->will($this->returnValue($aProducts));
-        $o->expects($this->once())->method('setLastCallFnc')->with($this->equalTo('tobasket'))->will($this->returnValue(null));
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\BasketComponent::class, ['_getItems', '_setLastCallFnc', '_addItems']);
+        $o->expects($this->once())->method('_getItems')->will($this->returnValue($aProducts));
+        $o->expects($this->once())->method('_setLastCallFnc')->with($this->equalTo('tobasket'))->will($this->returnValue(null));
         $o->expects($this->once())->method('_addItems')->with($this->equalTo($aProducts))->will($this->returnValue($oBItem));
 
         $this->assertEquals('start?', $o->tobasket());
@@ -98,11 +98,11 @@ class CmpBasketTest extends \OxidTestCase
         $oBItem->expects($this->never())->method('getdBundledAmount')->will($this->returnValue('ret:getdBundledAmount'));
 
         /** @var oxcmp_basket|PHPUnit\Framework\MockObject\MockObject $o */
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\BasketComponent::class, ['getItems', 'setLastCallFnc', '_addItems', 'getRedirectUrl']);
-        $o->expects($this->once())->method('getItems')->will($this->returnValue($aProducts));
-        $o->expects($this->once())->method('setLastCallFnc')->with($this->equalTo('tobasket'))->will($this->returnValue(null));
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\BasketComponent::class, ['_getItems', '_setLastCallFnc', '_addItems', '_getRedirectUrl']);
+        $o->expects($this->once())->method('_getItems')->will($this->returnValue($aProducts));
+        $o->expects($this->once())->method('_setLastCallFnc')->with($this->equalTo('tobasket'))->will($this->returnValue(null));
         $o->expects($this->once())->method('_addItems')->with($this->equalTo($aProducts))->will($this->returnValue($oBItem));
-        $o->expects($this->once())->method('getRedirectUrl')->will($this->returnValue('new url'));
+        $o->expects($this->once())->method('_getRedirectUrl')->will($this->returnValue('new url'));
 
         $this->assertEquals('new url', $o->tobasket());
 
@@ -124,8 +124,8 @@ class CmpBasketTest extends \OxidTestCase
     {
         $this->prepareSessionChallengeToken();
 
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\BasketComponent::class, ['getItems', 'getSession']);
-        $o->expects($this->once())->method('getItems')
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\BasketComponent::class, ['_getItems', 'getSession']);
+        $o->expects($this->once())->method('_getItems')
             ->with(
                 $this->equalTo('abc'),
                 $this->equalTo(10),
@@ -161,8 +161,8 @@ class CmpBasketTest extends \OxidTestCase
         $oBItem->expects($this->never())->method('getAmount')->will($this->returnValue('ret:getAmount'));
         $oBItem->expects($this->never())->method('getdBundledAmount')->will($this->returnValue('ret:getdBundledAmount'));
 
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\BasketComponent::class, ['getItems', 'setLastCallFnc', '_addItems']);
-        $o->expects($this->once())->method('getItems')
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\BasketComponent::class, ['_getItems', '_setLastCallFnc', '_addItems']);
+        $o->expects($this->once())->method('_getItems')
             ->with(
                 $this->equalTo('abc'),
                 $this->equalTo(11),
@@ -170,7 +170,7 @@ class CmpBasketTest extends \OxidTestCase
                 $this->equalTo('persparam'),
                 $this->equalTo('override')
             )->will($this->returnValue($aProducts));
-        $o->expects($this->once())->method('setLastCallFnc')->with($this->equalTo('changebasket'))->will($this->returnValue(null));
+        $o->expects($this->once())->method('_setLastCallFnc')->with($this->equalTo('changebasket'))->will($this->returnValue(null));
         $o->expects($this->once())->method('_addItems')->with($this->equalTo($aProducts))->will($this->returnValue($oBItem));
 
         $this->assertSame(null, $o->changebasket('abc', 11, 'sel', 'persparam', 'override'));
@@ -186,8 +186,8 @@ class CmpBasketTest extends \OxidTestCase
         $oBasket->expects($this->once())->method('getContents')->will($this->returnValue(['b:bindex' => $oArt]));
         \OxidEsales\Eshop\Core\Registry::getSession()->setBasket($oBasket);
 
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\BasketComponent::class, ['getItems']);
-        $o->expects($this->once())->method('getItems')
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\BasketComponent::class, ['_getItems']);
+        $o->expects($this->once())->method('_getItems')
             ->with(
                 $this->equalTo('b:artid'),
                 $this->equalTo('b:am'),
@@ -207,8 +207,8 @@ class CmpBasketTest extends \OxidTestCase
     {
         $this->prepareSessionChallengeToken();
 
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\BasketComponent::class, ['getItems', 'getSession']);
-        $o->expects($this->once())->method('getItems')
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\BasketComponent::class, ['_getItems', 'getSession']);
+        $o->expects($this->once())->method('_getItems')
             ->with(
                 $this->equalTo('b:artid'),
                 $this->equalTo('b:am'),
@@ -581,8 +581,8 @@ class CmpBasketTest extends \OxidTestCase
         $oBasket->expects($this->any())->method('getBasketSummary')->will($this->returnValue($aBasketInfo));
         \OxidEsales\Eshop\Core\Registry::getSession()->setBasket($oBasket);
 
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\BasketComponent::class, ['getLastCallFnc']);
-        $o->expects($this->any())->method('getLastCallFnc')->will($this->returnValue('tobasket'));
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\BasketComponent::class, ['_getLastCallFnc']);
+        $o->expects($this->any())->method('_getLastCallFnc')->will($this->returnValue('tobasket'));
 
         $this->assertEquals(
             null,

--- a/tests/Unit/Application/Controller/CmpCategoriesTest.php
+++ b/tests/Unit/Application/Controller/CmpCategoriesTest.php
@@ -46,8 +46,8 @@ class CmpCategoriesTest extends \OxidTestCase
         $oCfg->expects($this->once())->method('getTopActiveView')->will($this->returnValue($oActView));
         \OxidEsales\Eshop\Core\Registry::set(\OxidEsales\Eshop\Core\Config::class, $oCfg);
 
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['getActCat']);
-        $o->expects($this->never())->method('getActCat');
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['_getActCat']);
+        $o->expects($this->never())->method('_getActCat');
 
         $o->init();
     }
@@ -56,8 +56,8 @@ class CmpCategoriesTest extends \OxidTestCase
     {
         $this->getConfig()->setConfigParam('blDisableNavBars', false);
 
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['getActCat']);
-        $o->expects($this->once())->method('getActCat')->will($this->throwException(new Exception('passed: OK')));
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['_getActCat']);
+        $o->expects($this->once())->method('_getActCat')->will($this->throwException(new Exception('passed: OK')));
 
         try {
             $o->init();
@@ -79,8 +79,8 @@ class CmpCategoriesTest extends \OxidTestCase
         $oCfg->expects($this->once())->method('getTopActiveView')->will($this->returnValue($oActView));
         \OxidEsales\Eshop\Core\Registry::set(\OxidEsales\Eshop\Core\Config::class, $oCfg);
 
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['getActCat']);
-        $o->expects($this->once())->method('getActCat')->will($this->throwException(new Exception('passed: OK')));
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['_getActCat']);
+        $o->expects($this->once())->method('_getActCat')->will($this->throwException(new Exception('passed: OK')));
 
         try {
             $o->init();
@@ -103,9 +103,9 @@ class CmpCategoriesTest extends \OxidTestCase
         $oCfg->expects($this->once())->method('getTopActiveView')->will($this->returnValue($oActView));
         \OxidEsales\Eshop\Core\Registry::set(\OxidEsales\Eshop\Core\Config::class, $oCfg);
 
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['getActCat', 'loadManufacturerTree']);
-        $o->expects($this->once())->method('getActCat')->will($this->returnValue('actcat..'));
-        $o->expects($this->once())->method('loadManufacturerTree')->with($this->equalTo('manid'))->will($this->throwException(new Exception('passed: OK')));
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['_getActCat', '_loadManufacturerTree']);
+        $o->expects($this->once())->method('_getActCat')->will($this->returnValue('actcat..'));
+        $o->expects($this->once())->method('_loadManufacturerTree')->with($this->equalTo('manid'))->will($this->throwException(new Exception('passed: OK')));
 
         $this->setRequestParameter('mnid', 'manid');
         try {
@@ -129,10 +129,10 @@ class CmpCategoriesTest extends \OxidTestCase
         $oCfg->expects($this->once())->method('getTopActiveView')->will($this->returnValue($oActView));
         \OxidEsales\Eshop\Core\Registry::set(\OxidEsales\Eshop\Core\Config::class, $oCfg);
 
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['getActCat', 'loadManufacturerTree', 'loadCategoryTree']);
-        $o->expects($this->once())->method('getActCat')->will($this->returnValue('actcat..'));
-        $o->expects($this->any())->method('loadManufacturerTree');
-        $o->expects($this->once())->method('loadCategoryTree')->with($this->equalTo('actcat..'))->will($this->throwException(new Exception('passed: OK')));
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['_getActCat', '_loadManufacturerTree', '_loadCategoryTree']);
+        $o->expects($this->once())->method('_getActCat')->will($this->returnValue('actcat..'));
+        $o->expects($this->any())->method('_loadManufacturerTree');
+        $o->expects($this->once())->method('_loadCategoryTree')->with($this->equalTo('actcat..'))->will($this->throwException(new Exception('passed: OK')));
 
         try {
             $o->init();
@@ -155,10 +155,10 @@ class CmpCategoriesTest extends \OxidTestCase
         $oCfg->expects($this->once())->method('getTopActiveView')->will($this->returnValue($oActView));
         \OxidEsales\Eshop\Core\Registry::set(\OxidEsales\Eshop\Core\Config::class, $oCfg);
 
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['getActCat', 'loadManufacturerTree', 'loadCategoryTree']);
-        $o->expects($this->once())->method('getActCat')->will($this->returnValue('actcat..'));
-        $o->expects($this->any())->method('loadManufacturerTree');
-        $o->expects($this->once())->method('loadCategoryTree')->with($this->equalTo('actcat..'));
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['_getActCat', '_loadManufacturerTree', '_loadCategoryTree']);
+        $o->expects($this->once())->method('_getActCat')->will($this->returnValue('actcat..'));
+        $o->expects($this->any())->method('_loadManufacturerTree');
+        $o->expects($this->once())->method('_loadCategoryTree')->with($this->equalTo('actcat..'));
 
         $o->init();
     }
@@ -233,9 +233,9 @@ class CmpCategoriesTest extends \OxidTestCase
         $oCfg->expects($this->once())->method('getActiveShop')->will($this->returnValue($oActShop));
         \OxidEsales\Eshop\Core\Registry::set(\OxidEsales\Eshop\Core\Config::class, $oCfg);
 
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['getProduct', 'addAdditionalParams']);
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['getProduct', '_addAdditionalParams']);
         $o->expects($this->once())->method('getProduct')->will($this->returnValue(null));
-        $o->expects($this->never())->method('addAdditionalParams');
+        $o->expects($this->never())->method('_addAdditionalParams');
 
         $this->setRequestParameter('mnid', null);
         $this->setRequestParameter('cnid', null);
@@ -252,9 +252,9 @@ class CmpCategoriesTest extends \OxidTestCase
         $oCfg->expects($this->once())->method('getActiveShop')->will($this->returnValue($oActShop));
         \OxidEsales\Eshop\Core\Registry::set(\OxidEsales\Eshop\Core\Config::class, $oCfg);
 
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['getProduct', 'addAdditionalParams']);
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['getProduct', '_addAdditionalParams']);
         $o->expects($this->once())->method('getProduct')->will($this->returnValue(null));
-        $o->expects($this->never())->method('addAdditionalParams');
+        $o->expects($this->never())->method('_addAdditionalParams');
 
         $this->setRequestParameter('mnid', null);
         $this->setRequestParameter('cnid', null);
@@ -266,9 +266,9 @@ class CmpCategoriesTest extends \OxidTestCase
     {
         $this->getConfig()->setConfigParam('bl_perfLoadManufacturerTree', true);
 
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['getProduct', 'addAdditionalParams']);
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['getProduct', '_addAdditionalParams']);
         $o->expects($this->once())->method('getProduct')->will($this->returnValue('product'));
-        $o->expects($this->once())->method('addAdditionalParams')->with(
+        $o->expects($this->once())->method('_addAdditionalParams')->with(
             $this->equalTo('product'),
             $this->equalTo(null),
             $this->equalTo('mnid')
@@ -284,9 +284,9 @@ class CmpCategoriesTest extends \OxidTestCase
     {
         $this->getConfig()->setConfigParam('bl_perfLoadManufacturerTree', true);
 
-        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['getProduct', 'addAdditionalParams']);
+        $o = $this->getMock(\OxidEsales\Eshop\Application\Component\CategoriesComponent::class, ['getProduct', '_addAdditionalParams']);
         $o->expects($this->once())->method('getProduct')->will($this->returnValue('product'));
-        $o->expects($this->once())->method('addAdditionalParams')->with(
+        $o->expects($this->once())->method('_addAdditionalParams')->with(
             $this->equalTo('product'),
             $this->equalTo('cnid'),
             $this->equalTo('')

--- a/tests/Unit/Application/Controller/CmpUtilsTest.php
+++ b/tests/Unit/Application/Controller/CmpUtilsTest.php
@@ -171,8 +171,8 @@ class CmpUtilsTest extends \OxidTestCase
         \OxidEsales\Eshop\Core\Registry::set(\OxidEsales\Eshop\Core\Session::class, $oSession);
 
         /** @var oxcmp_utils|PHPUnit\Framework\MockObject\MockObject $oCmp */
-        $oCmp = $this->getMock(\OxidEsales\Eshop\Application\Component\UtilsComponent::class, ['toList']);
-        $oCmp->expects($this->once())->method('toList')->with($this->equalTo('noticelist'), $this->equalTo('1126'), $this->equalTo(999), $this->equalTo('sel'));
+        $oCmp = $this->getMock(\OxidEsales\Eshop\Application\Component\UtilsComponent::class, ['_toList']);
+        $oCmp->expects($this->once())->method('_toList')->with($this->equalTo('noticelist'), $this->equalTo('1126'), $this->equalTo(999), $this->equalTo('sel'));
         $oCmp->toNoticeList('1126', 999, 'sel');
     }
 
@@ -191,15 +191,15 @@ class CmpUtilsTest extends \OxidTestCase
         $this->getConfig()->setConfigParam('bl_showWishlist', false);
 
         /** @var oxcmp_utils|PHPUnit\Framework\MockObject\MockObject $oCmp */
-        $oCmp = $this->getMock(\OxidEsales\Eshop\Application\Component\UtilsComponent::class, ['toList']);
-        $oCmp->expects($this->never())->method('toList');
+        $oCmp = $this->getMock(\OxidEsales\Eshop\Application\Component\UtilsComponent::class, ['_toList']);
+        $oCmp->expects($this->never())->method('_toList');
         $oCmp->toWishList('1126', 999, 'sel');
 
         $this->getConfig()->setConfigParam('bl_showWishlist', true);
 
         /** @var oxcmp_utils|PHPUnit\Framework\MockObject\MockObject $oCmp */
-        $oCmp = $this->getMock(\OxidEsales\Eshop\Application\Component\UtilsComponent::class, ['toList']);
-        $oCmp->expects($this->once())->method('toList')->with($this->equalTo('wishlist'), $this->equalTo('1126'), $this->equalTo(999), $this->equalTo('sel'));
+        $oCmp = $this->getMock(\OxidEsales\Eshop\Application\Component\UtilsComponent::class, ['_toList']);
+        $oCmp->expects($this->once())->method('_toList')->with($this->equalTo('wishlist'), $this->equalTo('1126'), $this->equalTo(999), $this->equalTo('sel'));
         $oCmp->toWishList('1126', 999, 'sel');
     }
 

--- a/tests/Unit/Application/Controller/RssTest.php
+++ b/tests/Unit/Application/Controller/RssTest.php
@@ -111,8 +111,8 @@ class RssTest extends \OxidTestCase
         $oRssFeed = $this->getMock(\OxidEsales\Eshop\Application\Model\RssFeed::class, ['loadTopInShop']);
         $oRssFeed->expects($this->once())->method('loadTopInShop');
 
-        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['getRssFeed']);
-        $oRss->expects($this->once())->method('getRssFeed')->will($this->returnValue($oRssFeed));
+        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['_getRssFeed']);
+        $oRss->expects($this->once())->method('_getRssFeed')->will($this->returnValue($oRssFeed));
 
         $oRss->topshop();
     }
@@ -140,8 +140,8 @@ class RssTest extends \OxidTestCase
         $oRssFeed = $this->getMock(\OxidEsales\Eshop\Application\Model\RssFeed::class, ['loadNewestArticles']);
         $oRssFeed->expects($this->once())->method('loadNewestArticles');
 
-        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['getRssFeed']);
-        $oRss->expects($this->once())->method('getRssFeed')->will($this->returnValue($oRssFeed));
+        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['_getRssFeed']);
+        $oRss->expects($this->once())->method('_getRssFeed')->will($this->returnValue($oRssFeed));
 
         $oRss->newarts();
     }
@@ -179,8 +179,8 @@ class RssTest extends \OxidTestCase
             $this->equalTo('x&amp;searchmanufacturer')
         );
 
-        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['getRssFeed']);
-        $oRss->expects($this->once())->method('getRssFeed')->will($this->returnValue($oRssFeed));
+        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['_getRssFeed']);
+        $oRss->expects($this->once())->method('_getRssFeed')->will($this->returnValue($oRssFeed));
 
         $oRss->searcharts();
     }
@@ -208,8 +208,8 @@ class RssTest extends \OxidTestCase
         $oRssFeed = $this->getMock(\OxidEsales\Eshop\Application\Model\RssFeed::class, ['loadBargain']);
         $oRssFeed->expects($this->once())->method('loadBargain');
 
-        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['getRssFeed']);
-        $oRss->expects($this->once())->method('getRssFeed')->will($this->returnValue($oRssFeed));
+        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['_getRssFeed']);
+        $oRss->expects($this->once())->method('_getRssFeed')->will($this->returnValue($oRssFeed));
 
         $oRss->bargain();
     }
@@ -240,8 +240,8 @@ class RssTest extends \OxidTestCase
         $oRssFeed = $this->getMock(\OxidEsales\Eshop\Application\Model\RssFeed::class, ['loadCategoryArticles']);
         $oRssFeed->expects($this->once())->method('loadCategoryArticles')->with($this->equalTo($oObj));
 
-        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['getRssFeed']);
-        $oRss->expects($this->once())->method('getRssFeed')->will($this->returnValue($oRssFeed));
+        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['_getRssFeed']);
+        $oRss->expects($this->once())->method('_getRssFeed')->will($this->returnValue($oRssFeed));
 
         $this->setRequestParameter('cat', 'x&objid');
         oxTestModules::addModuleObject('oxCategory', $oObj);
@@ -276,8 +276,8 @@ class RssTest extends \OxidTestCase
         $oRssFeed = $this->getMock(\OxidEsales\Eshop\Application\Model\RssFeed::class, ['loadRecommLists']);
         $oRssFeed->expects($this->once())->method('loadRecommLists')->with($this->equalTo($oObj));
 
-        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['getRssFeed']);
-        $oRss->expects($this->once())->method('getRssFeed')->will($this->returnValue($oRssFeed));
+        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['_getRssFeed']);
+        $oRss->expects($this->once())->method('_getRssFeed')->will($this->returnValue($oRssFeed));
 
         $this->setRequestParameter('anid', 'x&objid');
         oxTestModules::addModuleObject('oxarticle', $oObj);
@@ -311,8 +311,8 @@ class RssTest extends \OxidTestCase
         $oRssFeed = $this->getMock(\OxidEsales\Eshop\Application\Model\RssFeed::class, ['loadRecommListArticles']);
         $oRssFeed->expects($this->once())->method('loadRecommListArticles')->with($this->equalTo($oObj));
 
-        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['getRssFeed']);
-        $oRss->expects($this->once())->method('getRssFeed')->will($this->returnValue($oRssFeed));
+        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['_getRssFeed']);
+        $oRss->expects($this->once())->method('_getRssFeed')->will($this->returnValue($oRssFeed));
 
         $this->setRequestParameter('recommid', 'x&objid');
         oxTestModules::addModuleObject('oxrecommlist', $oObj);
@@ -331,8 +331,8 @@ class RssTest extends \OxidTestCase
         $oUtils->expects($this->once())->method('handlePageNotFoundError');
         oxTestModules::addModuleObject('oxutils', $oUtils);
 
-        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['getRssFeed']);
-        $oRss->expects($this->never())->method('getRssFeed');
+        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['_getRssFeed']);
+        $oRss->expects($this->never())->method('_getRssFeed');
 
         $this->setRequestParameter('recommid', 'x&objid');
         oxTestModules::addModuleObject('oxrecommlist', $oObj);
@@ -352,8 +352,8 @@ class RssTest extends \OxidTestCase
         $oUtils->expects($this->once())->method('handlePageNotFoundError');
         oxTestModules::addModuleObject('oxutils', $oUtils);
 
-        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['getRssFeed']);
-        $oRss->expects($this->never())->method('getRssFeed');
+        $oRss = $this->getMock(\OxidEsales\Eshop\Application\Controller\RssController::class, ['_getRssFeed']);
+        $oRss->expects($this->never())->method('_getRssFeed');
 
         $this->setRequestParameter('anid', 'x&objid');
         oxTestModules::addModuleObject('oxarticle', $oObj);

--- a/tests/Unit/BackwardsCompatibility/InternalShimCallSitesTest.php
+++ b/tests/Unit/BackwardsCompatibility/InternalShimCallSitesTest.php
@@ -1,0 +1,202 @@
+<?php
+
+/**
+ * This file is part of O3-Shop.
+ *
+ * O3-Shop is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, version 3.
+ *
+ * Convention-enforcement test for internal call sites of BC-shim methods.
+ *
+ * For every (Class, _method) entry in the pinned inventory, the test asserts
+ * that no `$this->method(...)` call site exists in source/ inside a class that
+ * declares both `_method()` and `method()` — every such call SHOULD be written
+ * as `$this->_method(...)` so internal code dispatches direct to the BC anchor.
+ *
+ * Companion to InheritanceContractTest:
+ *  - InheritanceContractTest enforces the structural contract: a subclass
+ *    override of `_method()` is dispatched through every public entry point.
+ *  - This test enforces the call-site convention: internal code uses the
+ *    underscore form so dispatch lands directly on `_method()` overrides
+ *    rather than detouring through the public delegate.
+ *
+ * A failure here is convention drift, not a correctness regression — both call
+ * forms reach a `_method()` override via virtual dispatch today. The narrowing
+ * is deliberate: the codebase commits to `_method()` as the canonical override
+ * target during the BC-shim transition. Long-term direction (#108) will invert
+ * this and promote `method()` to canonical via a template-method refactor.
+ *
+ * See:
+ *   - openspec/changes/fix-internal-shim-call-sites/proposal.md
+ *   - openspec/changes/fix-internal-shim-call-sites/design.md
+ *   - bin/find-internal-shim-call-sites.php (the detector this test runs)
+ *   - o3-shop/o3-shop#107 (call-site sweep), #108 (template-method refactor)
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\EshopCommunity\Tests\Unit\BackwardsCompatibility;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class InternalShimCallSitesTest extends TestCase
+{
+    private const INVENTORY_PATH = __DIR__ . '/underscore-method-snapshot.json';
+    private const SOURCE_ROOT = __DIR__ . '/../../../source';
+    private const FINDINGS_PATH = __DIR__
+        . '/../../../openspec/changes/fix-internal-shim-call-sites/findings.json';
+    private const DETECTOR_SCRIPT = __DIR__ . '/../../../bin/find-internal-shim-call-sites.php';
+    private const EXCLUSIONS_PATH = __DIR__ . '/internal-shim-call-sites-exclusions.json';
+
+    /**
+     * Run the detector and assert no findings remain.
+     *
+     * The detector script is the single source of truth for what constitutes a
+     * violation; this test invokes it as a subprocess so the convention is
+     * enforced identically whether a developer runs the script manually or the
+     * test runs in CI. The script writes findings to FINDINGS_PATH; if the
+     * file is non-empty after the run, the test fails with the violation list
+     * inlined into the assertion message so it shows up directly in PHPUnit
+     * output without requiring the developer to open the JSON file.
+     */
+    public function testInternalCallSitesUseUnderscoreForm(): void
+    {
+        $this->assertFileExists(
+            self::INVENTORY_PATH,
+            'Pinned baseline inventory missing — required input for the detector.'
+        );
+        $this->assertFileExists(
+            self::DETECTOR_SCRIPT,
+            'Detector script missing — bin/find-internal-shim-call-sites.php should exist.'
+        );
+
+        $repoRoot = realpath(__DIR__ . '/../../..');
+        $cmd = sprintf(
+            '%s %s --quiet --repo-root=%s --inventory=%s --source-root=%s --output=%s 2>&1',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg(self::DETECTOR_SCRIPT),
+            escapeshellarg($repoRoot),
+            escapeshellarg(realpath(self::INVENTORY_PATH)),
+            escapeshellarg(realpath(self::SOURCE_ROOT)),
+            escapeshellarg(self::FINDINGS_PATH)
+        );
+        $output = [];
+        $exitCode = 0;
+        exec($cmd, $output, $exitCode);
+
+        $this->assertSame(
+            0,
+            $exitCode,
+            sprintf(
+                "Detector exited with code %d. Output:\n%s",
+                $exitCode,
+                implode("\n", $output)
+            )
+        );
+
+        $findings = $this->loadFindings();
+        $exclusions = $this->loadExclusions();
+        $unexcluded = $this->subtractExclusions($findings, $exclusions);
+
+        $this->assertCount(
+            0,
+            $unexcluded,
+            $this->formatFindingsMessage($unexcluded)
+        );
+    }
+
+    /**
+     * @return list<array{file:string,line:int,class:string,method:string}>
+     */
+    private function loadFindings(): array
+    {
+        if (!is_file(self::FINDINGS_PATH)) {
+            return [];
+        }
+        $json = file_get_contents(self::FINDINGS_PATH);
+        if ($json === false) {
+            throw new RuntimeException('Could not read findings file at ' . self::FINDINGS_PATH);
+        }
+        $decoded = json_decode($json, true);
+        if (!is_array($decoded)) {
+            throw new RuntimeException('Findings file is not a JSON array: ' . self::FINDINGS_PATH);
+        }
+        /** @var list<array{file:string,line:int,class:string,method:string}> $decoded */
+        return $decoded;
+    }
+
+    /**
+     * @return list<array{file:string,line:int,method:string}>
+     */
+    private function loadExclusions(): array
+    {
+        if (!is_file(self::EXCLUSIONS_PATH)) {
+            return [];
+        }
+        $json = file_get_contents(self::EXCLUSIONS_PATH);
+        if ($json === false) {
+            throw new RuntimeException('Could not read exclusions at ' . self::EXCLUSIONS_PATH);
+        }
+        $decoded = json_decode($json, true);
+        if (!is_array($decoded) || !isset($decoded['exclusions']) || !is_array($decoded['exclusions'])) {
+            throw new RuntimeException(
+                'Exclusions file shape: expected {"exclusions": [...]} at ' . self::EXCLUSIONS_PATH
+            );
+        }
+        /** @var list<array{file:string,line:int,method:string}> $entries */
+        $entries = $decoded['exclusions'];
+        return $entries;
+    }
+
+    /**
+     * @param list<array{file:string,line:int,class:string,method:string}> $findings
+     * @param list<array{file:string,line:int,method:string}> $exclusions
+     * @return list<array{file:string,line:int,class:string,method:string}>
+     */
+    private function subtractExclusions(array $findings, array $exclusions): array
+    {
+        $excluded = [];
+        foreach ($exclusions as $e) {
+            $excluded[$e['file'] . '|' . $e['line'] . '|' . $e['method']] = true;
+        }
+        $remaining = [];
+        foreach ($findings as $f) {
+            $key = $f['file'] . '|' . $f['line'] . '|' . $f['method'];
+            if (!isset($excluded[$key])) {
+                $remaining[] = $f;
+            }
+        }
+        return $remaining;
+    }
+
+    /**
+     * @param list<array{file:string,line:int,class:string,method:string}> $findings
+     */
+    private function formatFindingsMessage(array $findings): string
+    {
+        $count = count($findings);
+        if ($count === 0) {
+            return '';
+        }
+        $lines = [
+            sprintf(
+                '%d internal call-site convention violation%s found.',
+                $count,
+                $count === 1 ? '' : 's'
+            ),
+            'Each entry below is a `$this->method(...)` call that SHOULD be `$this->_method(...)`:',
+            '',
+        ];
+        foreach ($findings as $f) {
+            $lines[] = sprintf('  %s:%d — %s::%s()', $f['file'], $f['line'], $f['class'], $f['method']);
+        }
+        $lines[] = '';
+        $lines[] = sprintf(
+            'Full list at %s. See bin/find-internal-shim-call-sites.php and o3-shop/o3-shop#107.',
+            ltrim(str_replace(__DIR__ . '/../../../', '', self::FINDINGS_PATH), '/')
+        );
+        return implode("\n", $lines);
+    }
+}

--- a/tests/Unit/BackwardsCompatibility/internal-shim-call-sites-exclusions.json
+++ b/tests/Unit/BackwardsCompatibility/internal-shim-call-sites-exclusions.json
@@ -1,0 +1,2506 @@
+{
+    "_meta": {
+        "_doc": "Exclusions for InternalShimCallSitesTest. Each entry is a $this->method( call site that the detector flags but is intentional / pre-existing \u2014 either authored by a trusted O3-Shop identity (Daniel) post-baseline, or never had the $this->_method( underscore form in the 2022 baseline. The gate test subtracts these from the detector's raw output. See openspec/changes/fix-internal-shim-call-sites/."
+    },
+    "exclusions": [
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 116,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "setListLocatorData",
+            "reason": "method has an inverted shim pair (\\_setListLocatorData() body delegates UP to setListLocatorData()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 132,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "loadIdsInList",
+            "reason": "method has an inverted shim pair (\\_loadIdsInList() body delegates UP to loadIdsInList()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 135,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "findActPageNumber",
+            "reason": "method has an inverted shim pair (\\_findActPageNumber() body delegates UP to findActPageNumber()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 139,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "getProductPos",
+            "reason": "method has an inverted shim pair (\\_getProductPos() body delegates UP to getProductPos()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 146,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "getPageNumber",
+            "reason": "method has an inverted shim pair (\\_getPageNumber() body delegates UP to getPageNumber()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 146,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "makeLink",
+            "reason": "method has an inverted shim pair (\\_makeLink() body delegates UP to makeLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 151,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "makeLink",
+            "reason": "method has an inverted shim pair (\\_makeLink() body delegates UP to makeLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 152,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "makeLink",
+            "reason": "method has an inverted shim pair (\\_makeLink() body delegates UP to makeLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 176,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "setVendorLocatorData",
+            "reason": "method has an inverted shim pair (\\_setVendorLocatorData() body delegates UP to setVendorLocatorData()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 201,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "findActPageNumber",
+            "reason": "method has an inverted shim pair (\\_findActPageNumber() body delegates UP to findActPageNumber()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 210,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "getProductPos",
+            "reason": "method has an inverted shim pair (\\_getProductPos() body delegates UP to getProductPos()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 215,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "getPageNumber",
+            "reason": "method has an inverted shim pair (\\_getPageNumber() body delegates UP to getPageNumber()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 215,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "makeLink",
+            "reason": "method has an inverted shim pair (\\_makeLink() body delegates UP to makeLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 220,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "makeLink",
+            "reason": "method has an inverted shim pair (\\_makeLink() body delegates UP to makeLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 221,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "makeLink",
+            "reason": "method has an inverted shim pair (\\_makeLink() body delegates UP to makeLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 237,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "setManufacturerLocatorData",
+            "reason": "method has an inverted shim pair (\\_setManufacturerLocatorData() body delegates UP to setManufacturerLocatorData()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 262,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "findActPageNumber",
+            "reason": "method has an inverted shim pair (\\_findActPageNumber() body delegates UP to findActPageNumber()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 271,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "getProductPos",
+            "reason": "method has an inverted shim pair (\\_getProductPos() body delegates UP to getProductPos()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 278,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "getPageNumber",
+            "reason": "method has an inverted shim pair (\\_getPageNumber() body delegates UP to getPageNumber()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 278,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "makeLink",
+            "reason": "method has an inverted shim pair (\\_makeLink() body delegates UP to makeLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 283,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "makeLink",
+            "reason": "method has an inverted shim pair (\\_makeLink() body delegates UP to makeLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 284,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "makeLink",
+            "reason": "method has an inverted shim pair (\\_makeLink() body delegates UP to makeLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 308,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "setSearchLocatorData",
+            "reason": "method has an inverted shim pair (\\_setSearchLocatorData() body delegates UP to setSearchLocatorData()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 342,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "findActPageNumber",
+            "reason": "method has an inverted shim pair (\\_findActPageNumber() body delegates UP to findActPageNumber()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 361,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "getProductPos",
+            "reason": "method has an inverted shim pair (\\_getProductPos() body delegates UP to getProductPos()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 363,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "getPageNumber",
+            "reason": "method has an inverted shim pair (\\_getPageNumber() body delegates UP to getPageNumber()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 365,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "makeLink",
+            "reason": "method has an inverted shim pair (\\_makeLink() body delegates UP to makeLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 368,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "makeLink",
+            "reason": "method has an inverted shim pair (\\_makeLink() body delegates UP to makeLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 369,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "makeLink",
+            "reason": "method has an inverted shim pair (\\_makeLink() body delegates UP to makeLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 398,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "findActPageNumber",
+            "reason": "method has an inverted shim pair (\\_findActPageNumber() body delegates UP to findActPageNumber()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 411,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "getProductPos",
+            "reason": "method has an inverted shim pair (\\_getProductPos() body delegates UP to getProductPos()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 419,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "getPageNumber",
+            "reason": "method has an inverted shim pair (\\_getPageNumber() body delegates UP to getPageNumber()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 419,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "makeLink",
+            "reason": "method has an inverted shim pair (\\_makeLink() body delegates UP to makeLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 421,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "makeLink",
+            "reason": "method has an inverted shim pair (\\_makeLink() body delegates UP to makeLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 430,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "makeLink",
+            "reason": "method has an inverted shim pair (\\_makeLink() body delegates UP to makeLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 431,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "makeLink",
+            "reason": "method has an inverted shim pair (\\_makeLink() body delegates UP to makeLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 457,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "loadIdsInList",
+            "reason": "method has an inverted shim pair (\\_loadIdsInList() body delegates UP to loadIdsInList()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 505,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "makeLink",
+            "reason": "method has an inverted shim pair (\\_makeLink() body delegates UP to makeLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 538,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "findActPageNumber",
+            "reason": "method has an inverted shim pair (\\_findActPageNumber() body delegates UP to findActPageNumber()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 579,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "getPageNumber",
+            "reason": "method has an inverted shim pair (\\_getPageNumber() body delegates UP to getPageNumber()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Component/Locator.php",
+            "line": 610,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Component\\Locator",
+            "method": "getProductPos",
+            "reason": "method has an inverted shim pair (\\_getProductPos() body delegates UP to getProductPos()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsArticleAjax.php",
+            "line": 78,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsArticleAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsArticleAjax.php",
+            "line": 79,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsArticleAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsArticleAjax.php",
+            "line": 143,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsArticleAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsGroupsAjax.php",
+            "line": 72,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsGroupsAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsGroupsAjax.php",
+            "line": 120,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsGroupsAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsGroupsAjax.php",
+            "line": 142,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsGroupsAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsGroupsAjax.php",
+            "line": 143,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsGroupsAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+            "line": 93,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+            "line": 94,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+            "line": 167,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+            "line": 245,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+            "method": "getOxRssFeed",
+            "reason": "method has an inverted shim pair (\\_getOxRssFeed() body delegates UP to getOxRssFeed()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+            "line": 248,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+            "line": 270,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+            "method": "getOxRssFeed",
+            "reason": "method has an inverted shim pair (\\_getOxRssFeed() body delegates UP to getOxRssFeed()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+            "line": 273,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+            "line": 274,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+            "line": 279,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+            "line": 317,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+            "line": 361,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+            "line": 366,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+            "method": "getData",
+            "reason": "method has an inverted shim pair (\\_getData() body delegates UP to getData()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsMainAjax.php",
+            "line": 377,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsMainAjax",
+            "method": "getOxRssFeed",
+            "reason": "method has an inverted shim pair (\\_getOxRssFeed() body delegates UP to getOxRssFeed()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsOrderAjax.php",
+            "line": 65,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsOrderAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsOrderAjax.php",
+            "line": 165,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsOrderAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ActionsOrderAjax.php",
+            "line": 170,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ActionsOrderAjax",
+            "method": "getData",
+            "reason": "method has an inverted shim pair (\\_getData() body delegates UP to getData()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminController.php",
+            "line": 201,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminController",
+            "method": "authorize",
+            "reason": "method has an inverted shim pair (\\_authorize() body delegates UP to authorize()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminController.php",
+            "line": 342,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminController",
+            "method": "setupNavigation",
+            "reason": "method has an inverted shim pair (\\_setupNavigation() body delegates UP to setupNavigation()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminController.php",
+            "line": 408,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminController",
+            "method": "getMaxUploadFileInfo",
+            "reason": "method has an inverted shim pair (\\_getMaxUploadFileInfo() body delegates UP to getMaxUploadFileInfo()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminController.php",
+            "line": 429,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminController",
+            "method": "getMaxUploadFileInfo",
+            "reason": "method has an inverted shim pair (\\_getMaxUploadFileInfo() body delegates UP to getMaxUploadFileInfo()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminController.php",
+            "line": 477,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminController",
+            "method": "resetContentCache",
+            "reason": "authored by trusted Daniel/O3-Shop identity o3-shop-github@ist-einmalig.de in 2022-10-11 (sha ebe86dc0); not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminController.php",
+            "line": 543,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminController",
+            "method": "allowAdminEdit",
+            "reason": "method has an inverted shim pair (\\_allowAdminEdit() body delegates UP to allowAdminEdit()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminController.php",
+            "line": 570,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminController",
+            "method": "getCountryByCode",
+            "reason": "method has an inverted shim pair (\\_getCountryByCode() body delegates UP to getCountryByCode()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminController.php",
+            "line": 621,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminController",
+            "method": "authorize",
+            "reason": "method has an inverted shim pair (\\_authorize() body delegates UP to authorize()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminDetailsController.php",
+            "line": 219,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminDetailsController",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminDetailsController.php",
+            "line": 228,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminDetailsController",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminDetailsController.php",
+            "line": 237,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminDetailsController",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminListController.php",
+            "line": 296,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminListController.php",
+            "line": 707,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+            "method": "changeselect",
+            "reason": "method has an inverted shim pair (\\_changeselect() body delegates UP to changeselect()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminListController.php",
+            "line": 750,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+            "method": "convertToDBDate",
+            "reason": "method has an inverted shim pair (\\_convertToDBDate() body delegates UP to convertToDBDate()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminListController.php",
+            "line": 775,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+            "method": "convertToDBDate",
+            "reason": "method has an inverted shim pair (\\_convertToDBDate() body delegates UP to convertToDBDate()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminListController.php",
+            "line": 795,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+            "method": "convertTime",
+            "reason": "method has an inverted shim pair (\\_convertTime() body delegates UP to convertTime()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminListController.php",
+            "line": 797,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+            "method": "convertDate",
+            "reason": "method has an inverted shim pair (\\_convertDate() body delegates UP to convertDate()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminListController.php",
+            "line": 804,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+            "method": "convertDate",
+            "reason": "method has an inverted shim pair (\\_convertDate() body delegates UP to convertDate()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminListController.php",
+            "line": 821,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+            "method": "convertDate",
+            "reason": "method has an inverted shim pair (\\_convertDate() body delegates UP to convertDate()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminListController.php",
+            "line": 872,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+            "method": "convertTime",
+            "reason": "method has an inverted shim pair (\\_convertTime() body delegates UP to convertTime()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminListController.php",
+            "line": 923,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+            "method": "setListNavigationParams",
+            "reason": "method has an inverted shim pair (\\_setListNavigationParams() body delegates UP to setListNavigationParams()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminListController.php",
+            "line": 1017,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+            "method": "setupNavigation",
+            "reason": "method has an inverted shim pair (\\_setupNavigation() body delegates UP to setupNavigation()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminListController.php",
+            "line": 1090,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminListController",
+            "method": "changeselect",
+            "reason": "method has an inverted shim pair (\\_changeselect() body delegates UP to changeselect()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminRightsMainAjax.php",
+            "line": 77,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminRightsMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminRightsMainAjax.php",
+            "line": 125,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminRightsMainAjax",
+            "method": "getActionIds",
+            "reason": "baseline (ebe86dc) had no \\$this->_getActionIds( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminRightsMainAjax.php",
+            "line": 128,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminRightsMainAjax",
+            "method": "addFilter",
+            "reason": "baseline (ebe86dc) had no \\$this->_addFilter( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminRightsMainAjax.php",
+            "line": 128,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminRightsMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminRightsMainAjax.php",
+            "line": 141,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminRightsMainAjax",
+            "method": "getActionIds",
+            "reason": "baseline (ebe86dc) had no \\$this->_getActionIds( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminRightsMainAjax.php",
+            "line": 146,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminRightsMainAjax",
+            "method": "addFilter",
+            "reason": "baseline (ebe86dc) had no \\$this->_addFilter( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminRightsMainAjax.php",
+            "line": 146,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminRightsMainAjax",
+            "method": "getAll",
+            "reason": "baseline (ebe86dc) had no \\$this->_getAll( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/AdminRightsMainAjax.php",
+            "line": 146,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AdminRightsMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleAccessoriesAjax.php",
+            "line": 165,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAccessoriesAjax",
+            "method": "getSorting",
+            "reason": "method has an inverted shim pair (\\_getSorting() body delegates UP to getSorting()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleAttributeAjax.php",
+            "line": 76,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAttributeAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleAttributeAjax.php",
+            "line": 77,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAttributeAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleAttributeAjax.php",
+            "line": 117,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAttributeAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleAttributeAjax.php",
+            "line": 118,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAttributeAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleAttributeAjax.php",
+            "line": 138,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAttributeAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleAttributeAjax.php",
+            "line": 139,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAttributeAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleAttributeAjax.php",
+            "line": 164,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAttributeAjax",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleAttributeAjax.php",
+            "line": 179,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleAttributeAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleBundleAjax.php",
+            "line": 76,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleBundleAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleBundleAjax.php",
+            "line": 77,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleBundleAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleBundleAjax.php",
+            "line": 142,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleBundleAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleCrosssellingAjax.php",
+            "line": 87,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleCrosssellingAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleCrosssellingAjax.php",
+            "line": 88,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleCrosssellingAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleCrosssellingAjax.php",
+            "line": 172,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleCrosssellingAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleCrosssellingAjax.php",
+            "line": 191,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleCrosssellingAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleCrosssellingAjax.php",
+            "line": 192,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleCrosssellingAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+            "line": 74,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+            "line": 75,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+            "line": 193,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+            "line": 194,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+            "line": 211,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+            "line": 227,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+            "line": 231,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+            "line": 232,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+            "line": 261,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+            "line": 276,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+            "method": "updateOxTime",
+            "reason": "method has an inverted shim pair (\\_updateOxTime() body delegates UP to updateOxTime()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+            "line": 289,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleExtendAjax.php",
+            "line": 327,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleExtendAjax",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleMain.php",
+            "line": 428,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleMain.php",
+            "line": 531,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+            "method": "copyAttributes",
+            "reason": "method has an inverted shim pair (\\_copyAttributes() body delegates UP to copyAttributes()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleMain.php",
+            "line": 576,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+            "method": "copyFiles",
+            "reason": "method has an inverted shim pair (\\_copyFiles() body delegates UP to copyFiles()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleMain.php",
+            "line": 622,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+            "method": "copySelectlists",
+            "reason": "method has an inverted shim pair (\\_copySelectlists() body delegates UP to copySelectlists()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleMain.php",
+            "line": 669,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+            "method": "copyCrossseling",
+            "reason": "method has an inverted shim pair (\\_copyCrossseling() body delegates UP to copyCrossseling()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleMain.php",
+            "line": 716,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+            "method": "copyAccessoires",
+            "reason": "method has an inverted shim pair (\\_copyAccessoires() body delegates UP to copyAccessoires()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleMain.php",
+            "line": 761,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+            "method": "copyStaffelpreis",
+            "reason": "method has an inverted shim pair (\\_copyStaffelpreis() body delegates UP to copyStaffelpreis()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleMain.php",
+            "line": 800,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+            "method": "copyArtExtends",
+            "reason": "method has an inverted shim pair (\\_copyArtExtends() body delegates UP to copyArtExtends()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleMain.php",
+            "line": 849,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+            "method": "formJumpList",
+            "reason": "method has an inverted shim pair (\\_formJumpList() body delegates UP to formJumpList()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleMain.php",
+            "line": 864,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+            "method": "getTitle",
+            "reason": "method has an inverted shim pair (\\_getTitle() body delegates UP to getTitle()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleMain.php",
+            "line": 869,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+            "method": "getTitle",
+            "reason": "method has an inverted shim pair (\\_getTitle() body delegates UP to getTitle()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleMain.php",
+            "line": 874,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+            "method": "getTitle",
+            "reason": "method has an inverted shim pair (\\_getTitle() body delegates UP to getTitle()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleMain.php",
+            "line": 881,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+            "method": "getTitle",
+            "reason": "method has an inverted shim pair (\\_getTitle() body delegates UP to getTitle()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleMain.php",
+            "line": 886,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+            "method": "getTitle",
+            "reason": "method has an inverted shim pair (\\_getTitle() body delegates UP to getTitle()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleMain.php",
+            "line": 905,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleMain",
+            "method": "getTitle",
+            "reason": "method has an inverted shim pair (\\_getTitle() body delegates UP to getTitle()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleReview.php",
+            "line": 177,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleReview",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleSelectionAjax.php",
+            "line": 73,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSelectionAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleSelectionAjax.php",
+            "line": 74,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSelectionAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleSelectionAjax.php",
+            "line": 129,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSelectionAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleSelectionAjax.php",
+            "line": 154,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSelectionAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleSelectionAjax.php",
+            "line": 155,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSelectionAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleSeo.php",
+            "line": 154,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSeo",
+            "method": "getVendorList",
+            "reason": "method has an inverted shim pair (\\_getVendorList() body delegates UP to getVendorList()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleSeo.php",
+            "line": 158,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSeo",
+            "method": "getManufacturerList",
+            "reason": "method has an inverted shim pair (\\_getManufacturerList() body delegates UP to getManufacturerList()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleSeo.php",
+            "line": 249,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSeo",
+            "method": "getVendorList",
+            "reason": "method has an inverted shim pair (\\_getVendorList() body delegates UP to getVendorList()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleSeo.php",
+            "line": 283,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSeo",
+            "method": "getManufacturerList",
+            "reason": "method has an inverted shim pair (\\_getManufacturerList() body delegates UP to getManufacturerList()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleSeo.php",
+            "line": 385,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSeo",
+            "method": "getAltSeoEntryId",
+            "reason": "method has an inverted shim pair (\\_getAltSeoEntryId() body delegates UP to getAltSeoEntryId()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleSeo.php",
+            "line": 406,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSeo",
+            "method": "getType",
+            "reason": "method has an inverted shim pair (\\_getType() body delegates UP to getType()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleSeo.php",
+            "line": 441,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSeo",
+            "method": "getEncoder",
+            "reason": "method has an inverted shim pair (\\_getEncoder() body delegates UP to getEncoder()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleSeo.php",
+            "line": 466,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleSeo",
+            "method": "getEncoder",
+            "reason": "method has an inverted shim pair (\\_getEncoder() body delegates UP to getEncoder()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleStock.php",
+            "line": 156,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleStock",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleStock.php",
+            "line": 250,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleStock",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleVariant.php",
+            "line": 285,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleVariant",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleVariant.php",
+            "line": 303,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleVariant",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleVariant.php",
+            "line": 318,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleVariant",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/ArticleVariant.php",
+            "line": 347,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ArticleVariant",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/AttributeCategoryAjax.php",
+            "line": 83,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeCategoryAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AttributeCategoryAjax.php",
+            "line": 135,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeCategoryAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AttributeCategoryAjax.php",
+            "line": 143,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeCategoryAjax",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/AttributeCategoryAjax.php",
+            "line": 159,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeCategoryAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AttributeCategoryAjax.php",
+            "line": 160,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeCategoryAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AttributeCategoryAjax.php",
+            "line": 185,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeCategoryAjax",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/AttributeMainAjax.php",
+            "line": 90,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AttributeMainAjax.php",
+            "line": 91,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AttributeMainAjax.php",
+            "line": 92,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AttributeMainAjax.php",
+            "line": 163,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AttributeMainAjax.php",
+            "line": 200,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AttributeMainAjax.php",
+            "line": 202,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AttributeMainAjax.php",
+            "line": 221,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AttributeMainAjax.php",
+            "line": 222,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AttributeOrderAjax.php",
+            "line": 63,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeOrderAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AttributeOrderAjax.php",
+            "line": 160,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeOrderAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/AttributeOrderAjax.php",
+            "line": 165,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\AttributeOrderAjax",
+            "method": "getData",
+            "reason": "method has an inverted shim pair (\\_getData() body delegates UP to getData()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+            "line": 88,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+            "line": 89,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+            "line": 152,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+            "line": 196,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+            "line": 200,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+            "line": 204,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+            "line": 254,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+            "method": "updateOxTime",
+            "reason": "method has an inverted shim pair (\\_updateOxTime() body delegates UP to updateOxTime()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+            "line": 267,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+            "line": 315,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryMainAjax.php",
+            "line": 316,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+            "line": 82,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+            "line": 83,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+            "line": 144,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+            "line": 189,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+            "line": 190,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+            "line": 230,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+            "line": 231,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+            "line": 262,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategoryOrderAjax.php",
+            "line": 266,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategoryOrderAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategorySeo.php",
+            "line": 53,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategorySeo",
+            "method": "getEncoder",
+            "reason": "method has an inverted shim pair (\\_getEncoder() body delegates UP to getEncoder()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/CategorySeo.php",
+            "line": 157,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\CategorySeo",
+            "method": "getEncoder",
+            "reason": "method has an inverted shim pair (\\_getEncoder() body delegates UP to getEncoder()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ContentSeo.php",
+            "line": 109,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ContentSeo",
+            "method": "getEncoder",
+            "reason": "method has an inverted shim pair (\\_getEncoder() body delegates UP to getEncoder()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryArticlesAjax.php",
+            "line": 89,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryArticlesAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryArticlesAjax.php",
+            "line": 90,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryArticlesAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryArticlesAjax.php",
+            "line": 162,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryArticlesAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryArticlesAjax.php",
+            "line": 180,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryArticlesAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryArticlesAjax.php",
+            "line": 181,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryArticlesAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryCategoriesAjax.php",
+            "line": 74,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryCategoriesAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryCategoriesAjax.php",
+            "line": 131,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryCategoriesAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryCategoriesAjax.php",
+            "line": 150,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryCategoriesAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryCategoriesAjax.php",
+            "line": 151,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryCategoriesAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryGroupsAjax.php",
+            "line": 74,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryGroupsAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryGroupsAjax.php",
+            "line": 123,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryGroupsAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryGroupsAjax.php",
+            "line": 142,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryGroupsAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryGroupsAjax.php",
+            "line": 143,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryGroupsAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryMainAjax.php",
+            "line": 74,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryMainAjax.php",
+            "line": 123,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryMainAjax.php",
+            "line": 141,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryMainAjax.php",
+            "line": 142,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetCountryAjax.php",
+            "line": 78,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetCountryAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetCountryAjax.php",
+            "line": 125,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetCountryAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetCountryAjax.php",
+            "line": 144,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetCountryAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetCountryAjax.php",
+            "line": 145,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetCountryAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetGroupsAjax.php",
+            "line": 74,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetGroupsAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetGroupsAjax.php",
+            "line": 120,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetGroupsAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetGroupsAjax.php",
+            "line": 139,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetGroupsAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetGroupsAjax.php",
+            "line": 140,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetGroupsAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetMainAjax.php",
+            "line": 77,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetMainAjax.php",
+            "line": 118,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetMainAjax.php",
+            "line": 138,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetMainAjax.php",
+            "line": 139,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetPaymentAjax.php",
+            "line": 77,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetPaymentAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetPaymentAjax.php",
+            "line": 118,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetPaymentAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetPaymentAjax.php",
+            "line": 138,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetPaymentAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetPaymentAjax.php",
+            "line": 139,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetPaymentAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetUsersAjax.php",
+            "line": 91,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetUsersAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetUsersAjax.php",
+            "line": 145,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetUsersAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetUsersAjax.php",
+            "line": 163,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetUsersAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliverySetUsersAjax.php",
+            "line": 164,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliverySetUsersAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryUsersAjax.php",
+            "line": 87,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryUsersAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryUsersAjax.php",
+            "line": 141,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryUsersAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryUsersAjax.php",
+            "line": 159,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryUsersAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DeliveryUsersAjax.php",
+            "line": 160,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DeliveryUsersAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountArticlesAjax.php",
+            "line": 92,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountArticlesAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountArticlesAjax.php",
+            "line": 93,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountArticlesAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountArticlesAjax.php",
+            "line": 155,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountArticlesAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountArticlesAjax.php",
+            "line": 174,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountArticlesAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountArticlesAjax.php",
+            "line": 175,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountArticlesAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountCategoriesAjax.php",
+            "line": 82,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountCategoriesAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountCategoriesAjax.php",
+            "line": 135,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountCategoriesAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountCategoriesAjax.php",
+            "line": 154,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountCategoriesAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountCategoriesAjax.php",
+            "line": 155,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountCategoriesAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountGroupsAjax.php",
+            "line": 75,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountGroupsAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountGroupsAjax.php",
+            "line": 122,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountGroupsAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountGroupsAjax.php",
+            "line": 141,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountGroupsAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountGroupsAjax.php",
+            "line": 142,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountGroupsAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountItemAjax.php",
+            "line": 79,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountItemAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountItemAjax.php",
+            "line": 80,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountItemAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountItemAjax.php",
+            "line": 81,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountItemAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountItemAjax.php",
+            "line": 220,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountItemAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountItemAjax.php",
+            "line": 241,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountItemAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountMainAjax.php",
+            "line": 73,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountMainAjax.php",
+            "line": 117,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountMainAjax.php",
+            "line": 135,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountMainAjax.php",
+            "line": 136,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountUsersAjax.php",
+            "line": 87,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountUsersAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountUsersAjax.php",
+            "line": 142,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountUsersAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountUsersAjax.php",
+            "line": 160,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountUsersAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DiscountUsersAjax.php",
+            "line": 161,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DiscountUsersAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 223,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "getHeapTableName",
+            "reason": "method has an inverted shim pair (\\_getHeapTableName() body delegates UP to getHeapTableName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 485,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "findDeepestCatPath",
+            "reason": "method has an inverted shim pair (\\_findDeepestCatPath() body delegates UP to findDeepestCatPath()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 498,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "getHeapTableName",
+            "reason": "method has an inverted shim pair (\\_getHeapTableName() body delegates UP to getHeapTableName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 503,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "generateTableCharSet",
+            "reason": "method has an inverted shim pair (\\_generateTableCharSet() body delegates UP to generateTableCharSet()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 506,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "createHeapTable",
+            "reason": "method has an inverted shim pair (\\_createHeapTable() body delegates UP to createHeapTable()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 511,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "getCatAdd",
+            "reason": "method has an inverted shim pair (\\_getCatAdd() body delegates UP to getCatAdd()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 512,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "insertArticles",
+            "reason": "method has an inverted shim pair (\\_insertArticles() body delegates UP to insertArticles()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 543,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "getHeapTableName",
+            "reason": "method has an inverted shim pair (\\_getHeapTableName() body delegates UP to getHeapTableName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 545,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "setCampaignDetailLink",
+            "reason": "method has an inverted shim pair (\\_setCampaignDetailLink() body delegates UP to setCampaignDetailLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 587,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "unHtmlEntities",
+            "reason": "method has an inverted shim pair (\\_unHtmlEntities() body delegates UP to unHtmlEntities()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 613,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "getHeapTableName",
+            "reason": "method has an inverted shim pair (\\_getHeapTableName() body delegates UP to getHeapTableName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 639,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "generateTableCharSet",
+            "reason": "method has an inverted shim pair (\\_generateTableCharSet() body delegates UP to generateTableCharSet()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 683,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "createHeapTable",
+            "reason": "method has an inverted shim pair (\\_createHeapTable() body delegates UP to createHeapTable()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 720,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "getCatAdd",
+            "reason": "method has an inverted shim pair (\\_getCatAdd() body delegates UP to getCatAdd()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 764,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "insertArticles",
+            "reason": "method has an inverted shim pair (\\_insertArticles() body delegates UP to insertArticles()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 833,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "removeParentArticles",
+            "reason": "method has an inverted shim pair (\\_removeParentArticles() body delegates UP to removeParentArticles()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 877,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "setSessionParams",
+            "reason": "method has an inverted shim pair (\\_setSessionParams() body delegates UP to setSessionParams()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 936,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "loadRootCats",
+            "reason": "method has an inverted shim pair (\\_loadRootCats() body delegates UP to loadRootCats()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 1002,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "findDeepestCatPath",
+            "reason": "method has an inverted shim pair (\\_findDeepestCatPath() body delegates UP to findDeepestCatPath()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 1021,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "loadRootCats",
+            "reason": "method has an inverted shim pair (\\_loadRootCats() body delegates UP to loadRootCats()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 1061,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "initArticle",
+            "reason": "method has an inverted shim pair (\\_initArticle() body delegates UP to initArticle()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/DynamicExportBaseController.php",
+            "line": 1113,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\DynamicExportBaseController",
+            "method": "setCampaignDetailLink",
+            "reason": "method has an inverted shim pair (\\_setCampaignDetailLink() body delegates UP to setCampaignDetailLink()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+            "line": 283,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+            "method": "getData",
+            "reason": "method has an inverted shim pair (\\_getData() body delegates UP to getData()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+            "line": 529,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+            "line": 659,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+            "method": "getSortDir",
+            "reason": "method has an inverted shim pair (\\_getSortDir() body delegates UP to getSortDir()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+            "line": 756,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+            "line": 880,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+            "method": "getSortDir",
+            "reason": "method has an inverted shim pair (\\_getSortDir() body delegates UP to getSortDir()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+            "line": 906,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+            "method": "getStartIndex",
+            "reason": "method has an inverted shim pair (\\_getStartIndex() body delegates UP to getStartIndex()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+            "line": 930,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+            "method": "getTotalCount",
+            "reason": "method has an inverted shim pair (\\_getTotalCount() body delegates UP to getTotalCount()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+            "line": 996,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+            "method": "outputResponse",
+            "reason": "method has an inverted shim pair (\\_outputResponse() body delegates UP to outputResponse()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+            "line": 1017,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+            "method": "output",
+            "reason": "method has an inverted shim pair (\\_output() body delegates UP to output()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+            "line": 1040,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+            "line": 1068,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+            "method": "getData",
+            "reason": "method has an inverted shim pair (\\_getData() body delegates UP to getData()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+            "line": 1086,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+            "method": "getStartIndex",
+            "reason": "method has an inverted shim pair (\\_getStartIndex() body delegates UP to getStartIndex()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+            "line": 1088,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+            "method": "getSortDir",
+            "reason": "method has an inverted shim pair (\\_getSortDir() body delegates UP to getSortDir()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ListComponentAjax.php",
+            "line": 1098,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ListComponentAjax",
+            "method": "getTotalCount",
+            "reason": "method has an inverted shim pair (\\_getTotalCount() body delegates UP to getTotalCount()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ManufacturerMainAjax.php",
+            "line": 87,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ManufacturerMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ManufacturerMainAjax.php",
+            "line": 88,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ManufacturerMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ManufacturerMainAjax.php",
+            "line": 147,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ManufacturerMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ManufacturerMainAjax.php",
+            "line": 183,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ManufacturerMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ManufacturerMainAjax.php",
+            "line": 184,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ManufacturerMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ManufacturerMainAjax.php",
+            "line": 222,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ManufacturerMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ManufacturerMainAjax.php",
+            "line": 223,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ManufacturerMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ManufacturerSeo.php",
+            "line": 153,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ManufacturerSeo",
+            "method": "getEncoder",
+            "reason": "method has an inverted shim pair (\\_getEncoder() body delegates UP to getEncoder()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/ModuleConfiguration.php",
+            "line": 197,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ModuleConfiguration",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationController.php",
+            "line": 123,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationController",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 119,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "addLinks",
+            "reason": "method has an inverted shim pair (\\_addLinks() body delegates UP to addLinks()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 157,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "loadFromFile",
+            "reason": "method has an inverted shim pair (\\_loadFromFile() body delegates UP to loadFromFile()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 275,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "sessionizeLocalUrls",
+            "reason": "method has an inverted shim pair (\\_sessionizeLocalUrls() body delegates UP to sessionizeLocalUrls()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 285,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "getAdminUrl",
+            "reason": "method has an inverted shim pair (\\_getAdminUrl() body delegates UP to getAdminUrl()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 307,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "checkRights",
+            "reason": "method has an inverted shim pair (\\_checkRights() body delegates UP to checkRights()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 325,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "hasRights",
+            "reason": "method has an inverted shim pair (\\_hasRights() body delegates UP to hasRights()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 333,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "hasRights",
+            "reason": "method has an inverted shim pair (\\_hasRights() body delegates UP to hasRights()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 349,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "checkGroups",
+            "reason": "method has an inverted shim pair (\\_checkGroups() body delegates UP to checkGroups()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 367,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "hasGroup",
+            "reason": "method has an inverted shim pair (\\_hasGroup() body delegates UP to hasGroup()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 375,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "hasGroup",
+            "reason": "method has an inverted shim pair (\\_hasGroup() body delegates UP to hasGroup()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 393,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "checkDemoShopDenials",
+            "reason": "method has an inverted shim pair (\\_checkDemoShopDenials() body delegates UP to checkDemoShopDenials()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 444,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "copyAttributes",
+            "reason": "method has an inverted shim pair (\\_copyAttributes() body delegates UP to copyAttributes()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 471,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "mergeNodes",
+            "reason": "method has an inverted shim pair (\\_mergeNodes() body delegates UP to mergeNodes()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 520,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "merge",
+            "reason": "method has an inverted shim pair (\\_merge() body delegates UP to merge()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 612,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "getMenuFiles",
+            "reason": "method has an inverted shim pair (\\_getMenuFiles() body delegates UP to getMenuFiles()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 688,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "processCachedFile",
+            "reason": "method has an inverted shim pair (\\_processCachedFile() body delegates UP to processCachedFile()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 711,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "getInitialDom",
+            "reason": "method has an inverted shim pair (\\_getInitialDom() body delegates UP to getInitialDom()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 724,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "getMenuFiles",
+            "reason": "method has an inverted shim pair (\\_getMenuFiles() body delegates UP to getMenuFiles()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 763,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "processCachedFile",
+            "reason": "method has an inverted shim pair (\\_processCachedFile() body delegates UP to processCachedFile()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 785,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "getInitialDom",
+            "reason": "method has an inverted shim pair (\\_getInitialDom() body delegates UP to getInitialDom()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 899,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "getAdminUrl",
+            "reason": "method has an inverted shim pair (\\_getAdminUrl() body delegates UP to getAdminUrl()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 930,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "hasRights",
+            "reason": "method has an inverted shim pair (\\_hasRights() body delegates UP to hasRights()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 955,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "hasGroup",
+            "reason": "method has an inverted shim pair (\\_hasGroup() body delegates UP to hasGroup()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NavigationTree.php",
+            "line": 979,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NavigationTree",
+            "method": "getInitialDom",
+            "reason": "method has an inverted shim pair (\\_getInitialDom() body delegates UP to getInitialDom()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NewsMainAjax.php",
+            "line": 72,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NewsMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NewsMainAjax.php",
+            "line": 116,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NewsMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NewsMainAjax.php",
+            "line": 133,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NewsMainAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NewsMainAjax.php",
+            "line": 134,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NewsMainAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NewsletterSelectionAjax.php",
+            "line": 70,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NewsletterSelectionAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NewsletterSelectionAjax.php",
+            "line": 116,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NewsletterSelectionAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NewsletterSelectionAjax.php",
+            "line": 133,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NewsletterSelectionAjax",
+            "method": "getViewName",
+            "reason": "method has an inverted shim pair (\\_getViewName() body delegates UP to getViewName()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/NewsletterSelectionAjax.php",
+            "line": 134,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\NewsletterSelectionAjax",
+            "method": "getQuery",
+            "reason": "method has an inverted shim pair (\\_getQuery() body delegates UP to getQuery()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Controller/Admin/OrderList.php",
+            "line": 111,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\OrderList",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/ShopConfiguration.php",
+            "line": 185,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ShopConfiguration",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Controller/Admin/ThemeMain.php",
+            "line": 114,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Controller\\Admin\\ThemeMain",
+            "method": "resetContentCache",
+            "reason": "baseline (ebe86dc) had no \\$this->_resetContentCache( call in this file; not a rename to revert"
+        },
+        {
+            "file": "source/Application/Model/Article.php",
+            "line": 996,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+            "method": "getPrice",
+            "reason": "authored by trusted Daniel/O3-Shop identity o3-shop-github@ist-einmalig.de in 2022-10-11 (sha ebe86dc0); not a rename to revert"
+        },
+        {
+            "file": "source/Application/Model/Article.php",
+            "line": 1037,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+            "method": "getVarMinPrice",
+            "reason": "authored by trusted Daniel/O3-Shop identity o3-shop-github@ist-einmalig.de in 2022-10-11 (sha ebe86dc0); not a rename to revert"
+        },
+        {
+            "file": "source/Application/Model/Article.php",
+            "line": 1735,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+            "method": "getPrice",
+            "reason": "authored by trusted Daniel/O3-Shop identity o3-shop-github@ist-einmalig.de in 2022-10-11 (sha ebe86dc0); not a rename to revert"
+        },
+        {
+            "file": "source/Application/Model/Article.php",
+            "line": 2069,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+            "method": "getPrice",
+            "reason": "authored by trusted Daniel/O3-Shop identity o3-shop-github@ist-einmalig.de in 2022-10-11 (sha ebe86dc0); not a rename to revert"
+        },
+        {
+            "file": "source/Application/Model/Article.php",
+            "line": 2114,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+            "method": "getVarMinPrice",
+            "reason": "authored by trusted Daniel/O3-Shop identity o3-shop-github@ist-einmalig.de in 2022-10-11 (sha ebe86dc0); not a rename to revert"
+        },
+        {
+            "file": "source/Application/Model/Article.php",
+            "line": 2117,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+            "method": "getPrice",
+            "reason": "authored by trusted Daniel/O3-Shop identity o3-shop-github@ist-einmalig.de in 2022-10-11 (sha ebe86dc0); not a rename to revert"
+        },
+        {
+            "file": "source/Application/Model/Article.php",
+            "line": 3187,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+            "method": "getPrice",
+            "reason": "authored by trusted Daniel/O3-Shop identity o3-shop-github@ist-einmalig.de in 2022-10-11 (sha ebe86dc0); not a rename to revert"
+        },
+        {
+            "file": "source/Application/Model/Article.php",
+            "line": 3219,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+            "method": "getPrice",
+            "reason": "authored by trusted Daniel/O3-Shop identity o3-shop-github@ist-einmalig.de in 2022-10-11 (sha ebe86dc0); not a rename to revert"
+        },
+        {
+            "file": "source/Application/Model/Article.php",
+            "line": 4526,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Article",
+            "method": "getAmountPriceList",
+            "reason": "authored by trusted Daniel/O3-Shop identity o3-shop-github@ist-einmalig.de in 2022-10-11 (sha ebe86dc0); not a rename to revert"
+        },
+        {
+            "file": "source/Application/Model/Basket.php",
+            "line": 3039,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Basket",
+            "method": "addedNewItem",
+            "reason": "method has an inverted shim pair (\\_addedNewItem() body delegates UP to addedNewItem()); sweep risks recursion or unnecessary indirection through a buggy shim. Structural fix tracked separately."
+        },
+        {
+            "file": "source/Application/Model/Content.php",
+            "line": 513,
+            "class": "OxidEsales\\EshopCommunity\\Application\\Model\\Content",
+            "method": "getFieldData",
+            "reason": "authored by trusted Daniel/O3-Shop identity o3-shop-github@ist-einmalig.de in 2023-04-05 (sha 2ebe8ead); not a rename to revert"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Closes the call-site convention half of #107. PR #104 fixed the structural shim direction across ~225 `(Class, _method)` entries — `_method()` got the implementation back, `method()` became a one-line delegate, and the runtime `InheritanceContractTest` proves the public dispatch contract holds.

What that PR did NOT do is sweep the **internal** `$this->method(...)` call sites that the renaming commits had introduced across `source/`. Those calls still routed through the public delegate even though the implementation now lived on `_method()`. After this change, every internal call goes direct to the BC anchor:

```
$this->method(...)   →   $this->_method(...)
```

This narrows dispatch to `_method()` overrides only — module overrides of the new public name are bypassed by internal call paths. Deliberate design choice during the BC-shim transition. Reflected in PHPDoc on every shim pair: modules SHOULD override `_method()` for now; #108 will eventually invert this and promote `method()` to canonical via a template-method refactor.

## Scope filtering

Detector finds 711 raw `$this->method(` sites; **656 in scope**. The other 55 are excluded with documented reasons:

| Category | Count | Why |
|---|---:|---|
| baseline-non-underscore | 43 | Was already `$this->method(` in the 2022 import — not a rename to revert |
| trusted-author intentional | 12 | Lines authored by trusted O3-Shop identities |

After remediation, **276 additional findings stay excluded** because they target inverted-shim methods — pairs whose `_method()` body still delegates UP to `method()` (impl on the public name). PR #104 missed these from its inventory snapshot; sweeping their call sites would either create recursion or pointlessly indirect through a buggy shim.

**74 inverted pairs remain in the structural-inversion state** — that is a separate concern, suitable for a follow-up issue (the same kind of remediation PR #104 applied, but anchored to a more thorough inventory).

## What lands

- `bin/find-internal-shim-call-sites.php` — tokenizer-based detector; walks `source/`, resolves inheritance through the OXID virtual namespace, reports `$this->method(` call sites where the declaring class chain has both `_method()` and `method()` defined.
- `tests/Unit/BackwardsCompatibility/InternalShimCallSitesTest.php` — PHPUnit gate test. Runs the detector, subtracts the durable allow-list, asserts the remainder is empty. Companion to `InheritanceContractTest`.
- `tests/Unit/BackwardsCompatibility/internal-shim-call-sites-exclusions.json` — 357-entry allow-list with a `reason` field per entry.
- ~380 production call-site rewrites across ~80 files in `source/Application/{Component,Component/Widget,Controller,Controller/Admin}/`.
- 302 PHPDoc rewrites on shim pairs across 71 files — `@deprecated` and `@internal` blocks reframed as transitional, with reference to #108.
- ~30 test mock-string updates in `tests/Unit/Application/Controller/Admin/` — tests that mocked the public method name now mock the underscore name to match new dispatch.
- One-shot rewriter tooling at `bin/apply-internal-shim-call-site-sweep.php`, `bin/apply-test-mock-name-sweep.php`, `bin/apply-shim-phpdoc-transitional-rewrite.php` (idempotent; kept for replay).
- OpenSpec change folder at `openspec/changes/fix-internal-shim-call-sites/` (proposal/design/tasks/spec — ready to archive on merge).

## Test plan

- [x] `InheritanceContractTest`: green (668 / 668) — no public-surface regression.
- [x] `InternalShimCallSitesTest`: green — 357 findings, 357 exclusions, 0 in scope.
- [x] `tests/Unit/Application/Controller/Admin/`: 1168 tests, no failures (13 pre-existing risky tests with no assertions).
- [x] `tests/Unit/Application/{Component,Controller,Model}/`: all pass.
- [x] Full `tests/Unit/`: 8466 tests, 1 failure (`Smarty\LangIntegrityTest::testNotUsedTranslations`, reproduces on `b-1.6.0` — pre-existing, not introduced here).

Closes #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)