### PR TITLE
test(#141): playwright suite for the 2nd-level category menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,4 +83,8 @@ oxideshop.log
 /var/configuration-backup/shops/1.yaml
 /.claude/settings.local.json
 /.playwright-mcp/
+# Ad-hoc screenshots from the Playwright MCP browser tool — always saved
+# at repo root with arbitrary names. Real test screenshots land in
+# tests/Acceptance/playwright/test-results/ and stay tracked there.
+/*.png
 /openspec/changes/fix-underscore-method-inheritance/findings.json

--- a/tests/Acceptance/playwright/fixtures/db.ts
+++ b/tests/Acceptance/playwright/fixtures/db.ts
@@ -106,6 +106,74 @@ export class DbClient {
     );
     return (rows[0]?.c ?? 0) > 0;
   }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // oxcategories — used by the issue #141 menu specs.
+  //
+  // We only need the cleanup side (DELETE) here: tests create categories
+  // through the admin form (CategoryAdminPage) so the create path
+  // exercises the real oxleft/oxright/oxrootid bookkeeping. Cleanup,
+  // however, is a chore that should not depend on the admin GUI — the
+  // post-test DELETE just removes the row by OXID.
+  // ───────────────────────────────────────────────────────────────────────
+
+  async findCategoryByTitle(title: string): Promise<string | null> {
+    const rows = await this.query<{ OXID: string }>(
+      `SELECT OXID FROM oxcategories WHERE OXTITLE = ? AND OXSHOPID = 1 LIMIT 1`,
+      [title],
+    );
+    return rows[0]?.OXID ?? null;
+  }
+
+  async categoryExists(oxid: string): Promise<boolean> {
+    const rows = await this.query<{ c: number }>(
+      `SELECT COUNT(*) AS c FROM oxcategories WHERE OXID = ?`,
+      [oxid],
+    );
+    return (rows[0]?.c ?? 0) > 0;
+  }
+
+  /**
+   * Delete a category by OXID. Use `cascade: true` to also remove every
+   * descendant (oxleft/oxright nested-set range) — useful for cleaning up
+   * a 2-level + 3-level tree the test created.
+   *
+   * Caveat: we do NOT call OXID's `Category::delete()` (which would also
+   * tidy oxobject2category, oxseo, etc.). For test categories that have
+   * no products / SEO entries, a plain DELETE is sufficient; if that
+   * stops being true, swap this for an admin-fnc=delete invocation.
+   */
+  async deleteCategory(oxid: string, opts: { cascade?: boolean } = {}): Promise<number> {
+    if (opts.cascade) {
+      const rows = await this.query<{ OXLEFT: number; OXRIGHT: number; OXROOTID: string }>(
+        `SELECT OXLEFT, OXRIGHT, OXROOTID FROM oxcategories WHERE OXID = ? LIMIT 1`,
+        [oxid],
+      );
+      const root = rows[0];
+      if (!root) return 0;
+      const [result] = await this.pool.query<import('mysql2').ResultSetHeader>(
+        `DELETE FROM oxcategories
+         WHERE OXROOTID = ? AND OXLEFT >= ? AND OXRIGHT <= ?`,
+        [root.OXROOTID, root.OXLEFT, root.OXRIGHT],
+      );
+      return result.affectedRows ?? 0;
+    }
+    const [result] = await this.pool.query<import('mysql2').ResultSetHeader>(
+      `DELETE FROM oxcategories WHERE OXID = ?`,
+      [oxid],
+    );
+    return result.affectedRows ?? 0;
+  }
+
+  /**
+   * Delete a category by title. Returns the number of rows removed
+   * (0 if the title was not present — cleanup helpers shouldn't throw).
+   */
+  async deleteCategoryByTitle(title: string, opts: { cascade?: boolean } = {}): Promise<number> {
+    const oxid = await this.findCategoryByTitle(title);
+    if (!oxid) return 0;
+    return this.deleteCategory(oxid, opts);
+  }
 }
 
 function cryptoRandom(): string {

--- a/tests/Acceptance/playwright/helpers/category-cleanup.php
+++ b/tests/Acceptance/playwright/helpers/category-cleanup.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Tests-only helper: delete a category by OXID using OXID's
  * Category::delete() so the oxleft/oxright nested-set ranges in the

--- a/tests/Acceptance/playwright/helpers/category-cleanup.php
+++ b/tests/Acceptance/playwright/helpers/category-cleanup.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Tests-only helper: delete a category by OXID using OXID's
+ * Category::delete() so the oxleft/oxright nested-set ranges in the
+ * surrounding tree stay consistent. Plain `DELETE FROM oxcategories`
+ * leaves ancestors with bloated OXRIGHT and breaks getSubCatList()
+ * lookups for the rest of the test suite.
+ *
+ * Usage (inside the shop container):
+ *   php tests/Acceptance/playwright/helpers/category-cleanup.php <oxid> [<oxid> ...]
+ *
+ * Exit code: 0 if every requested OXID was deleted (or absent — idempotent);
+ * non-zero only on bootstrap failure.
+ */
+require_once __DIR__ . '/../../../../vendor/autoload.php';
+require_once __DIR__ . '/../../../../source/bootstrap.php';
+
+$ids = array_slice($argv, 1);
+if (empty($ids)) {
+    fwrite(STDERR, "Usage: category-cleanup.php <oxid> [...]\n");
+    exit(2);
+}
+
+$db = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
+
+foreach ($ids as $oxid) {
+    $cat = oxNew(\OxidEsales\Eshop\Application\Model\Category::class);
+    if (!$cat->load($oxid)) {
+        echo "absent : $oxid\n";
+        continue;
+    }
+
+    // OXID's SeoEncoderCategory::setRelatedToCategorySeoUrlsAsExpired()
+    // runs a subquery that assumes oxseo holds at most one row per
+    // (oxobjectid, oxtype). With multi-language demo data the test
+    // category has two rows (one per lang) and the subquery throws
+    // SQLSTATE[21000] Cardinality violation. We never need the SEO
+    // entries for these throwaway test categories — drop them first
+    // and the delete proceeds cleanly.
+    $db->execute(
+        'DELETE FROM oxseo WHERE oxobjectid = ? AND oxtype = ?',
+        [$oxid, 'oxcategory']
+    );
+
+    $cat->delete($oxid);
+    echo "deleted: $oxid\n";
+}

--- a/tests/Acceptance/playwright/helpers/category-seed.php
+++ b/tests/Acceptance/playwright/helpers/category-seed.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Tests-only helper: create a single category via OXID's
+ * `Category::save()` so the oxleft/oxright nested-set ranges in the
+ * surrounding tree stay consistent. Plain `INSERT INTO oxcategories`
+ * leaves the parent's OXRIGHT untouched and breaks
+ * `Category::getSubCatList()` for the rest of the test suite.
+ *
+ * Usage (inside the shop container):
+ *   php tests/Acceptance/playwright/helpers/category-seed.php <title> <parent_oxid_or_'oxrootid'>
+ *
+ * Output: the assigned OXID on stdout (one line, no trailing whitespace).
+ * Exit code: 0 on success, non-zero on bootstrap or save failure.
+ */
+require_once __DIR__ . '/../../../../vendor/autoload.php';
+require_once __DIR__ . '/../../../../source/bootstrap.php';
+
+if ($argc < 3) {
+    fwrite(STDERR, "Usage: category-seed.php <title> <parent_oxid_or_'oxrootid'>\n");
+    exit(2);
+}
+
+[$title, $parent] = [$argv[1], $argv[2]];
+
+$cat = oxNew(\OxidEsales\Eshop\Application\Model\Category::class);
+$cat->oxcategories__oxtitle = new \OxidEsales\Eshop\Core\Field(
+    $title,
+    \OxidEsales\Eshop\Core\Field::T_RAW,
+);
+$cat->oxcategories__oxparentid = new \OxidEsales\Eshop\Core\Field(
+    $parent,
+    \OxidEsales\Eshop\Core\Field::T_RAW,
+);
+$cat->oxcategories__oxactive = new \OxidEsales\Eshop\Core\Field(
+    1,
+    \OxidEsales\Eshop\Core\Field::T_RAW,
+);
+$cat->save();
+
+$oxid = $cat->getId();
+if (!$oxid) {
+    fwrite(STDERR, "category-seed.php: save did not assign an OXID\n");
+    exit(1);
+}
+echo $oxid;

--- a/tests/Acceptance/playwright/helpers/category-seed.php
+++ b/tests/Acceptance/playwright/helpers/category-seed.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Tests-only helper: create a single category via OXID's
  * `Category::save()` so the oxleft/oxright nested-set ranges in the

--- a/tests/Acceptance/playwright/helpers/config.ts
+++ b/tests/Acceptance/playwright/helpers/config.ts
@@ -1,6 +1,16 @@
+import { execFile } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { promisify } from 'node:util';
 import type { DbClient } from '../fixtures/db';
+
+const execFileP = promisify(execFile);
+
+/**
+ * Container name for the running shop. Override via SHOP_CONTAINER if
+ * the local stack uses a non-default name.
+ */
+const SHOP_CONTAINER = process.env.SHOP_CONTAINER ?? 'o3shop-app';
 
 /**
  * Path to the host-mounted OXID file cache (matches the docker-compose
@@ -32,6 +42,71 @@ export async function clearRevocationAntiSpamCache(): Promise<void> {
       .filter((name) => /^oxc_o3rev_antispam_/.test(name))
       .map((name) => fs.rm(path.join(dir, name), { force: true })),
   );
+}
+
+/**
+ * Wipe OXID's data caches under `source/tmp/` — `oxc_*` files only.
+ *
+ * Tests that mutate persistent state the storefront then renders
+ * against — the category tree above all (`oxc_oxcategories_*` plus the
+ * SEO caches) — must call this after the mutation, otherwise the
+ * storefront serves stale HTML.
+ *
+ * What we DELIBERATELY DO NOT touch:
+ *   - `container_cache.php`  the compiled Symfony DI container. Wiping
+ *                            this leaves the shop unable to bootstrap;
+ *                            a fresh page request returns blank-white
+ *                            until the container is rebuilt.
+ *   - `smarty/`              Smarty compiled templates. Wiping forces a
+ *                            full recompile on the next request which
+ *                            adds 5–10 s — enough to blow past the test
+ *                            navigation timeout. Templates compile from
+ *                            `.tpl` files which the test never touches,
+ *                            so the cache here can never be stale.
+ *
+ * Why `docker exec` instead of host `fs.rm`?
+ *   The bind mount between Docker-Desktop on macOS and the container
+ *   has a sync window where host writes (here: deletions) are not yet
+ *   visible to PHP processes running in the container. Removing files
+ *   *inside* the container guarantees the next storefront request sees
+ *   the empty cache.
+ */
+export async function clearShopRuntimeCache(): Promise<void> {
+  // sh -c so the glob expands inside the container.
+  await execFileP('docker', [
+    'exec',
+    SHOP_CONTAINER,
+    'sh',
+    '-c',
+    'rm -f /var/www/html/source/tmp/oxc_*',
+  ]).catch(() => undefined); // tmp absent or container down — ignore
+}
+
+/**
+ * Delete one or more categories using OXID's `Category::delete()` so
+ * the oxleft / oxright nested-set ranges in the surrounding tree are
+ * kept consistent. A plain `DELETE FROM oxcategories` (as `db.deleteCategory`
+ * does) is fine for stand-alone rows but corrupts the parent's right-edge
+ * once a subtree is removed — symptom: `Category::getSubCatList()` returns
+ * empty for an apparently-populated parent on the next test run.
+ *
+ * Implementation: shells out to `php` inside the shop container and runs
+ * the `category-cleanup.php` helper. Idempotent — unknown OXIDs are
+ * reported but don't fail the call.
+ *
+ * Returns the helper's stdout for diagnostics; non-zero exit codes throw.
+ */
+export async function deleteCategoriesViaModel(oxids: string[]): Promise<string> {
+  if (oxids.length === 0) return '';
+  const scriptPath = '/var/www/html/tests/Acceptance/playwright/helpers/category-cleanup.php';
+  const { stdout } = await execFileP('docker', [
+    'exec',
+    SHOP_CONTAINER,
+    'php',
+    scriptPath,
+    ...oxids,
+  ]);
+  return stdout;
 }
 
 // oxconfig.OXSHOPID is INT — owning shop ID. Single-shop CE uses 1.

--- a/tests/Acceptance/playwright/helpers/config.ts
+++ b/tests/Acceptance/playwright/helpers/config.ts
@@ -109,6 +109,42 @@ export async function deleteCategoriesViaModel(oxids: string[]): Promise<string>
   return stdout;
 }
 
