### PR TITLE
fix(#136): seed o3-theme settings reliably during install

### DIFF
--- a/source/Setup/Database.php
+++ b/source/Setup/Database.php
@@ -363,6 +363,14 @@ class Database extends Core
      * @param string $sSQL query string (usually reqd from *.sql file)
      *
      * @return array
+     *
+     * Comment handling matches the MySQL reference: `#` starts a comment to
+     * end-of-line; `--` starts a comment to end-of-line when followed by
+     * whitespace (or EOL) — at any column, not just at line start. Earlier
+     * revisions only recognised `--` at column 0, which let an indented
+     * `--` comment inside an `INSERT … VALUES` list survive the line-join
+     * here and silently swallow the rest of the statement once handed to
+     * MySQL on a single line — see issue #136.
      */
     public function parseQuery($sSQL)
     {
@@ -378,8 +386,16 @@ class Database extends Core
         foreach ($aLines as $sLine) {
             $iLen = strlen($sLine);
             for ($i = 0; $i < $iLen; $i++) {
-                if (!$blQuote && ($sLine[$i] == '#' || ($sLine[0] == '-' && $sLine[1] == '-'))) {
-                    $blComment = true;
+                if (!$blQuote && !$blComment) {
+                    if ($sLine[$i] == '#') {
+                        $blComment = true;
+                    } elseif (
+                        $sLine[$i] == '-'
+                        && isset($sLine[$i + 1]) && $sLine[$i + 1] == '-'
+                        && (!isset($sLine[$i + 2]) || $sLine[$i + 2] === ' ' || $sLine[$i + 2] === "\t" || $sLine[$i + 2] === "\r")
+                    ) {
+                        $blComment = true;
+                    }
                 }
 
                 // add this char to current command
@@ -392,8 +408,10 @@ class Database extends Core
                     $blQuote = !$blQuote; // toggle
                 }
 
-                // now test if command end is reached
-                if (!$blQuote && $sLine[$i] == ';') {
+                // now test if command end is reached. Comment-mode also
+                // gates this so a `;` inside a `# …` or `-- …` comment
+                // does not split the surrounding statement.
+                if (!$blQuote && !$blComment && $sLine[$i] == ';') {
                     // add this
                     $sThisSQL = trim($sThisSQL);
                     if ($sThisSQL) {

--- a/source/Setup/Sql/initial_data.sql
+++ b/source/Setup/Sql/initial_data.sql
@@ -394,12 +394,14 @@ VALUES ('0038ea008e74fdef4a0b0438ec2e4de6', 1, 'theme:o3-theme', 'sGATrackingId'
        ('f0138a6c6476ad469fdece47080d2e63', 1, 'theme:o3-theme', 'sDeliveryDaysOnStock', 'str', '6'),
        ('fd57bffe01b3ffbc77975bcc985df591', 1, 'theme:o3-theme', 'blPrimaryColor', 'str', '#82BA00'),
        ('fefe216a7bba565b54c92183ac5d2199', 1, 'theme:o3-theme', 'sShoppingCountry', 'str', 'DE'),
-       -- issue #118: settings present in theme.php but previously missing from initial_data.sql
+-- issue #118: settings present in theme.php but previously missing from initial_data.sql.
+-- iPasswordLength deliberately NOT seeded — see issue #125 (Config::reinitialize() caching
+-- leak). InputValidator falls back to 6 when unset, which the unit tests rely on.
+-- (Comments must stay at column 0; indented `--` inside an INSERT VALUES list silently
+-- swallowed the rest of this block before #136.)
        ('96839442ce96de4e558377d77da64c9b', 1, 'theme:o3-theme', 'sShowMode', 'bool', ''),
        ('9dc20d91df5914750245cf5ed5b0bdf4', 1, 'theme:o3-theme', 'sShowModePosition', 'select', 'topleft'),
        ('9cd18f45054c3dc812b2d9b64df3f014', 1, 'theme:o3-theme', 'blShowFiltersSearch', 'str', '10'),
-       -- iPasswordLength deliberately NOT seeded — see issue #125 (Config::reinitialize()
-       -- caching leak). InputValidator falls back to 6 when unset, which the unit tests rely on.
        ('ceb7d00c057007c2c3ba0d1737761d74', 1, 'theme:o3-theme', 'bInputCompany', 'bool', ''),
        ('3cd2cfb0758c0421346434007c133384', 1, 'theme:o3-theme', 'bInputUstid', 'bool', ''),
        ('eb96d79eb736a81b35270761622fa146', 1, 'theme:o3-theme', 'bInputState', 'bool', ''),
@@ -627,11 +629,12 @@ VALUES ('091fa9cc622351c270d5522741a21695', 'theme:o3-theme', 'sYouTubeUrl', 'fo
        ('f0463f97d4bcdf07c4fa49c5e86a713a', 'theme:o3-theme', 'bl_showWishlist', 'features', '', 1),
        ('f2ebd34a35aba9ff51a3b19dcfd7d268', 'theme:o3-theme', 'blFooterShowLinks', 'footer', '', 1),
        ('f3fbf3a218543967d2db45d9eda4bb7c', 'theme:o3-theme', 'sEmailLogo', 'logo', '', 1),
-       -- issue #118: settings present in theme.php but previously missing from initial_data.sql
+-- issue #118: display rows for settings previously missing from initial_data.sql.
+-- iPasswordLength display row also omitted — see issue #125.
+-- (Comments must stay at column 0 — see #136.)
        ('516c5d0284c8901295508fe5f2724014', 'theme:o3-theme', 'sShowMode', 'mode', '', 1),
        ('dbee9d7d717f78f309386792e483a214', 'theme:o3-theme', 'sShowModePosition', 'mode', 'topleft|topright|bottomleft|bottomright', 1),
        ('7cc228989a29ae584492ff08ab56cd92', 'theme:o3-theme', 'blShowFiltersSearch', 'display', '', 1),
-       -- iPasswordLength display row also omitted — see issue #125.
        ('1cc73e0e9c17e4d9ed1253196d463208', 'theme:o3-theme', 'bInputCompany', 'form', '', 1),
        ('6c692dddcddddd2c7ec3b33241833f1d', 'theme:o3-theme', 'bInputUstid', 'form', '', 1),
        ('dbfa6de4df36e0cd377f110a42a4eb19', 'theme:o3-theme', 'bInputState', 'form', '', 1),

--- a/tests/Unit/Setup/DatabaseCoverageTest.php
+++ b/tests/Unit/Setup/DatabaseCoverageTest.php
@@ -104,6 +104,88 @@ class DatabaseCoverageTest extends \OxidTestCase
     }
 
     /**
+     * Regression test for issue #136. parseQuery used to recognise `--`
+     * comments only at column 0; an indented `--` comment inside an
+     * INSERT VALUES list survived the line-join and, on a single-line
+     * MySQL parse, swallowed the rest of the statement. Result: the
+     * whole o3-theme settings block in initial_data.sql was silently
+     * dropped at install time.
+     *
+     * @covers \OxidEsales\EshopCommunity\Setup\Database::parseQuery
+     */
+    public function testParseQueryStripsDoubleDashCommentEvenWithLeadingWhitespace(): void
+    {
+        $database = new Database();
+        $sql = "INSERT INTO t VALUES (1),\n"
+            . "       -- skip me, leading-whitespace comment\n"
+            . '       (2);';
+        $statements = $database->parseQuery($sql);
+
+        $this->assertCount(1, $statements);
+        $this->assertStringNotContainsString('skip me', $statements[0]);
+        // The two values rows must still concatenate cleanly into one INSERT.
+        $this->assertStringContainsString('VALUES (1),', $statements[0]);
+        $this->assertStringContainsString('(2);', $statements[0]);
+    }
+
+    /**
+     * Per the MySQL spec, `--` only opens a comment when followed by
+     * whitespace (or EOL). A bare `--` between values must be left intact
+     * — if a future row ever needed `'--something'` as a literal value,
+     * we don't want parseQuery eating it.
+     *
+     * @covers \OxidEsales\EshopCommunity\Setup\Database::parseQuery
+     */
+    public function testParseQueryDoesNotTreatDoubleDashWithoutWhitespaceAsComment(): void
+    {
+        $database = new Database();
+        $sql = "SELECT '--keep' FROM t;";
+        $statements = $database->parseQuery($sql);
+
+        $this->assertSame(["SELECT '--keep' FROM t;"], $statements);
+    }
+
+    /**
+     * `#` and `--` inside quoted strings must not trigger comment mode.
+     *
+     * @covers \OxidEsales\EshopCommunity\Setup\Database::parseQuery
+     */
+    public function testParseQueryKeepsHashAndDoubleDashInsideQuotes(): void
+    {
+        $database = new Database();
+        $sql = "INSERT INTO t VALUES ('#ABC123', '-- not a comment');";
+        $statements = $database->parseQuery($sql);
+
+        $this->assertCount(1, $statements);
+        $this->assertStringContainsString('#ABC123', $statements[0]);
+        $this->assertStringContainsString('-- not a comment', $statements[0]);
+    }
+
+    /**
+     * A `;` inside a comment must NOT terminate the surrounding statement.
+     * Companion to issue #136 — the same fix discovered that the
+     * end-of-statement check used to ignore comment mode entirely, so a
+     * `;` inside a `-- …` comment line silently chopped the next INSERT
+     * row off the previous one.
+     *
+     * @covers \OxidEsales\EshopCommunity\Setup\Database::parseQuery
+     */
+    public function testParseQueryIgnoresSemicolonInsideComment(): void
+    {
+        $database = new Database();
+        $sql = "INSERT INTO t VALUES (1),\n"
+            . "-- explanatory note; with embedded semicolon\n"
+            . "       (2);\n"
+            . 'INSERT INTO t VALUES (3);';
+        $statements = $database->parseQuery($sql);
+
+        $this->assertCount(2, $statements);
+        $this->assertStringContainsString('VALUES (1),', $statements[0]);
+        $this->assertStringContainsString('(2);', $statements[0]);
+        $this->assertStringContainsString('VALUES (3);', $statements[1]);
+    }
+
+    /**
      * @covers \OxidEsales\EshopCommunity\Setup\Database::parseQuery
      */
     public function testParseQueryReturnsEmptyArrayForEmptyOrCommentOnlyInput(): void


### PR DESCRIPTION
Fixes [o3-shop/o3-shop#136](https://github.com/o3-shop/o3-shop/issues/136).

## Summary

`Setup\Database::parseQuery()` only recognised `--` SQL comments at column 0. An indented `-- …` comment inside an `INSERT VALUES` list slipped past the line-stripper, and once parseQuery joined every line into a single MySQL command, the `--` consumed everything to EOL, silently dropping the rest of the INSERT.

In v1.6.0-RC1 that took out the **entire `theme:o3-theme` seed block** of `initial_data.sql` — ~70 `oxconfig` rows and ~70 `oxconfigdisplay` rows never made it to the database. The visible symptom is the missing logo (`<img class="header__logo" src="…/img/">` with empty filename), but all theme settings are gone, including favicons, image sizes, slider config, footer toggles, social URLs, color tokens, and form-field flags. `theme:flow` and `theme:wave` are unaffected because their blocks have no embedded `-- ` comments.

## Changes

Two layers of fix so the SQL imports cleanly under both fixed and unfixed parseQuery — important because RC1 installs in the wild already have a busted o3-theme block, and any operator manually re-running the SQL needs it to be standalone-safe:

- **`source/Setup/Database.php`** — parseQuery now mirrors the MySQL spec: `-- ` opens a comment when followed by whitespace at *any* column, not just at line start. The end-of-statement `;` check additionally gates on `!\$blComment` so a `;` inside a comment cannot split the surrounding statement.
- **`source/Setup/Sql/initial_data.sql`** — dedents the inline §118 / §125 explanatory comments to column 0 and notes the column-0 invariant inline.
- **`tests/Unit/Setup/DatabaseCoverageTest.php`** — 4 new regression tests: indented `-- ` is stripped; bare `--` (no trailing whitespace) is preserved as data; `#` and `-- ` inside quoted strings stay intact; `;` inside a comment does not split the statement.

## Test plan

- [x] `./docker.sh test --fast tests/Unit/Setup/DatabaseCoverageTest.php` — 12 tests, 30 assertions, all green
- [x] `./docker.sh test --fast --all-failures tests/Unit` — 9321 tests, 17091 assertions, 0 failures
- [x] `./docker.sh cs-fixer` — clean
- [x] End-to-end against v1.6.0-RC1 install: re-running the regenerated o3-theme query imports 70/70 `oxconfig` + `oxconfigdisplay` rows; storefront then renders `…/out/o3-theme/img/logo_o3.png` instead of `…/img/`.

## Release notes for v1.6.0-RC1 installs already in the wild

Operators with an existing v1.6.0-RC1 install will not pick up the fixed seed automatically — they need to either:

1. Drop and re-import (clean reinstall), or
2. Manually run the regenerated `INSERT INTO oxconfig (…) VALUES … WHERE OXMODULE='theme:o3-theme';` and `INSERT INTO oxconfigdisplay (…) VALUES … WHERE OXCFGMODULE='theme:o3-theme';` blocks from `source/Setup/Sql/initial_data.sql` against their database.

We should call this out in the v1.6.0 final release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)