+/**
+ * Create a single category through `Category::save()` and return its OXID.
+ *
+ * Used by the issue #141 frontend specs to seed Unter-Einhörner /
+ * Sub-Category / Sub-Sub-Category at test start so the suite is
+ * self-contained — i.e. survives a `docker.sh stop / remove volume /
+ * start` cycle that wipes any manually-added demo data.
+ *
+ * Why the model save, not a raw INSERT? It updates the parent's
+ * oxleft/oxright nested-set range, generates a real 32-char OXID, and
+ * runs the same SEO/cache hooks an admin form save would. The frontend
+ * megamenu won't show direct DB inserts because the parent's OXRIGHT
+ * stays at the pre-insert value.
+ */
+export async function seedCategoryViaModel(
+  title: string,
+  parentOxid: string,
+): Promise<string> {
+  const scriptPath = '/var/www/html/tests/Acceptance/playwright/helpers/category-seed.php';
+  const { stdout } = await execFileP('docker', [
+    'exec',
+    SHOP_CONTAINER,
+    'php',
+    scriptPath,
+    title,
+    parentOxid,
+  ]);
+  const oxid = stdout.trim();
+  if (!oxid) {
+    throw new Error(
+      `seedCategoryViaModel: empty OXID for title='${title}' parent='${parentOxid}'`,
+    );
+  }
+  return oxid;
+}
+
 // oxconfig.OXSHOPID is INT — owning shop ID. Single-shop CE uses 1.
 const OXSHOPID = 1;
 

--- a/tests/Acceptance/playwright/pages/admin/CategoryAdminPage.ts
+++ b/tests/Acceptance/playwright/pages/admin/CategoryAdminPage.ts
@@ -1,0 +1,147 @@
+import { Page, Locator, expect } from '@playwright/test';
+import { BaseAdminPage } from './BaseAdminPage';
+
+export interface NewCategoryInput {
+    /** The category title (oxtitle in default lang). */
+    title: string;
+    /**
+     * Parent category — either an OXID or the literal string `'oxrootid'`
+     * for a top-level category. The admin's parent <select> is keyed on
+     * OXID; passing a title is intentionally unsupported because the
+     * dropdown's option labels include " - " indentation prefixes.
+     */
+    parentId?: string;
+    /** Activate the category. Defaults to `true`. */
+    active?: boolean;
+}
+
+/**
+ * POM for `cl=category_main` — the admin category-edit form. Used by
+ * issue #141 specs to seed test categories before exercising the
+ * storefront menu, and to read back the OXID so cleanup can target the
+ * exact row.
+ *
+ * The framed admin home rendered by the `adminPage` fixture exposes a
+ * fresh `stoken` on every nav link — we read it from the navigation
+ * frame on first use and reuse it for the lifetime of this POM.
+ */
+export class CategoryAdminPage extends BaseAdminPage {
+    private cachedStoken: string | null = null;
+
+    constructor(page: Page) {
+        super(page);
+    }
+
+    private async stoken(): Promise<string> {
+        if (this.cachedStoken) return this.cachedStoken;
+        const navFrame = this.page
+            .frameLocator('frame[name="navigation"]')
+            .frameLocator('frame[name="adminnav"]');
+        const href = await navFrame.locator('a[href*="stoken="]').first().getAttribute('href');
+        const m = href?.match(/stoken=([A-Za-z0-9]+)/);
+        if (!m) {
+            throw new Error('CategoryAdminPage: could not extract stoken from admin nav.');
+        }
+        this.cachedStoken = m[1] ?? '';
+        return this.cachedStoken;
+    }
+
+    /**
+     * Navigate to the empty-form variant of `cl=category_main` so we can
+     * fill it and submit a new category. Bypasses the framed admin tree —
+     * `category_main` renders the form at the top level when invoked
+     * with `oxid=-1`, so the test interacts with regular DOM (no frame).
+     */
+    async gotoNewForm(): Promise<void> {
+        const stoken = await this.stoken();
+        await this.page.goto(`/admin/index.php?cl=category_main&oxid=-1&stoken=${stoken}`, {
+            waitUntil: 'domcontentloaded',
+        });
+        await expect(this.page.locator('form#myedit')).toHaveCount(1);
+    }
+
+    /**
+     * Submit a new category using the admin form. Returns the OXID of the
+     * created row.
+     *
+     * Why use the GUI rather than a raw INSERT? Because it goes through
+     * `Category::save()` and exercises the same validation, OXIDs, SEO
+     * URL generation, and oxleft/oxright nested-set bookkeeping a real
+     * admin user would. Issue #141 is a presentation bug; using the same
+     * code path catches regressions if the admin save side ever drifts.
+     */
+    async createCategory(input: NewCategoryInput): Promise<string> {
+        await this.gotoNewForm();
+
+        const form = this.page.locator('form#myedit');
+        await form.locator('input[name="editval[oxcategories__oxtitle]"]').fill(input.title);
+
+        if (input.parentId !== undefined) {
+            await form
+                .locator('select[name="editval[oxcategories__oxparentid]"]')
+                .selectOption(input.parentId);
+        }
+
+        // OXID's category-create form ships with the OXACTIVE checkbox
+        // **unchecked** (verified empirically — saving without touching
+        // it lands an `oxactive=0` row that the storefront then hides).
+        // Set the `checked` property directly in the DOM rather than
+        // `.check()` — the latter clicks the box, which fires inline
+        // onChange handlers in the OXID admin that nudge the form into
+        // a state where save() returns oxid=-1.
+        const activate = input.active !== false;
+        await form
+            .locator('input[type="checkbox"][name="editval[oxcategories__oxactive]"]')
+            .evaluate((el, on) => {
+                (el as HTMLInputElement).checked = on;
+            }, activate);
+
+        // OXID admin uses a non-standard JS submit path. It assigns
+        // `document.myedit.fnc.value = "save"` and then calls submit().
+        // Mimic that here so we don't depend on a particular button label
+        // (which is i18n-dependent).
+        await Promise.all([
+            this.page.waitForLoadState('domcontentloaded'),
+            this.page.evaluate(() => {
+                const f = document.querySelector<HTMLFormElement>('form#myedit');
+                if (!f) throw new Error('form#myedit not found at submit time');
+                const fnc = f.querySelector<HTMLInputElement>('input[name="fnc"]');
+                if (!fnc) throw new Error('hidden fnc input not found');
+                fnc.value = 'save';
+                f.submit();
+            }),
+        ]);
+
+        // OXID re-renders the same form post-save; the URL still says
+        // `oxid=-1` but the form's hidden inputs now carry the assigned
+        // OXID (UtilsObject::generateUID() output). Read it from
+        // editval[oxcategories__oxid] which is more specific than the
+        // top-level `oxid` hidden (which the controller updates last).
+        const newOxid = await this.page
+            .locator('form#myedit input[name="editval[oxcategories__oxid]"]')
+            .first()
+            .inputValue();
+        if (!newOxid || newOxid === '-1') {
+            throw new Error(
+                `CategoryAdminPage.createCategory: save did not assign an OXID ` +
+                    `(url=${this.page.url()}, hidden oxid='${newOxid}').`,
+            );
+        }
+        return newOxid;
+    }
+
+    // ─── Discovery helpers ────────────────────────────────────────────────────
+
+    /** Visit the populated parent <select> and return its options. */
+    async listParentOptions(): Promise<Array<{ value: string; text: string }>> {
+        await this.gotoNewForm();
+        return await this.page
+            .locator('select[name="editval[oxcategories__oxparentid]"]')
+            .evaluate((sel) =>
+                [...(sel as HTMLSelectElement).options].map((o) => ({
+                    value: o.value,
+                    text: o.text.trim(),
+                })),
+            );
+    }
+}

--- a/tests/Acceptance/playwright/pages/storefront/CategoryPage.ts
+++ b/tests/Acceptance/playwright/pages/storefront/CategoryPage.ts
@@ -1,0 +1,147 @@
+import { Page, Locator, expect } from '@playwright/test';
+import { BaseStorefrontPage } from './BaseStorefrontPage';
+
+function appendLangParam(path: string, lang: number): string {
+    const sep = path.includes('?') ? '&' : '?';
+    return `${path}${sep}lang=${lang}`;
+}
+
+/**
+ * POM for any o3-theme category page (PLP) and the storefront megamenu.
+ *
+ * Backs the issue #141 specs — 2nd-level menu rendering on the frontend.
+ */
+export class StorefrontCategoryPage extends BaseStorefrontPage {
+    constructor(page: Page) {
+        super(page);
+    }
+
+    /**
+     * Navigate to a storefront URL.
+     *
+     * Always pins the language to German (`lang=0`). Why: OXID's homepage
+     * has no SEO path of its own, so visiting `/` falls back to the
+     * Accept-Language header — and Chromium's default `en-US` would send
+     * us into the English shop where the test expectations ("Einhörner",
+     * "Party-Pinguine", "In dieser Kategorie") don't exist. SEO paths
+     * like `/Einhoerner/` carry an implicit language anyway, so the
+     * extra `?lang=0` is harmless on those.
+     */
+    async goto(path: string): Promise<void> {
+        const url = path.includes('lang=') ? path : appendLangParam(path, 0);
+        await this.page.goto(url, { waitUntil: 'domcontentloaded' });
+    }
+
+    // ─── Top-nav megamenu ─────────────────────────────────────────────────────
+
+    /**
+     * Top-nav `<li>` whose link's visible text matches `title`.
+     *
+     * Scoped to `.header__mainnav` so the mobile offcanvas duplicate of the
+     * nav (always present in DOM, hidden via Bootstrap utilities) doesn't
+     * confuse the match.
+     */
+    topNavItem(title: string): Locator {
+        return this.page
+            .locator('.header__mainnav .nav-item')
+            .filter({ hasText: title });
+    }
+
+    /** True iff the top-nav item exposes the .mega-dropdown affordance. */
+    async hasMegamenu(title: string): Promise<boolean> {
+        return (await this.topNavItem(title).evaluate((li) =>
+            li.classList.contains('mega-dropdown'),
+        )) as boolean;
+    }
+
+    /** Open the megamenu for `title` by hovering the top-nav link. */
+    async openMegamenu(title: string): Promise<Locator> {
+        const item = this.topNavItem(title);
+        await item.locator('.nav-link').first().hover();
+        const menu = item.locator('.megamenu');
+        await expect(menu).toBeVisible({ timeout: 2000 });
+        return menu;
+    }
+
+    /** Close any open megamenu by moving the cursor far away. */
+    async closeMegamenu(): Promise<void> {
+        // hover the page logo (always present, never a megamenu owner)
+        await this.page.locator('.header__logo, header .logo').first().hover();
+    }
+
+    /** All level-2 link texts inside the open megamenu for `title`. */
+    async megamenuItems(title: string): Promise<string[]> {
+        const menu = await this.openMegamenu(title);
+        return await menu.locator('a[data-level="is-level-2"]').allTextContents();
+    }
+
+    // ─── Inline sub-category strip on the PLP ─────────────────────────────────
+
+    /** The labelled <nav> rendered above the product grid. */
+    get inlineSubcatNav(): Locator {
+        return this.page.locator('nav.alist__orga-subcats');
+    }
+
+    /** Texts of the chip links in the inline strip. */
+    async inlineSubcatChips(): Promise<string[]> {
+        return await this.inlineSubcatNav.locator('a.btn').allTextContents();
+    }
+
+    /** Eyebrow label text, read from the data-label attribute (rendered via ::before). */
+    async inlineSubcatLabel(): Promise<string | null> {
+        return await this.inlineSubcatNav.getAttribute('data-label');
+    }
+
+    // ─── Geometry checks (positioning bugs from #141) ─────────────────────────
+
+    /**
+     * Pixel gap between the parent <li>'s bottom edge and the megamenu's top edge.
+     * Should be 0 — the menu uses a transparent padding-top as hover-bridge so
+     * the cursor never crosses an unhovered region (#141 issue 2).
+     */
+    async measureHoverBridgeGap(title: string): Promise<number> {
+        const item = this.topNavItem(title);
+        await item.locator('.nav-link').first().hover();
+        return await item.evaluate((li) => {
+            const menu = li.querySelector('.megamenu') as HTMLElement | null;
+            if (!menu) return Number.NaN;
+            const liRect = li.getBoundingClientRect();
+            const menuRect = menu.getBoundingClientRect();
+            return Math.round(menuRect.top - liRect.bottom);
+        });
+    }
+
+    /**
+     * True iff the open megamenu is anchored to the *right* of its parent.
+     *
+     * Checks the geometry rather than `getComputedStyle().left/right`,
+     * because once `right: 0` resolves, `left` collapses from `auto` to
+     * a negative pixel value (parent-width minus menu-width). The
+     * semantically correct check is: the menu's right edge aligns with
+     * the parent LI's right edge.
+     */
+    async isMegamenuRightAnchored(title: string): Promise<boolean> {
+        const item = this.topNavItem(title);
+        await item.locator('.nav-link').first().hover();
+        return await item.evaluate((li) => {
+            const menu = li.querySelector('.megamenu') as HTMLElement | null;
+            if (!menu) return false;
+            const liRect = li.getBoundingClientRect();
+            const menuRect = menu.getBoundingClientRect();
+            // Right edges within 5 px (subpixel + the panel pseudo's borders)
+            return Math.abs(menuRect.right - liRect.right) <= 5;
+        });
+    }
+
+    /** True iff the open megamenu's right edge lies within the viewport. */
+    async isMegamenuOnScreen(title: string): Promise<boolean> {
+        const item = this.topNavItem(title);
+        await item.locator('.nav-link').first().hover();
+        return await item.evaluate((li) => {
+            const menu = li.querySelector('.megamenu') as HTMLElement | null;
+            if (!menu) return false;
+            const r = menu.getBoundingClientRect();
+            return r.left >= 0 && r.right <= window.innerWidth + 1;
+        });
+    }
+}

--- a/tests/Acceptance/playwright/tests/storefront/menu/2nd-level-menu-e2e.spec.ts
+++ b/tests/Acceptance/playwright/tests/storefront/menu/2nd-level-menu-e2e.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect } from '../../../fixtures';
+import { CategoryAdminPage } from '../../../pages/admin/CategoryAdminPage';
+import { StorefrontCategoryPage } from '../../../pages/storefront/CategoryPage';
+import {
+    clearShopRuntimeCache,
+    deleteCategoriesViaModel,
+} from '../../../helpers/config';
+
+/**
+ * Composed E2E test for issue #141.
+ *
+ * Flow (the order the user asked for, in case anything fails midway):
+ *   1. CREATE three categories via the admin form (cl=category_main):
+ *        TestL2A     — direct child of `Pandas`     (level-2)
+ *        TestL2B     — direct child of `Pandas`     (level-2)
+ *        TestL3      — direct child of TestL2A      (level-3)
+ *      Pandas is used because the demo data ships it without sub-cats,
+ *      so the test starts from a known-empty subtree.
+ *   2. NAVIGATE the frontend and assert:
+ *        - Pandas now exposes a megamenu with TestL2A + TestL2B
+ *        - /Pandas/ inline strip lists TestL2A + TestL2B as chips
+ *        - /Pandas/<TestL2A>/ inline strip lists TestL3 as a chip
+ *        - both views show the **same** depth (no level-3 in the megamenu)
+ *   3. CLEAN UP by cascading-deleting the TestL2A subtree (removes
+ *      TestL2A + TestL3) and TestL2B. Cleanup runs in `afterAll` so a
+ *      mid-test failure still triggers it.
+ */
+
+const PANDAS_OXID = '5a1b82c8a7c97d78f270315bb7d5e20b';
+const L2A = 'PW-Test-L2-A';
+const L2B = 'PW-Test-L2-B';
+const L3 = 'PW-Test-L3';
+
+test.describe.serial('storefront / 2nd-level menu E2E (#141)', () => {
+    let oxidL2A: string;
+    let oxidL2B: string;
+    let oxidL3: string;
+
+    test.beforeAll(async ({ db }) => {
+        // Belt-and-braces: if a previous run died before cleanup, drop
+        // any leftovers before recreating. We resolve OXIDs and delete
+        // through Category::delete() so the parent's nested-set ranges
+        // shrink correctly — a plain DELETE leaves Pandas with bloated
+        // OXRIGHT, which the next run's getSubCatList() reads as
+        // "Pandas has children" even when the rows are gone.
+        const ids = (
+            await Promise.all([
+                db.findCategoryByTitle(L3),
+                db.findCategoryByTitle(L2A),
+                db.findCategoryByTitle(L2B),
+            ])
+        ).filter((id): id is string => !!id);
+        if (ids.length > 0) {
+            await deleteCategoriesViaModel(ids);
+            await clearShopRuntimeCache();
+        }
+    });
+
+    test.afterAll(async ({ db }) => {
+        const ids = (
+            await Promise.all([
+                db.findCategoryByTitle(L3),
+                db.findCategoryByTitle(L2A),
+                db.findCategoryByTitle(L2B),
+            ])
+        ).filter((id): id is string => !!id);
+        if (ids.length > 0) {
+            await deleteCategoriesViaModel(ids);
+        }
+        // Bust the storefront category-tree cache so a follow-up run starts clean.
+        await clearShopRuntimeCache();
+    });
+
+    test('1) admin: create level-2 + level-3 sub-categories under Pandas', async ({
+        adminPage,
+        db,
+    }) => {
+        const admin = new CategoryAdminPage(adminPage);
+
+        oxidL2A = await admin.createCategory({ title: L2A, parentId: PANDAS_OXID });
+        oxidL2B = await admin.createCategory({ title: L2B, parentId: PANDAS_OXID });
+        expect(oxidL2A).not.toBe('');
+        expect(oxidL2B).not.toBe('');
+        expect(oxidL2A).not.toBe(oxidL2B);
+
+        oxidL3 = await admin.createCategory({ title: L3, parentId: oxidL2A });
+        expect(oxidL3).not.toBe('');
+
+        // OXID caches the category tree in source/tmp/oxc_aLocalCatCache.txt;
+        // without clearing it the storefront serves stale HTML and the
+        // megamenu won't show the new sub-cats.
+        await clearShopRuntimeCache();
+
+        // DB sanity: rows exist with the expected parent links
+        await expect.poll(() => db.categoryExists(oxidL2A)).toBe(true);
+        await expect.poll(() => db.categoryExists(oxidL2B)).toBe(true);
+        await expect.poll(() => db.categoryExists(oxidL3)).toBe(true);
+
+        const l3parent = await db.query<{ OXPARENTID: string }>(
+            `SELECT OXPARENTID FROM oxcategories WHERE OXID = ? LIMIT 1`,
+            [oxidL3],
+        );
+        expect(l3parent[0]?.OXPARENTID).toBe(oxidL2A);
+
+        // Pandas's oxright must have grown to enclose its three new
+        // descendants — otherwise `Category::getSubCatList()` returns
+        // empty and the storefront megamenu never appears (#141 spec).
+        // 1 left + 3 descendants × 2 (L+R) + 1 right = 8.
+        const pandasRange = await db.query<{ OXLEFT: number; OXRIGHT: number }>(
+            `SELECT OXLEFT, OXRIGHT FROM oxcategories WHERE OXID = ? LIMIT 1`,
+            [PANDAS_OXID],
+        );
+        expect(pandasRange[0]?.OXRIGHT).toBeGreaterThanOrEqual(8);
+    });
+
+    test('2) storefront: megamenu and inline strip reflect the new tree (consistent depth)', async ({
+        storefrontPage,
+    }) => {
+        const plp = new StorefrontCategoryPage(storefrontPage);
+
+        // Pandas now has children → its top-nav <li> must gain .mega-dropdown.
+        // Poll a few times: OXID's category-list build caches per request,
+        // so the very first storefront response after the admin mutations
+        // can occasionally race the cache repopulation. A reload or two
+        // is enough.
+        await expect
+            .poll(
+                async () => {
+                    await plp.goto('/');
+                    return plp.hasMegamenu('Pandas');
+                },
+                { message: 'Pandas should expose .mega-dropdown after admin create', timeout: 10_000 },
+            )
+            .toBe(true);
+        const megamenuItems = await plp.megamenuItems('Pandas');
+        expect(megamenuItems).toEqual(expect.arrayContaining([L2A, L2B]));
+
+        // Hover bridge: no dead zone (gap ≤ 0) on a freshly-grown megamenu.
+        const gap = await plp.measureHoverBridgeGap('Pandas');
+        expect(gap).toBeLessThanOrEqual(0);
+
+        // Crucially: NO level-3 appears in the megamenu, even though L3
+        // exists as a grandchild. This is the consistency contract from
+        // issue #141 — both megamenu and inline strip show direct children only.
+        await plp.closeMegamenu();
+        const menu = await plp.openMegamenu('Pandas');
+        expect(await menu.locator('a[data-level="is-level-3"]').count()).toBe(0);
+
+        // PLP /Pandas/ → inline strip shows the same two level-2 chips.
+        await plp.goto('/Pandas/');
+        const pandasChips = await plp.inlineSubcatChips();
+        expect(pandasChips).toEqual(expect.arrayContaining([L2A, L2B]));
+        expect(pandasChips).not.toContain(L3); // direct children only
+
+        // Drilling into TestL2A → its PLP shows TestL3 as the lone chip.
+        // We follow the chip to keep the test data-driven (no hard-coded URL).
+        await plp.inlineSubcatNav.locator('a.btn', { hasText: L2A }).click();
+        await storefrontPage.waitForLoadState('domcontentloaded');
+        const l2aChips = await plp.inlineSubcatChips();
+        expect(l2aChips).toEqual([L3]);
+
+        // Eyebrow label is rendered on the L2A PLP too.
+        expect(await plp.inlineSubcatLabel()).toBe('In dieser Kategorie');
+    });
+
+    test('3) admin/db: cleanup removes the seeded categories', async ({ db }) => {
+        // Delete through Category::delete() so the parent's nested-set
+        // ranges shrink correctly. Order matters: L3 first (deepest), then
+        // L2A and L2B; otherwise the model-level delete on a parent skips
+        // the descendant rows and leaves them orphaned.
+        const out = await deleteCategoriesViaModel([oxidL3, oxidL2A, oxidL2B]);
+        expect(out).toContain(`deleted: ${oxidL3}`);
+        expect(out).toContain(`deleted: ${oxidL2A}`);
+        expect(out).toContain(`deleted: ${oxidL2B}`);
+
+        await expect.poll(() => db.categoryExists(oxidL2A)).toBe(false);
+        await expect.poll(() => db.categoryExists(oxidL2B)).toBe(false);
+        await expect.poll(() => db.categoryExists(oxidL3)).toBe(false);
+
+        // Bust the cache so the next test sees a Pandas without sub-cats.
+        await clearShopRuntimeCache();
+    });
+
+    test('3b) storefront: Pandas no longer exposes a megamenu after cleanup', async ({
+        storefrontPage,
+    }) => {
+        // Bust any stale OXID list-rendering cache that could keep stale
+        // children on screen briefly. We hit a different page first to
+        // avoid serving the prior /Pandas/ HTML out of any browser cache.
+        const plp = new StorefrontCategoryPage(storefrontPage);
+        await plp.goto('/Fuechse/');
+        await plp.goto('/');
+
+        // Without children, Pandas reverts to a plain .nav-item.
+        // Smarty/Composer caches can lag — poll a few times before failing.
+        await expect
+            .poll(async () => plp.hasMegamenu('Pandas'), {
+                message: 'Pandas should no longer have .mega-dropdown after cleanup',
+                timeout: 5_000,
+            })
+            .toBe(false);
+    });
+});

--- a/tests/Acceptance/playwright/tests/storefront/menu/2nd-level-menu.spec.ts
+++ b/tests/Acceptance/playwright/tests/storefront/menu/2nd-level-menu.spec.ts
@@ -60,8 +60,16 @@ test.describe('storefront / 2nd-level menu (#141)', () => {
     });
 
     test.afterAll(async ({ db }) => {
+        // Leaf-first: Category::delete() does not cascade, so a parent
+        // can't be removed while its child still exists. Sub-Sub-Category
+        // → Sub-Category → Unter-Einhörner.
+        const orderedTitles = [
+            SEED_TITLES.L3_PINGUINE,
+            SEED_TITLES.L2_PINGUINE,
+            SEED_TITLES.L2_EINHOERNER,
+        ];
         const ids = (
-            await Promise.all(Object.values(SEED_TITLES).map((t) => db.findCategoryByTitle(t)))
+            await Promise.all(orderedTitles.map((t) => db.findCategoryByTitle(t)))
         ).filter((id): id is string => !!id);
         if (ids.length > 0) {
             await deleteCategoriesViaModel(ids);

--- a/tests/Acceptance/playwright/tests/storefront/menu/2nd-level-menu.spec.ts
+++ b/tests/Acceptance/playwright/tests/storefront/menu/2nd-level-menu.spec.ts
@@ -1,22 +1,74 @@
 import { test, expect } from '../../../fixtures';
 import { StorefrontCategoryPage } from '../../../pages/storefront/CategoryPage';
+import {
+    clearShopRuntimeCache,
+    deleteCategoriesViaModel,
+    seedCategoryViaModel,
+} from '../../../helpers/config';
 
 /**
  * Issue #141 — 2nd-level menu polish.
  *
- * These specs run against **existing demo data** so they're the cheapest
- * smoke tests of the megamenu / inline sub-category strip. The composed
- * E2E spec (see ../menu-e2e/...) creates its own categories before
- * asserting; the tests here just validate what's already shipped.
+ * These specs validate the megamenu / inline sub-category strip against
+ * a **fixture tree the spec seeds itself** (see beforeAll). They used to
+ * lean on hand-added demo categories, which broke any time the maintainer
+ * wiped the docker volume — the suite now creates the same shape of
+ * tree on the fly and removes it in afterAll.
  *
- * Demo categories the specs depend on:
- *   • Einhörner       → has sub-cat `Unter-Einhörner` (left-anchored case)
- *   • Party-Pinguine  → has sub-cat `Unter-Party-Pinguine` plus level-3
- *                       (right-edge case — must flip the dropdown anchor)
- *   • Pandas          → no sub-cats (negative test — no megamenu rendered)
+ * Fixture tree:
+ *   Einhörner (top-cat from initial_data.sql)
+ *     └─ Unter-Einhörner       — left-anchored megamenu case
+ *   Party-Pinguine (top-cat)
+ *     └─ Sub-Category          — right-anchored megamenu case
+ *          └─ Sub-Sub-Category — depth-consistency check (must NOT
+ *                                appear in the megamenu)
+ *   Pandas (top-cat) — left untouched: negative test for no-children
  */
 
+const EINHOERNER_OXID = '0ab8dc7f345c3da293988a706d85643a';
+const PARTY_PINGUINE_OXID = '93ff2bf29071afef17c57beb3fcc9d71';
+
+const SEED_TITLES = {
+    L2_EINHOERNER: 'Unter-Einhörner',
+    L2_PINGUINE: 'Sub-Category',
+    L3_PINGUINE: 'Sub-Sub-Category',
+} as const;
+
 test.describe('storefront / 2nd-level menu (#141)', () => {
+    test.beforeAll(async ({ db }) => {
+        // Belt-and-braces: drop any leftover from a previous failed run
+        // before recreating, so a re-run starts from a known state.
+        const stale = (
+            await Promise.all(Object.values(SEED_TITLES).map((t) => db.findCategoryByTitle(t)))
+        ).filter((id): id is string => !!id);
+        if (stale.length > 0) {
+            await deleteCategoriesViaModel(stale);
+        }
+
+        // Create level-2 first (Einhörner branch and Party-Pinguine branch),
+        // then the level-3 under Sub-Category.
+        await seedCategoryViaModel(SEED_TITLES.L2_EINHOERNER, EINHOERNER_OXID);
+        const subCategoryOxid = await seedCategoryViaModel(
+            SEED_TITLES.L2_PINGUINE,
+            PARTY_PINGUINE_OXID,
+        );
+        await seedCategoryViaModel(SEED_TITLES.L3_PINGUINE, subCategoryOxid);
+
+        // Bust the storefront category-tree cache so the next page request
+        // sees the new fixture tree instead of the pre-seed snapshot.
+        await clearShopRuntimeCache();
+    });
+
+    test.afterAll(async ({ db }) => {
+        const ids = (
+            await Promise.all(Object.values(SEED_TITLES).map((t) => db.findCategoryByTitle(t)))
+        ).filter((id): id is string => !!id);
+        if (ids.length > 0) {
+            await deleteCategoriesViaModel(ids);
+        }
+        await clearShopRuntimeCache();
+    });
+
     test('PLP renders the labelled sub-category strip with chip-styled links', async ({
         storefrontPage,
     }) => {
@@ -30,10 +82,10 @@ test.describe('storefront / 2nd-level menu (#141)', () => {
         // ARIA label echoes the same string for screen-reader users
         await expect(plp.inlineSubcatNav).toHaveAttribute('aria-label', 'In dieser Kategorie');
 
-        // Demo data: Einhörner has at least the user-created `Unter-Einhörner`
+        // Fixture: Einhörner has Unter-Einhörner as its level-2.
         const chips = await plp.inlineSubcatChips();
         expect(chips.length).toBeGreaterThan(0);
-        expect(chips).toContain('Unter-Einhörner');
+        expect(chips).toContain(SEED_TITLES.L2_EINHOERNER);
 
         // Chips are pill-shaped (border-radius >= 24 → effectively 999px clamped)
         const radius = await plp.inlineSubcatNav

--- a/tests/Acceptance/playwright/tests/storefront/menu/2nd-level-menu.spec.ts
+++ b/tests/Acceptance/playwright/tests/storefront/menu/2nd-level-menu.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect } from '../../../fixtures';
+import { StorefrontCategoryPage } from '../../../pages/storefront/CategoryPage';
+
+/**
+ * Issue #141 — 2nd-level menu polish.
+ *
+ * These specs run against **existing demo data** so they're the cheapest
+ * smoke tests of the megamenu / inline sub-category strip. The composed
+ * E2E spec (see ../menu-e2e/...) creates its own categories before
+ * asserting; the tests here just validate what's already shipped.
+ *
+ * Demo categories the specs depend on:
+ *   • Einhörner       → has sub-cat `Unter-Einhörner` (left-anchored case)
+ *   • Party-Pinguine  → has sub-cat `Unter-Party-Pinguine` plus level-3
+ *                       (right-edge case — must flip the dropdown anchor)
+ *   • Pandas          → no sub-cats (negative test — no megamenu rendered)
+ */
+
+test.describe('storefront / 2nd-level menu (#141)', () => {
+    test('PLP renders the labelled sub-category strip with chip-styled links', async ({
+        storefrontPage,
+    }) => {
+        const plp = new StorefrontCategoryPage(storefrontPage);
+        await plp.goto('/Einhoerner/');
+
+        // Eyebrow label is rendered via data-label + CSS ::before
+        const label = await plp.inlineSubcatLabel();
+        expect(label).toBe('In dieser Kategorie');
+
+        // ARIA label echoes the same string for screen-reader users
+        await expect(plp.inlineSubcatNav).toHaveAttribute('aria-label', 'In dieser Kategorie');
+
+        // Demo data: Einhörner has at least the user-created `Unter-Einhörner`
+        const chips = await plp.inlineSubcatChips();
+        expect(chips.length).toBeGreaterThan(0);
+        expect(chips).toContain('Unter-Einhörner');
+
+        // Chips are pill-shaped (border-radius >= 24 → effectively 999px clamped)
+        const radius = await plp.inlineSubcatNav
+            .locator('a.btn')
+            .first()
+            .evaluate((a) => parseFloat(getComputedStyle(a).borderRadius));
+        expect(radius).toBeGreaterThanOrEqual(20);
+    });
+
+    test('top-nav megamenu opens with caret and styled panel (left-anchored)', async ({
+        storefrontPage,
+    }) => {
+        const plp = new StorefrontCategoryPage(storefrontPage);
+        await plp.goto('/');
+
+        expect(await plp.hasMegamenu('Einhörner')).toBe(true);
+        const menu = await plp.openMegamenu('Einhörner');
+
+        // Visible panel: white bg + rounded radius drawn by ::before pseudo
+        const panelStyles = await menu.evaluate((el) => {
+            const cs = getComputedStyle(el, '::before');
+            return {
+                bg: cs.backgroundColor,
+                radius: parseFloat(cs.borderRadius),
+                hasShadow: cs.boxShadow !== 'none' && cs.boxShadow !== '',
+            };
+        });
+        expect(panelStyles.bg).toBe('rgb(255, 255, 255)');
+        expect(panelStyles.radius).toBeGreaterThanOrEqual(8);
+        expect(panelStyles.hasShadow).toBe(true);
+
+        // Caret (::after pseudo) is anchored to the LEFT side for left-side items
+        const caret = await menu.evaluate((el) => {
+            const cs = getComputedStyle(el, '::after');
+            return { left: cs.left, right: cs.right };
+        });
+        expect(caret.left).not.toBe('auto');
+    });
+
+    test('right-side top-nav megamenu flips anchoring to stay on screen', async ({
+        storefrontPage,
+    }) => {
+        const plp = new StorefrontCategoryPage(storefrontPage);
+        await plp.goto('/');
+
+        expect(await plp.hasMegamenu('Party-Pinguine')).toBe(true);
+
+        // The CSS flip target the last two .nav-items so the panel doesn't
+        // overflow the viewport on the right.
+        expect(await plp.isMegamenuRightAnchored('Party-Pinguine')).toBe(true);
+        expect(await plp.isMegamenuOnScreen('Party-Pinguine')).toBe(true);
+    });
+
+    test('hover bridge: no dead zone between parent and dropdown', async ({ storefrontPage }) => {
+        // Issue #141 issue 2: cursor moving parent → menu must never cross
+        // an unhovered region. The menu uses padding-top: 12px as a
+        // transparent hit-area bridge; the visible panel is offset via ::before.
+        //
+        // Contract: `gap <= 0`. Zero means menu's hit area starts exactly
+        // at LI bottom; negative means it overlaps the LI from above
+        // (e.g. -5 from subpixel rounding / chevron transform). Both are
+        // safe — only a *positive* gap would leave a dead zone.
+        const plp = new StorefrontCategoryPage(storefrontPage);
+        await plp.goto('/');
+
+        const gap = await plp.measureHoverBridgeGap('Einhörner');
+        expect(gap).toBeLessThanOrEqual(0);
+    });
+
+    test('megamenu and inline strip render the same depth (one level)', async ({
+        storefrontPage,
+    }) => {
+        // Issue #141 issue 3: the megamenu used to render level-2 *and*
+        // level-3 categories nested; the inline strip rendered only level-2.
+        // The fix removes the level-3 rendering from categorylist.tpl so
+        // both views show direct children only — consistent depth.
+        const plp = new StorefrontCategoryPage(storefrontPage);
+        await plp.goto('/Party-Pinguine/');
+
+        // The megamenu under Party-Pinguine must NOT contain any [data-level="is-level-3"]
+        const menu = await plp.openMegamenu('Party-Pinguine');
+        const level3Count = await menu.locator('a[data-level="is-level-3"]').count();
+        expect(level3Count).toBe(0);
+
+        // Inline strip on the PLP shows only direct children — same depth contract
+        const chips = await plp.inlineSubcatChips();
+        expect(chips.length).toBeGreaterThan(0);
+    });
+
+    test('top-nav category without sub-cats does NOT render a megamenu', async ({
+        storefrontPage,
+    }) => {
+        // Demo: Pandas has no sub-cats, so it must not gain .mega-dropdown
+        // and its <li> must contain no .megamenu node.
+        const plp = new StorefrontCategoryPage(storefrontPage);
+        await plp.goto('/');
+
+        const pandas = plp.topNavItem('Pandas');
+        await expect(pandas).toHaveCount(1);
+        const isMega = await plp.hasMegamenu('Pandas');
+        expect(isMega).toBe(false);
+        await expect(pandas.locator('.megamenu')).toHaveCount(0);
+    });
+});


### PR DESCRIPTION
## Summary

Adds Playwright E2E coverage for the [#141 menu polish in o3-theme](https://github.com/o3-shop/o3-Theme/pull/21). Two specs under `tests/Acceptance/playwright/tests/storefront/menu/`:

- **2nd-level-menu.spec.ts** — six checks against the existing demo data (eyebrow label, chip styling, megamenu open/anchor, hover-bridge no dead zone, depth consistency, and the negative case for Pandas).
- **2nd-level-menu-e2e.spec.ts** — composed flow per the user-asked order (2 → 3 → 1):
  - **Step 1** admin GUI (`cl=category_main`) creates Pandas/L2A, Pandas/L2B, L2A/L3
  - **Step 2** storefront verifies the megamenu + inline strip both reflect the new tree at the same depth
  - **Step 3** cleanup removes the seeded categories and Pandas reverts to a plain nav-item

Plus the supporting page objects, fixtures, helpers, and a `.gitignore` tweak to drop ad-hoc Playwright-MCP screenshots from the repo root.

## What was added

| File | Purpose |
|---|---|
| `pages/storefront/CategoryPage.ts` | POM for PLP + megamenu (`topNavItem`, `openMegamenu`, `inlineSubcatChips`, `measureHoverBridgeGap`, `isMegamenuRightAnchored`) |
| `pages/admin/CategoryAdminPage.ts` | POM for `cl=category_main` (`gotoNewForm`, `createCategory`) — exercises the real admin form |
| `tests/storefront/menu/2nd-level-menu.spec.ts` | Step 2 — frontend assertions against existing demo data |
| `tests/storefront/menu/2nd-level-menu-e2e.spec.ts` | Steps 1+2+3 composed |
| `helpers/category-cleanup.php` | PHP CLI invoking `Category::delete()` so the nested-set tree stays consistent |
| `helpers/config.ts` (extended) | `clearShopRuntimeCache()` (in-container `rm -f oxc_*`), `deleteCategoriesViaModel()` |
| `fixtures/db.ts` (extended) | `findCategoryByTitle`, `categoryExists`, `deleteCategory(cascade?)` |
| `.gitignore` | Drops `/.png` at repo root (Playwright-MCP screenshots) |

## Five non-obvious things the suite had to work around

Worth knowing if extending category coverage:

1. **Admin OXACTIVE checkbox** ships *unchecked* for new categories. Saving without an explicit set lands `oxactive=0` and the storefront hides the row. Set `.checked = true` directly on the DOM — `.check()` clicks the box, which fires an OXID inline `onchange` that nudges the form into a state where `save()` returns `oxid=-1`.
2. Plain `DELETE FROM oxcategories` corrupts the parent's nested-set range; cleanup must go through `Category::delete()`.
3. `Category::delete()` then chokes on multi-language `oxseo` entries (`SQLSTATE[21000] cardinality violation`) — the helper pre-deletes `oxseo` rows for the target oxid first.
4. Cache wipe must run inside the container (Docker-on-macOS bind-mount sync window) and must NOT touch `container_cache.php` (blank pages) or `smarty/` (5–10 s recompile stalls the test).
5. Storefront `/` follows browser `Accept-Language`; Chromium's default `en-US` lands on the English shop. The POM pins `?lang=0` on every goto so the German expectations ("Einhörner", "In dieser Kategorie") match.

## Test plan

- [x] `./docker.sh playwright tests/storefront/menu/` → 10/10 green in ~11 s
- [x] Full suite still runs: `./docker.sh playwright` → 34 passed (the 4 unrelated Mailpit failures pre-date this branch)
- [ ] Reviewer to verify on a fresh `./docker.sh start` — the suite is idempotent (beforeAll wipes any leftover test categories before recreating)

## Related

- o3-theme fix: o3-shop/o3-Theme#21

🤖 Generated with [Claude Code](https://claude.com/claude-code)