### PR TITLE
feat(#140): wire live execution in ReleaseCommand (§15)

### DIFF
--- a/openspec/changes/automate-release-procedure/tasks.md
+++ b/openspec/changes/automate-release-procedure/tasks.md
@@ -116,7 +116,7 @@ New components:
   DefaultBranchResolver per-package release-branch map (matches Section 1.5 decisions)
   GitLsRemoteRepoIntrospector  reference RemoteRepoIntrospector via `git ls-remote --tags --heads`
 
-ReleaseCommand now accepts an optional `(planner, printer)` constructor pair; production-mode invocations build the default planner inline with `Https*Fetcher`s + `GitLsRemoteRepoIntrospector` + `GhCliReleaseNotesProvider`. Tests inject stubs that bypass the parent constructor entirely so no real services are constructed. Live execution still prints a "Section 14 wiring pending" notice (4 exit codes: OK / USAGE_ERROR / PRE_FLIGHT_ABORT / PLAN_ERROR).
+ReleaseCommand now accepts an optional `(planner, printer)` constructor pair; production-mode invocations build the default planner inline with `Https*Fetcher`s + `GitLsRemoteRepoIntrospector` + `GhCliReleaseNotesProvider`. Tests inject stubs that bypass the parent constructor entirely so no real services are constructed. Live execution still prints a "Section 15 wiring pending" notice (4 exit codes: OK / USAGE_ERROR / PRE_FLIGHT_ABORT / PLAN_ERROR) — see §15 for the open work to land it.
 
 Refactor: `VersionResolution` gained an optional `latestTag` field so the planner can pass it to `TagCutter` for case-3 candidates. All 14 Section 6 tests still pass.
 
@@ -156,29 +156,53 @@ No `bin/release` code changes — the merge-back machinery already targets `main
     - PR required to merge (`required_approving_review_count: 0` — no approver requirement, but no direct pushes either)
     - No force-pushes (`allow_force_pushes: false`)
     - No branch deletion (`allow_deletions: false`)
-    Linear-history rule intentionally NOT enforced (would conflict with §15.4's "merge commit, not squash" guidance for merge-back PRs). `enforce_admins: false` so the maintainer can land emergency direct pushes if needed.
-- [x] 14.5 Verify uniformly: confirmed across all 17 repos that (a) `default_branch == "main"`, (b) protection state matches the §14.4 invariants, (c) the merge-back gate's underlying call (`gh pr list --base main --head <release-branch> --state open`) returns clean JSON on every repo (no `--base main`-not-found errors). End-to-end final-release dry-run verification deferred to §15.1's first machine-driven cut, which exercises the full pre-flight gate stack against live origin.
-- [x] 14.6 §14 audit gap discovered during §15.1 dry-run: the original §14.1 audit picked the 9 repos that visibly lacked `main` from a manual list, but the actual release graph (derived from the dep walk in §15.1) contains 22 release-eligible repos — 5 more than the §14 list: `smarty`, `shop-doctrine-migration-wrapper`, `shop-db-views-generator`, `shop-demodata-installer`, `php-selenium`. RC1 wasn't blocked (RC1 cuts no merge-back PRs and `gh pr list --base main` returns empty when main is missing) but v1.6.1 final's merge-back PR creation would have failed. Extension fix landed in this PR: 4 of the 5 (`smarty`, `shop-doctrine-migration-wrapper`, `shop-demodata-installer`, `php-selenium`) had `main` bootstrapped at HEAD of the actual release branch (support/2.6, b-1.6, b-1.6, b-1.0 respectively); 2 of those 4 also had stale defaults at `b-7.0.x` that got flipped to `main`; the 5th (`shop-db-views-generator`) already had main as default and just got §14.4 protection. All 22 release-eligible repos now uniform: `default_branch == "main"`, PR-required (0 approvers), no force-push, no delete. **Lesson:** future audits should start from the dep walk, not a manual repo list.
+    Linear-history rule intentionally NOT enforced (would conflict with the wiki's "merge commit, not squash" guidance for merge-back PRs in [Create-a-Release](https://github.com/o3-shop/o3-shop/wiki/Create-a-Release)). `enforce_admins: false` so the maintainer can land emergency direct pushes if needed.
+- [x] 14.5 Verify uniformly: confirmed across all 17 repos that (a) `default_branch == "main"`, (b) protection state matches the §14.4 invariants, (c) the merge-back gate's underlying call (`gh pr list --base main --head <release-branch> --state open`) returns clean JSON on every repo (no `--base main`-not-found errors). End-to-end final-release dry-run verification deferred to §16.3's first machine-driven cut, which exercises the full pre-flight gate stack against live origin.
+- [x] 14.6 §14 audit gap discovered during §16.1 dry-run: the original §14.1 audit picked the 9 repos that visibly lacked `main` from a manual list, but the actual release graph (derived from the dep walk in §16.1) contains 22 release-eligible repos — 5 more than the §14 list: `smarty`, `shop-doctrine-migration-wrapper`, `shop-db-views-generator`, `shop-demodata-installer`, `php-selenium`. RC1 wasn't blocked (RC1 cuts no merge-back PRs and `gh pr list --base main` returns empty when main is missing) but v1.6.1 final's merge-back PR creation would have failed. Extension fix landed in this PR: 4 of the 5 (`smarty`, `shop-doctrine-migration-wrapper`, `shop-demodata-installer`, `php-selenium`) had `main` bootstrapped at HEAD of the actual release branch (support/2.6, b-1.6, b-1.6, b-1.0 respectively); 2 of those 4 also had stale defaults at `b-7.0.x` that got flipped to `main`; the 5th (`shop-db-views-generator`) already had main as default and just got §14.4 protection. All 22 release-eligible repos now uniform: `default_branch == "main"`, PR-required (0 approvers), no force-push, no delete. **Lesson:** future audits should start from the dep walk, not a manual repo list.
 
-## 15. First live release with bin/release
+## 15. Live-execution wiring in `ReleaseCommand`
 
-- [ ] 15.1 Run `bin/release --from v1.6.0 --to v1.6.1-RC1 --dry-run` and review the plan (Step 1 must use the pre-fold-in metapackage indirection)
-- [ ] 15.2 Resolve any issues uncovered by the dry-run (missing release branches, malformed `.next-bump` files, etc.)
-- [ ] 15.3 Run `bin/release --from v1.6.0 --to v1.6.1-RC1` for real — this is the first machine-driven release and ships this entire change
-- [ ] 15.4 Manually publish the draft GitHub releases per repo and the aggregated o3-shop draft
-- [ ] 15.5 No merge-back PRs are auto-opened (RC1 is pre-release); merge-back PRs land with the eventual v1.6.1 final cut
-- [ ] 15.6 Run Section 16 verification on the produced v1.6.1-RC1 artifact
-- [ ] 15.7 Capture lessons learned in `.claude/memory/` (per the repo's finish protocol)
+The dry-run path is fully implemented (§11). The live path in `ReleaseCommand::execute()` currently prints a "Section 15 wiring pending" notice and exits `EXIT_OK` — running `bin/release --from v1.6.0 --to v1.6.1-RC1` (no `--dry-run`) does not actually cut anything yet. This section closes that gap.
 
-## 16. Verification of the v1.6.1-RC1 cut
+The required components already exist and are unit-tested in isolation:
+- §10 gates (`WorkingTreeGate`, `BranchGate`, `ComposerInstallGate`, `TestSuiteGate`, `IncomingPrGate`, `MergeBackPrGate`) and `PerRepoActions`
+- `ReleasePlanner` already accepts an optional `PreFlightRunner` and a `repoPaths` map
+- `MergeBackPolicy::shouldOpenForShopTo()` predicate
 
-> Note: v1.6.0 shipped pre-fold-in (with the old hardcoded `ShopVersion.php`). There is no separate manual v1.6.1 release — `bin/release` cuts v1.6.1-RC1 directly from `--from v1.6.0` (Section 15) using the pre-fold-in metapackage indirection in Step 1. These tasks verify the result of that run and run after Section 15.
+The work is purely orchestration in the CLI layer.
 
-- [ ] 16.1 Verify a fresh `composer install` of `o3-shop v1.6.1-RC1` produces a working shop with `ShopVersion::getVersion() === "v1.6.1-RC1"` (folds in former §12.2 — composer-install integration check against the post-fold-in `o3-shop/composer.json`)
-- [ ] 16.2 Smoke-test the admin UI: confirm the version display shows `v1.6.1-RC1`
-- [ ] 16.3 Verify `o3-shop/composer.json` at `v1.6.1-RC1` is post-fold-in (no `o3-shop/shop-metapackage-ce` in `require`, `replace: oxid-esales/oxideshop-metapackage-ce` present)
-- [ ] 16.4 Verify the v1.6.1-RC1 dist archive does not contain `.next-bump` (archive.exclude works end-to-end) (folds in former §12.3 — `.next-bump` archive-exclude check, exercised end-to-end against the real cut)
+- [ ] 15.1 Add a CLI flag for local repo paths — `--repo-path o3-shop/<package>=/abs/path` (repeatable). Validate that each path exists and is a Git working tree. Empty / unsupplied = pre-flight skipped (current dry-run behavior).
+- [ ] 15.2 In the default-planner factory, instantiate a `PreFlightRunner` with all 6 gates from §10, and a `PerRepoActions` (with `SymfonyProcessExecutor`). Wire both into the planner constructor (`PreFlightRunner` is already accepted; `PerRepoActions` will need a new constructor slot or a separate orchestrator class).
+- [ ] 15.3 Pass the parsed repo paths into `ReleasePlanner::plan()` so pre-flight gates fire.
+- [ ] 15.4 Live-mode entry path: after planning, if `ReleasePlan::shouldAbort()` is true, print the combined gate diagnostic and return `EXIT_PRE_FLIGHT_ABORT (3)` without touching state.
+- [ ] 15.5 Walk candidates in topological order (leaves first, per `WalkResult::topologicalOrder()`) and for each that needs a new tag invoke, in order:
+    - `PerRepoActions::commitChangesAndPush()` — applies constraint edits + `.next-bump` deletion, single commit per repo, pushed directly to the release branch
+    - `PerRepoActions::createTag()` — annotated tag at the new commit, pushed
+    - `PerRepoActions::createDraftRelease()` — `--generate-notes` for tier-0 / tier-1; for `o3-shop` pass the aggregated cross-repo body via `--notes`
+    - `PerRepoActions::openMergeBackPr()` — only when `MergeBackPolicy::shouldOpenForShopTo($toTag)` returns true (i.e. final shop releases, not RC/alpha/beta)
+- [ ] 15.6 Stream progress to `OutputInterface` per repo (mirrors the dry-run progress style introduced in §11). Print the resulting GitHub release URLs as the run progresses so a partial-failure state is recoverable from the log.
+- [ ] 15.7 Unit tests: live path with a fake `ProcessExecutor` and stubbed planner — assert (a) pre-flight abort short-circuits before any state-changing call, (b) RC `--to` does **not** trigger `openMergeBackPr`, (c) final `--to` does, (d) the orchestration walks candidates in topological order, (e) on a `PerRepoActions` failure mid-walk, the run aborts with a meaningful exit code and the partial state is printed.
+- [ ] 15.8 Update `ReleaseCommand` doc-comment and the live-mode notice in `ReleaseCommand::execute()` once wiring lands (remove the "wiring pending" branch).
 
-## 17. Post-v1.6.1-final cleanup
+## 16. First live release with bin/release
 
-- [ ] 17.1 (After v1.6.1 final stabilizes — not blocking the v1.6.1-RC1 cut.) Archive the `shop-metapackage-ce` GitHub repo and update its README to point at `o3-shop/o3-shop`. Its v1.6.0 tag already pins the final pre-archival state; no new tag is needed.
+- [x] 16.1 Run `bin/release --from v1.6.0 --to v1.6.1-RC1 --dry-run` and review the plan (Step 1 must use the pre-fold-in metapackage indirection) — done; pre-fold-in indirection fired correctly, 21 candidates resolved, plan structurally clean. Two known constraint jumps acknowledged (gdpr-optin v1.0.1→v2.3.5 and usercentrics v1.0.0→v1.2.2). Two phantom release-notes items (shop-ce#99, shop-facts#2) will resolve when v1.6.1-RC1 is an actual tag.
+- [ ] 16.2 Resolve any issues uncovered by the dry-run (missing release branches, malformed `.next-bump` files, etc.)
+- [ ] 16.3 Run `bin/release --from v1.6.0 --to v1.6.1-RC1` for real — depends on §15 (live wiring). This is the first machine-driven release and ships this entire change.
+- [ ] 16.4 Manually publish the draft GitHub releases per repo and the aggregated o3-shop draft
+- [ ] 16.5 No merge-back PRs are auto-opened (RC1 is pre-release); merge-back PRs land with the eventual v1.6.1 final cut
+- [ ] 16.6 Run Section 17 verification on the produced v1.6.1-RC1 artifact
+- [ ] 16.7 Capture lessons learned in `.claude/memory/` (per the repo's finish protocol)
+
+## 17. Verification of the v1.6.1-RC1 cut
+
+> Note: v1.6.0 shipped pre-fold-in (with the old hardcoded `ShopVersion.php`). There is no separate manual v1.6.1 release — `bin/release` cuts v1.6.1-RC1 directly from `--from v1.6.0` (Section 16) using the pre-fold-in metapackage indirection in Step 1. These tasks verify the result of that run and run after Section 16.
+
+- [ ] 17.1 Verify a fresh `composer install` of `o3-shop v1.6.1-RC1` produces a working shop with `ShopVersion::getVersion() === "v1.6.1-RC1"` (folds in former §12.2 — composer-install integration check against the post-fold-in `o3-shop/composer.json`)
+- [ ] 17.2 Smoke-test the admin UI: confirm the version display shows `v1.6.1-RC1`
+- [ ] 17.3 Verify `o3-shop/composer.json` at `v1.6.1-RC1` is post-fold-in (no `o3-shop/shop-metapackage-ce` in `require`, `replace: oxid-esales/oxideshop-metapackage-ce` present)
+- [ ] 17.4 Verify the v1.6.1-RC1 dist archive does not contain `.next-bump` (archive.exclude works end-to-end) (folds in former §12.3 — `.next-bump` archive-exclude check, exercised end-to-end against the real cut)
+
+## 18. Post-v1.6.1-final cleanup
+
+- [ ] 18.1 (After v1.6.1 final stabilizes — not blocking the v1.6.1-RC1 cut.) Archive the `shop-metapackage-ce` GitHub repo and update its README to point at `o3-shop/o3-shop`. Its v1.6.0 tag already pins the final pre-archival state; no new tag is needed.

--- a/openspec/changes/automate-release-procedure/tasks.md
+++ b/openspec/changes/automate-release-procedure/tasks.md
@@ -116,7 +116,7 @@ New components:
   DefaultBranchResolver per-package release-branch map (matches Section 1.5 decisions)
   GitLsRemoteRepoIntrospector  reference RemoteRepoIntrospector via `git ls-remote --tags --heads`
 
-ReleaseCommand now accepts an optional `(planner, printer)` constructor pair; production-mode invocations build the default planner inline with `Https*Fetcher`s + `GitLsRemoteRepoIntrospector` + `GhCliReleaseNotesProvider`. Tests inject stubs that bypass the parent constructor entirely so no real services are constructed. Live execution still prints a "Section 15 wiring pending" notice (4 exit codes: OK / USAGE_ERROR / PRE_FLIGHT_ABORT / PLAN_ERROR) — see §15 for the open work to land it.
+ReleaseCommand now accepts an optional `(planner, printer, liveExecutor)` constructor triple; production-mode invocations build the default planner inline with `Https*Fetcher`s + `GitLsRemoteRepoIntrospector` + `GhCliReleaseNotesProvider`, and the default `LiveExecutor` with `SymfonyProcessExecutor` + `PerRepoActions` + `ComposerJsonConstraintWriter`. Tests inject stubs that bypass the parent constructor entirely so no real services are constructed. Exit codes: OK / USAGE_ERROR / PRE_FLIGHT_ABORT / PLAN_ERROR. (Live-mode wiring landed in §15.)
 
 Refactor: `VersionResolution` gained an optional `latestTag` field so the planner can pass it to `TagCutter` for case-3 candidates. All 14 Section 6 tests still pass.
 
@@ -171,18 +171,14 @@ The required components already exist and are unit-tested in isolation:
 
 The work is purely orchestration in the CLI layer.
 
-- [ ] 15.1 Add a CLI flag for local repo paths — `--repo-path o3-shop/<package>=/abs/path` (repeatable). Validate that each path exists and is a Git working tree. Empty / unsupplied = pre-flight skipped (current dry-run behavior).
-- [ ] 15.2 In the default-planner factory, instantiate a `PreFlightRunner` with all 6 gates from §10, and a `PerRepoActions` (with `SymfonyProcessExecutor`). Wire both into the planner constructor (`PreFlightRunner` is already accepted; `PerRepoActions` will need a new constructor slot or a separate orchestrator class).
-- [ ] 15.3 Pass the parsed repo paths into `ReleasePlanner::plan()` so pre-flight gates fire.
-- [ ] 15.4 Live-mode entry path: after planning, if `ReleasePlan::shouldAbort()` is true, print the combined gate diagnostic and return `EXIT_PRE_FLIGHT_ABORT (3)` without touching state.
-- [ ] 15.5 Walk candidates in topological order (leaves first, per `WalkResult::topologicalOrder()`) and for each that needs a new tag invoke, in order:
-    - `PerRepoActions::commitChangesAndPush()` — applies constraint edits + `.next-bump` deletion, single commit per repo, pushed directly to the release branch
-    - `PerRepoActions::createTag()` — annotated tag at the new commit, pushed
-    - `PerRepoActions::createDraftRelease()` — `--generate-notes` for tier-0 / tier-1; for `o3-shop` pass the aggregated cross-repo body via `--notes`
-    - `PerRepoActions::openMergeBackPr()` — only when `MergeBackPolicy::shouldOpenForShopTo($toTag)` returns true (i.e. final shop releases, not RC/alpha/beta)
-- [ ] 15.6 Stream progress to `OutputInterface` per repo (mirrors the dry-run progress style introduced in §11). Print the resulting GitHub release URLs as the run progresses so a partial-failure state is recoverable from the log.
-- [ ] 15.7 Unit tests: live path with a fake `ProcessExecutor` and stubbed planner — assert (a) pre-flight abort short-circuits before any state-changing call, (b) RC `--to` does **not** trigger `openMergeBackPr`, (c) final `--to` does, (d) the orchestration walks candidates in topological order, (e) on a `PerRepoActions` failure mid-walk, the run aborts with a meaningful exit code and the partial state is printed.
-- [ ] 15.8 Update `ReleaseCommand` doc-comment and the live-mode notice in `ReleaseCommand::execute()` once wiring lands (remove the "wiring pending" branch).
+- [x] 15.1 Add a CLI flag for local repo paths — `--repo-path <package>=/abs/path` (repeatable). Validates that each path exists and is a Git working tree (`.git/` present); rejects relative paths and missing `vendor/repo` slugs.
+- [x] 15.2 Default-planner factory builds a `PreFlightRunner` with all 6 gates (`WorkingTreeGate`, `BranchGate`, `ComposerInstallGate`, `TestSuiteGate` with a no-op resolver, `IncomingPrGate`, `MergeBackPrGate`) when any `--repo-path` is supplied. New `LiveExecutor` orchestrator wires `PerRepoActions` (with `SymfonyProcessExecutor`) and a new `ComposerJsonConstraintWriter` (regex-based, formatting-preserving) plus `DefaultBranchResolver`.
+- [x] 15.3 Parsed repo paths are threaded through `ReleasePlanner::plan($from, $to, $bumpFlags, $repoPaths)`; pre-flight reports populate `ReleasePlan::preFlightReports()`.
+- [x] 15.4 Live-mode entry path checks `ReleasePlan::shouldAbort()` after planning; on abort the printer renders the combined gate diagnostic, the command prints a one-liner, and exits `EXIT_PRE_FLIGHT_ABORT (3)` before instantiating the executor.
+- [x] 15.5 `LiveExecutor::execute()` walks candidates in topological order (leaves-first, per `ReleasePlan::candidates()`) and for each that needs a new tag invokes commit/push, tag/push, and draft-release (`--generate-notes`). After all candidates the orchestrator then processes `o3-shop/o3-shop` itself (never a candidate, always tagged with `--to`, draft body = aggregated §9 markdown via `--notes`). After every tag is cut, merge-back PRs are opened iff `MergeBackPolicy::shouldOpenForShopTo($toTag)` returns true. Constraint edits applied to local `composer.json` files via `ComposerJsonConstraintWriter` before each commit. `.next-bump` deletion driven by `TagCutResult::deleteNextBumpFile()`.
+- [x] 15.6 Progress mirrors the dry-run callable style (`<comment>...</comment>` per major step). After each candidate, the released-URL is captured into `LiveExecutor::releaseUrls()`. On success or failure, `ReleaseCommand::execute()` calls `printPartialState()` to dump the captured URLs (`Draft GitHub releases created:` + `Merge-back PRs opened:`) so a partial-failure state is recoverable from the log.
+- [x] 15.7 Unit tests added: `ComposerJsonConstraintWriterTest` (replace exact pin / multiple edits / missing pattern / format preservation / missing file), `LiveExecutorTest` (candidate-then-orchestrator order, `--notes` vs `--generate-notes` per repo, RC `--to` skips merge-back, final `--to` opens merge-back for candidates + orchestrator, missing repo path throws, `.next-bump` deletion fires when `TagCutResult` says so), and updated `ReleaseCommandTest` (live mode without `--repo-path` returns USAGE_ERROR; malformed `--repo-path` returns USAGE_ERROR; live mode with valid path invokes executor and exits OK; pre-flight abort short-circuits before executor; executor failure surfaces as PLAN_ERROR with partial state).
+- [x] 15.8 Removed the "Section 15 wiring pending" notice from `ReleaseCommand::execute()`. Doc-comment updated to reflect that §15 wiring landed.
 
 ## 16. First live release with bin/release
 

--- a/source/Internal/ReleaseTooling/Command/ReleaseCommand.php
+++ b/source/Internal/ReleaseTooling/Command/ReleaseCommand.php
@@ -25,6 +25,16 @@ namespace OxidEsales\EshopCommunity\Internal\ReleaseTooling\Command;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Composer\HttpsRawComposerJsonFetcher;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Composer\HttpsRawRepoFileFetcher;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Constraint\ConstraintUpdater;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\ComposerJsonConstraintWriter;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\Gates\BranchGate;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\Gates\ComposerInstallGate;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\Gates\IncomingPrGate;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\Gates\MergeBackPrGate;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\Gates\TestSuiteGate;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\Gates\WorkingTreeGate;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\LiveExecutor;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\PerRepoActions;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\PreFlightRunner;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\SymfonyProcessExecutor;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Graph\DepTreeWalker;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Notes\GhCliReleaseNotesProvider;
@@ -45,9 +55,13 @@ use Throwable;
 /**
  * Drives a tier-by-tier release across the o3-shop repo network.
  *
- * Section 11 (this iteration): wires the algorithm chain (Sections
- * 4-9) and the pre-flight gates (Section 10) into a single
- * `--dry-run` plan printout. Live execution lands with Section 15.
+ * §11 wired the dry-run path; §15 wires live execution via
+ * `LiveExecutor` (commit constraint changes, cut tags, create
+ * draft releases, optionally open merge-back PRs).
+ *
+ * Pre-flight gates fire whenever any `--repo-path` is supplied. With
+ * no paths, pre-flight is skipped and dry-run output is the same as
+ * before.
  *
  * See: openspec/changes/automate-release-procedure/specs/release-orchestration/spec.md
  */
@@ -77,16 +91,21 @@ class ReleaseCommand extends Command
 
     private ?ReleasePlanner $planner;
     private DryRunPrinter $printer;
+    private ?LiveExecutor $liveExecutor;
 
     /**
-     * Both arguments are optional so production invocations build
+     * All three arguments are optional so production invocations build
      * defaults inline; tests inject fakes via the constructor.
      */
-    public function __construct(?ReleasePlanner $planner = null, ?DryRunPrinter $printer = null)
-    {
+    public function __construct(
+        ?ReleasePlanner $planner = null,
+        ?DryRunPrinter $printer = null,
+        ?LiveExecutor $liveExecutor = null
+    ) {
         parent::__construct();
         $this->planner = $planner;
         $this->printer = $printer ?? new DryRunPrinter();
+        $this->liveExecutor = $liveExecutor;
     }
 
     protected function configure(): void
@@ -125,6 +144,15 @@ class ReleaseCommand extends Command
                 . 'level is patch | minor | major | v<semver>. Repeatable.'
             )
             ->addOption(
+                'repo-path',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Local clone path for a release-eligible repo. '
+                . 'Format: <package>=/abs/path. Repeatable. Required for '
+                . 'live execution (commits/tags/releases) and to fire '
+                . 'the pre-flight gates. Empty = dry-run-only.'
+            )
+            ->addOption(
                 'dry-run',
                 null,
                 InputOption::VALUE_NONE,
@@ -159,10 +187,29 @@ class ReleaseCommand extends Command
             $bumpFlags[$slug] = $level;
         }
 
+        $repoPaths = [];
+        foreach ($input->getOption('repo-path') ?: [] as $arg) {
+            $error = $this->parseRepoPath($arg, $repoPaths);
+            if ($error !== null) {
+                $this->writeUsageError($output, $error);
+                return self::EXIT_USAGE_ERROR;
+            }
+        }
+
+        if (!$dryRun && $repoPaths === []) {
+            $this->writeUsageError(
+                $output,
+                'Live execution requires at least one --repo-path '
+                . '<package>=/abs/path. Re-run with --dry-run if you only '
+                . 'wanted to preview the plan.'
+            );
+            return self::EXIT_USAGE_ERROR;
+        }
+
         $progress = static function (string $message) use ($output): void {
             $output->writeln('<comment>' . $message . '</comment>');
         };
-        $planner = $this->planner ?? $this->buildDefaultPlanner($progress);
+        $planner = $this->planner ?? $this->buildDefaultPlanner($progress, $repoPaths !== []);
 
         $output->writeln(sprintf(
             '<info>Planning release: --from %s --to %s%s</info>',
@@ -171,7 +218,7 @@ class ReleaseCommand extends Command
             $dryRun ? ' (dry-run)' : ''
         ));
         try {
-            $plan = $planner->plan($from, $to, $bumpFlags);
+            $plan = $planner->plan($from, $to, $bumpFlags, $repoPaths);
         } catch (Throwable $e) {
             $output->writeln(sprintf('<error>Plan failed: %s</error>', $e->getMessage()));
             return self::EXIT_PLAN_ERROR;
@@ -181,6 +228,10 @@ class ReleaseCommand extends Command
         $this->printer->print($plan, $output);
 
         if ($plan->shouldAbort()) {
+            $output->writeln(
+                '<error>Pre-flight gates aborted the release. '
+                . 'Resolve the issues above and re-run.</error>'
+            );
             return self::EXIT_PRE_FLIGHT_ABORT;
         }
 
@@ -189,12 +240,16 @@ class ReleaseCommand extends Command
             return self::EXIT_OK;
         }
 
-        $output->writeln(
-            '<comment>Live execution (commit constraint changes, cut tags, '
-            . 'create draft GitHub releases, open merge-back PRs) is not yet '
-            . 'wired — Section 15 in openspec/changes/automate-release-procedure/'
-            . 'tasks.md adds it. Re-run with --dry-run to preview.</comment>'
-        );
+        $executor = $this->liveExecutor ?? $this->buildDefaultLiveExecutor($progress);
+        try {
+            $executor->execute($plan, $repoPaths);
+        } catch (Throwable $e) {
+            $output->writeln(sprintf('<error>Live execution failed: %s</error>', $e->getMessage()));
+            $this->printPartialState($executor, $output);
+            return self::EXIT_PLAN_ERROR;
+        }
+        $this->printPartialState($executor, $output);
+        $output->writeln('<info>Live execution complete. Publish the draft GitHub releases manually.</info>');
         return self::EXIT_OK;
     }
 
@@ -232,7 +287,7 @@ class ReleaseCommand extends Command
         return null;
     }
 
-    private function buildDefaultPlanner(?callable $progress = null): ReleasePlanner
+    private function buildDefaultPlanner(?callable $progress = null, bool $withPreFlight = false): ReleasePlanner
     {
         $exec = new SymfonyProcessExecutor();
         $composerJsonFetcher = new HttpsRawComposerJsonFetcher();
@@ -247,6 +302,8 @@ class ReleaseCommand extends Command
         $constraintUpdater = new ConstraintUpdater();
         $notesAggregator = new ReleaseNotesAggregator(new GhCliReleaseNotesProvider(), $progress);
 
+        $preFlight = $withPreFlight ? $this->buildDefaultPreFlightRunner($exec) : null;
+
         return new ReleasePlanner(
             $snapshotBuilder,
             $walker,
@@ -255,9 +312,102 @@ class ReleaseCommand extends Command
             $constraintUpdater,
             $notesAggregator,
             $branchResolver,
-            null, // pre-flight runner skipped for dry-run unless wired explicitly
+            $preFlight,
             $progress
         );
+    }
+
+    private function buildDefaultPreFlightRunner(SymfonyProcessExecutor $exec): PreFlightRunner
+    {
+        // No per-repo test command resolver yet; TestSuiteGate is
+        // registered with a resolver that always returns null (= skip
+        // the gate without warning) so the default flow doesn't block
+        // on tests when the maintainer has run them out-of-band.
+        $skipTestsResolver = static function (string $_packageName, string $_repoPath): ?array {
+            return null;
+        };
+        return new PreFlightRunner([
+            new WorkingTreeGate($exec),
+            new BranchGate($exec),
+            new ComposerInstallGate($exec),
+            new TestSuiteGate($exec, $skipTestsResolver),
+            new IncomingPrGate($exec),
+            new MergeBackPrGate($exec),
+        ]);
+    }
+
+    private function buildDefaultLiveExecutor(?callable $progress = null): LiveExecutor
+    {
+        $exec = new SymfonyProcessExecutor();
+        return new LiveExecutor(
+            new PerRepoActions($exec),
+            new ComposerJsonConstraintWriter(),
+            new DefaultBranchResolver(),
+            $progress
+        );
+    }
+
+    /**
+     * @param array<string,string> &$repoPaths package => abs path; populated on success
+     */
+    private function parseRepoPath(string $arg, array &$repoPaths): ?string
+    {
+        $eq = strpos($arg, '=');
+        if ($eq === false || $eq === 0 || $eq === strlen($arg) - 1) {
+            return sprintf(
+                'Malformed --repo-path %s. Expected <package>=/abs/path '
+                . '(e.g. o3-shop/shop-ce=/Users/me/clones/shop-ce).',
+                self::quote($arg)
+            );
+        }
+        $package = substr($arg, 0, $eq);
+        $path = substr($arg, $eq + 1);
+        if ($package === '' || strpos($package, '/') === false) {
+            return sprintf(
+                'Malformed --repo-path package %s. Expected <vendor>/<repo> '
+                . '(e.g. o3-shop/shop-ce).',
+                self::quote($package)
+            );
+        }
+        if ($path === '' || $path[0] !== '/') {
+            return sprintf(
+                'Malformed --repo-path absolute path %s. Use an absolute path '
+                . 'so the orchestrator does not depend on shell cwd.',
+                self::quote($path)
+            );
+        }
+        if (!is_dir($path)) {
+            return sprintf('--repo-path %s is not a directory.', self::quote($path));
+        }
+        if (!is_dir($path . '/.git')) {
+            return sprintf(
+                '--repo-path %s does not look like a git working tree '
+                . '(no .git/ found).',
+                self::quote($path)
+            );
+        }
+        $repoPaths[$package] = $path;
+        return null;
+    }
+
+    private function printPartialState(LiveExecutor $executor, OutputInterface $output): void
+    {
+        $releases = $executor->releaseUrls();
+        if ($releases !== []) {
+            $output->writeln('');
+            $output->writeln('<info>Draft GitHub releases created:</info>');
+            foreach ($releases as $package => $url) {
+                $output->writeln(sprintf('  %s -> %s', $package, $url));
+            }
+        }
+        $mergeBacks = $executor->mergeBackUrls();
+        if ($mergeBacks !== []) {
+            $output->writeln('');
+            $output->writeln('<info>Merge-back PRs opened:</info>');
+            foreach ($mergeBacks as $package => $url) {
+                $output->writeln(sprintf('  %s -> %s', $package, $url));
+            }
+        }
     }
 
     private function writeUsageError(OutputInterface $output, string $message): void

--- a/source/Internal/ReleaseTooling/Flow/ComposerJsonConstraintWriter.php
+++ b/source/Internal/ReleaseTooling/Flow/ComposerJsonConstraintWriter.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * This file is part of O3-Shop.
+ *
+ * O3-Shop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * O3-Shop is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with O3-Shop.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * @copyright  Copyright (c) 2026 O3-Shop (https://www.o3-shop.com)
+ * @license    https://www.gnu.org/licenses/gpl-3.0  GNU General Public License 3 (GPLv3)
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow;
+
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning\ConstraintEditPlan;
+use RuntimeException;
+
+/**
+ * Applies the constraint-edit plans produced by §8 to a local clone's
+ * composer.json. Operates on the file as text (not via json_decode →
+ * json_encode) so existing key ordering, indentation, and trailing
+ * whitespace stay intact — composer.json files in this org are
+ * hand-curated and we don't want a release commit to also reflow them.
+ */
+final class ComposerJsonConstraintWriter
+{
+    /**
+     * @param string                         $composerJsonPath absolute path
+     * @param array<int,ConstraintEditPlan>  $edits            for this file only
+     * @return array<int,string>                                repo-relative paths staged (always ['composer.json'] when edits applied)
+     *
+     * @throws RuntimeException when the file is unreadable, unwritable,
+     *         or an expected pattern is missing (i.e. someone hand-edited
+     *         since the dry-run plan was computed).
+     */
+    public function apply(string $composerJsonPath, array $edits): array
+    {
+        if ($edits === []) {
+            return [];
+        }
+        if (!is_file($composerJsonPath) || !is_readable($composerJsonPath)) {
+            throw new RuntimeException(sprintf('composer.json not readable: %s', $composerJsonPath));
+        }
+        $contents = file_get_contents($composerJsonPath);
+        if ($contents === false) {
+            throw new RuntimeException(sprintf('failed to read composer.json: %s', $composerJsonPath));
+        }
+
+        foreach ($edits as $edit) {
+            $contents = $this->applyOne($contents, $edit, $composerJsonPath);
+        }
+
+        if (file_put_contents($composerJsonPath, $contents) === false) {
+            throw new RuntimeException(sprintf('failed to write composer.json: %s', $composerJsonPath));
+        }
+        return ['composer.json'];
+    }
+
+    private function applyOne(string $contents, ConstraintEditPlan $edit, string $path): string
+    {
+        $dep = $edit->depPackage();
+        $oldConstraint = $edit->update()->oldConstraint();
+        $newConstraint = $edit->update()->newConstraint();
+
+        // Match `"<dep>": "<oldConstraint>"` allowing any whitespace
+        // between key and value so we tolerate a tab/double-space style.
+        $pattern = sprintf(
+            '/(["\'])%s\1(\s*:\s*)(["\'])%s\3/',
+            preg_quote($dep, '/'),
+            preg_quote($oldConstraint, '/')
+        );
+        $replacement = sprintf(
+            '$1%s$1$2$3%s$3',
+            $dep,
+            $newConstraint
+        );
+        $count = 0;
+        $result = preg_replace($pattern, $replacement, $contents, -1, $count);
+        if ($result === null) {
+            throw new RuntimeException(sprintf(
+                'regex error while updating %s in %s',
+                $dep,
+                $path
+            ));
+        }
+        if ($count === 0) {
+            throw new RuntimeException(sprintf(
+                'expected pattern not found in %s — looking for "%s": "%s" '
+                . '(constraint may have been hand-edited since the dry-run plan)',
+                $path,
+                $dep,
+                $oldConstraint
+            ));
+        }
+        return $result;
+    }
+}

--- a/source/Internal/ReleaseTooling/Flow/LiveExecutor.php
+++ b/source/Internal/ReleaseTooling/Flow/LiveExecutor.php
@@ -1,0 +1,266 @@
+<?php
+
+/**
+ * This file is part of O3-Shop.
+ *
+ * O3-Shop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * O3-Shop is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with O3-Shop.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * @copyright  Copyright (c) 2026 O3-Shop (https://www.o3-shop.com)
+ * @license    https://www.gnu.org/licenses/gpl-3.0  GNU General Public License 3 (GPLv3)
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow;
+
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning\ConstraintEditPlan;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning\DefaultBranchResolver;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning\ReleasePlan;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Executes a `ReleasePlan` against live origin: applies constraint
+ * edits to local composer.json files, commits + pushes, cuts tags,
+ * creates draft releases, and (for final shop releases) opens
+ * merge-back PRs.
+ *
+ * Orchestration order, per spec §10.8 → §10.9 → §10.10 → §10.11:
+ *
+ *   1. Group constraint edits by parent package (the repo whose
+ *      composer.json is being edited).
+ *   2. Walk candidates in topological order (leaves first); for each
+ *      that needs a new tag, run the per-repo flow.
+ *   3. After all candidates, run the same flow for `o3-shop/o3-shop`
+ *      (the orchestrator/project-root, never a candidate but always
+ *      tagged with `--to`). Its draft release uses the aggregated
+ *      cross-repo body from §9.
+ *   4. After every tag is cut, open merge-back PRs (final releases
+ *      only — `MergeBackPolicy::shouldOpenForShopTo()`).
+ *
+ * Per-repo failures bubble as `RuntimeException`. The orchestrator
+ * does not roll back; the runbook in the wiki describes how to clean
+ * up partial state by hand.
+ */
+final class LiveExecutor
+{
+    public const O3_SHOP_PROJECT = 'o3-shop/o3-shop';
+
+    private PerRepoActions $actions;
+    private ComposerJsonConstraintWriter $writer;
+    private DefaultBranchResolver $branchResolver;
+    /** @var callable(string):void */
+    private $progress;
+
+    /** @var array<string,string> populated as draft releases are created */
+    private array $releaseUrls = [];
+
+    /** @var array<string,string> populated as merge-back PRs are opened */
+    private array $mergeBackUrls = [];
+
+    public function __construct(
+        PerRepoActions $actions,
+        ComposerJsonConstraintWriter $writer,
+        DefaultBranchResolver $branchResolver,
+        ?callable $progress = null
+    ) {
+        $this->actions = $actions;
+        $this->writer = $writer;
+        $this->branchResolver = $branchResolver;
+        $this->progress = $progress ?? static function (string $_msg): void {
+        };
+    }
+
+    /**
+     * @param array<string,string> $repoPaths package => local clone path; must include
+     *                                        every package that has a constraint edit
+     *                                        AND every candidate that needs a new tag
+     *                                        AND the o3-shop project root
+     */
+    public function execute(ReleasePlan $plan, array $repoPaths): void
+    {
+        $editsByParent = $this->groupEditsByParent($plan->constraintEdits());
+
+        $this->log(sprintf(
+            'Live execution starting (--from %s --to %s).',
+            $plan->fromTag(),
+            $plan->toTag()
+        ));
+
+        // Walk candidates leaves-first; for each needing a new tag, run
+        // commit → tag → draft.
+        foreach ($plan->candidates() as $candidate) {
+            $tagCut = $candidate->tagCut();
+            if ($tagCut === null) {
+                continue;
+            }
+            $this->processRepo(
+                $candidate->package(),
+                $candidate->chosenVersion(),
+                $editsByParent[$candidate->package()] ?? [],
+                $repoPaths,
+                $plan->toTag(),
+                null, // candidate repos use --generate-notes
+                $tagCut->deleteNextBumpFile()
+            );
+        }
+
+        // o3-shop is the orchestrator, never a candidate. Tag it with
+        // --to and attach the aggregated cross-repo body. No .next-bump
+        // file is ever consumed at the project root (the file convention
+        // is per-released-package, not per-orchestrator).
+        $this->processRepo(
+            self::O3_SHOP_PROJECT,
+            $plan->toTag(),
+            $editsByParent[self::O3_SHOP_PROJECT] ?? [],
+            $repoPaths,
+            $plan->toTag(),
+            $plan->aggregatedNotes(), // o3-shop carries the aggregated body
+            false
+        );
+
+        // Merge-back PRs (final releases only). Run after all tags so
+        // a partial-failure mid-walk doesn't leave stray PRs.
+        if (MergeBackPolicy::shouldOpenForShopTo($plan->toTag())) {
+            $this->openMergeBackPrs($plan, $repoPaths);
+        } else {
+            $this->log(sprintf(
+                'Pre-release shop --to (%s); no merge-back PRs auto-opened.',
+                $plan->toTag()
+            ));
+        }
+
+        $this->log('Live execution complete.');
+    }
+
+    /** @return array<string,string> package => GitHub draft release URL */
+    public function releaseUrls(): array
+    {
+        return $this->releaseUrls;
+    }
+
+    /** @return array<string,string> package => merge-back PR URL */
+    public function mergeBackUrls(): array
+    {
+        return $this->mergeBackUrls;
+    }
+
+    /**
+     * @param array<int,ConstraintEditPlan> $edits  edits whose parentPackage == $package
+     * @param array<string,string>          $repoPaths
+     */
+    private function processRepo(
+        string $package,
+        string $chosenVersion,
+        array $edits,
+        array $repoPaths,
+        string $shopTo,
+        ?string $bodyOverride,
+        bool $deleteNextBump
+    ): void {
+        if (!isset($repoPaths[$package])) {
+            throw new RuntimeException(sprintf(
+                'no local repo path supplied for %s — pass --repo-path %s=/path/to/clone',
+                $package,
+                $package
+            ));
+        }
+        $repoPath = $repoPaths[$package];
+        $branch = ($this->branchResolver)($package);
+
+        $this->log(sprintf('[%s] applying %d constraint edit(s)', $package, count($edits)));
+        $stagePaths = $this->writer->apply($repoPath . '/composer.json', $edits);
+
+        $commitMessage = $this->buildCommitMessage($package, $chosenVersion, $shopTo, count($edits));
+
+        if ($stagePaths !== [] || $deleteNextBump) {
+            $this->log(sprintf('[%s] commit + push to %s', $package, $branch));
+            $this->actions->commitChangesAndPush(
+                $repoPath,
+                $branch,
+                $stagePaths,
+                $deleteNextBump,
+                $commitMessage
+            );
+        }
+
+        $this->log(sprintf('[%s] tag %s', $package, $chosenVersion));
+        $this->actions->createTag($repoPath, $chosenVersion);
+
+        $this->log(sprintf('[%s] create draft GitHub release for %s', $package, $chosenVersion));
+        $url = $this->actions->createDraftRelease($package, $chosenVersion, $bodyOverride);
+        $this->releaseUrls[$package] = $url;
+        $this->log(sprintf('[%s] draft release: %s', $package, $url));
+    }
+
+    /**
+     * @param array<string,string> $repoPaths
+     */
+    private function openMergeBackPrs(ReleasePlan $plan, array $repoPaths): void
+    {
+        $packages = [];
+        foreach ($plan->candidates() as $candidate) {
+            if ($candidate->tagCut() !== null) {
+                $packages[] = $candidate->package();
+            }
+        }
+        $packages[] = self::O3_SHOP_PROJECT;
+
+        foreach ($packages as $package) {
+            if (!isset($repoPaths[$package])) {
+                continue;
+            }
+            $branch = ($this->branchResolver)($package);
+            $this->log(sprintf('[%s] open merge-back PR (%s -> main)', $package, $branch));
+            try {
+                $url = $this->actions->openMergeBackPr($package, $branch, $plan->toTag());
+                $this->mergeBackUrls[$package] = $url;
+                $this->log(sprintf('[%s] merge-back PR: %s', $package, $url));
+            } catch (Throwable $e) {
+                $this->log(sprintf('[%s] merge-back PR failed: %s', $package, $e->getMessage()));
+                throw $e;
+            }
+        }
+    }
+
+    /**
+     * @param  array<int,ConstraintEditPlan> $edits
+     * @return array<string,array<int,ConstraintEditPlan>> parent package => edits in that file
+     */
+    private function groupEditsByParent(array $edits): array
+    {
+        $byParent = [];
+        foreach ($edits as $edit) {
+            $byParent[$edit->parentPackage()][] = $edit;
+        }
+        return $byParent;
+    }
+
+    private function buildCommitMessage(string $package, string $chosenVersion, string $shopTo, int $editCount): string
+    {
+        if ($editCount === 0) {
+            return sprintf('release: %s for shop %s', $chosenVersion, $shopTo);
+        }
+        return sprintf(
+            'release: %s for shop %s (%d constraint edit%s)',
+            $chosenVersion,
+            $shopTo,
+            $editCount,
+            $editCount === 1 ? '' : 's'
+        );
+    }
+
+    private function log(string $message): void
+    {
+        ($this->progress)($message);
+    }
+}

--- a/tests/Unit/Internal/ReleaseTooling/Command/ReleaseCommandTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Command/ReleaseCommandTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\ReleaseTooling\Command;
 
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Command\ReleaseCommand;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\LiveExecutor;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning\DryRunPrinter;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning\ReleasePlan;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning\ReleasePlanner;
@@ -170,19 +171,115 @@ class ReleaseCommandTest extends TestCase
         $this->assertSame(ReleaseCommand::EXIT_PRE_FLIGHT_ABORT, $status);
     }
 
-    /* ---------- live mode is not yet wired ---------- */
+    /* ---------- live mode (§15) ---------- */
 
-    public function testLiveModeShowsNotYetWiredNotice(): void
+    public function testLiveModeWithoutRepoPathExitsUsageError(): void
     {
         $tester = $this->tester();
         $status = $tester->execute([
             '--from' => 'v1.6.0',
             '--to' => 'v1.6.1-RC1',
-            // no --dry-run
+            // no --dry-run, no --repo-path
+        ]);
+        $this->assertSame(ReleaseCommand::EXIT_USAGE_ERROR, $status);
+        $this->assertStringContainsString('--repo-path', $tester->getDisplay());
+    }
+
+    public function testMalformedRepoPathExitsUsageError(): void
+    {
+        $tester = $this->tester();
+        $status = $tester->execute([
+            '--from' => 'v1.6.0',
+            '--to' => 'v1.6.1-RC1',
+            '--repo-path' => ['no-equals-sign'],
+        ]);
+        $this->assertSame(ReleaseCommand::EXIT_USAGE_ERROR, $status);
+        $this->assertStringContainsString('Malformed --repo-path', $tester->getDisplay());
+    }
+
+    public function testLiveModeWithRepoPathInvokesExecutorAndExitsZero(): void
+    {
+        $tmpRepoPath = $this->makeFakeGitRepo();
+        $stub = new StubReleasePlanner(new ReleasePlan(
+            'v1.6.0',
+            'v1.6.1-RC1',
+            new FromSnapshot([], false, null),
+            [],
+            [],
+            '',
+            []
+        ));
+        $executor = new RecordingLiveExecutor();
+        $tester = new CommandTester(new ReleaseCommand($stub, null, $executor));
+        $status = $tester->execute([
+            '--from' => 'v1.6.0',
+            '--to' => 'v1.6.1-RC1',
+            '--repo-path' => ['o3-shop/shop-ce=' . $tmpRepoPath],
         ]);
         $this->assertSame(ReleaseCommand::EXIT_OK, $status);
-        $this->assertStringContainsString('Live execution', $tester->getDisplay());
-        $this->assertStringContainsString('Section 15', $tester->getDisplay());
+        $this->assertSame(1, $executor->callCount);
+        $this->assertSame(['o3-shop/shop-ce' => $tmpRepoPath], $executor->lastRepoPaths);
+        $this->assertSame('v1.6.0', $stub->lastFromTag);
+        $this->assertSame(['o3-shop/shop-ce' => $tmpRepoPath], $stub->lastRepoPaths);
+        $this->cleanupFakeGitRepo($tmpRepoPath);
+    }
+
+    public function testLiveModePreFlightAbortShortCircuitsBeforeExecutor(): void
+    {
+        $tmpRepoPath = $this->makeFakeGitRepo();
+        $abortingPlan = $this->planThatAborts();
+        $executor = new RecordingLiveExecutor();
+        $tester = new CommandTester(new ReleaseCommand(
+            new StubReleasePlanner($abortingPlan),
+            null,
+            $executor
+        ));
+        $status = $tester->execute([
+            '--from' => 'v1.6.0',
+            '--to' => 'v1.6.1-RC1',
+            '--repo-path' => ['o3-shop/shop-ce=' . $tmpRepoPath],
+        ]);
+        $this->assertSame(ReleaseCommand::EXIT_PRE_FLIGHT_ABORT, $status);
+        $this->assertSame(0, $executor->callCount, 'executor must not run on pre-flight abort');
+        $this->cleanupFakeGitRepo($tmpRepoPath);
+    }
+
+    public function testLiveExecutorFailureSurfacedAsPlanErrorExit(): void
+    {
+        $tmpRepoPath = $this->makeFakeGitRepo();
+        $stub = new StubReleasePlanner(new ReleasePlan(
+            'v1.6.0',
+            'v1.6.1-RC1',
+            new FromSnapshot([], false, null),
+            [],
+            [],
+            '',
+            []
+        ));
+        $executor = new RecordingLiveExecutor(true);
+        $tester = new CommandTester(new ReleaseCommand($stub, null, $executor));
+        $status = $tester->execute([
+            '--from' => 'v1.6.0',
+            '--to' => 'v1.6.1-RC1',
+            '--repo-path' => ['o3-shop/shop-ce=' . $tmpRepoPath],
+        ]);
+        $this->assertSame(ReleaseCommand::EXIT_PLAN_ERROR, $status);
+        $this->assertStringContainsString('Live execution failed', $tester->getDisplay());
+        $this->cleanupFakeGitRepo($tmpRepoPath);
+    }
+
+    private function makeFakeGitRepo(): string
+    {
+        $dir = sys_get_temp_dir() . '/release-cmd-test-' . bin2hex(random_bytes(4));
+        mkdir($dir);
+        mkdir($dir . '/.git');
+        return $dir;
+    }
+
+    private function cleanupFakeGitRepo(string $dir): void
+    {
+        @rmdir($dir . '/.git');
+        @rmdir($dir);
     }
 
     /* ---------- validateBumpValue() unit (preserved from Section 3) ---------- */
@@ -272,6 +369,7 @@ final class StubReleasePlanner extends ReleasePlanner
     public string $lastFromTag = '';
     public string $lastToTag = '';
     public array $lastBumpFlags = [];
+    public array $lastRepoPaths = [];
     public int $callCount = 0;
 
     private ReleasePlan $plan;
@@ -289,8 +387,41 @@ final class StubReleasePlanner extends ReleasePlanner
         $this->lastFromTag = $fromTag;
         $this->lastToTag = $toTag;
         $this->lastBumpFlags = $bumpFlags;
+        $this->lastRepoPaths = $repoPaths;
         $this->callCount++;
         return $this->plan;
+    }
+}
+
+final class RecordingLiveExecutor extends LiveExecutor
+{
+    public int $callCount = 0;
+    public array $lastRepoPaths = [];
+    private bool $shouldThrow;
+
+    public function __construct(bool $shouldThrow = false)
+    {
+        // Skip parent constructor — see StubReleasePlanner.
+        $this->shouldThrow = $shouldThrow;
+    }
+
+    public function execute(ReleasePlan $plan, array $repoPaths): void
+    {
+        $this->callCount++;
+        $this->lastRepoPaths = $repoPaths;
+        if ($this->shouldThrow) {
+            throw new RuntimeException('synthetic live executor failure');
+        }
+    }
+
+    public function releaseUrls(): array
+    {
+        return [];
+    }
+
+    public function mergeBackUrls(): array
+    {
+        return [];
     }
 }
 

--- a/tests/Unit/Internal/ReleaseTooling/Flow/ComposerJsonConstraintWriterTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Flow/ComposerJsonConstraintWriterTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * This file is part of O3-Shop.
+ *
+ * O3-Shop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * O3-Shop is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with O3-Shop.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * @copyright  Copyright (c) 2026 O3-Shop (https://www.o3-shop.com)
+ * @license    https://www.gnu.org/licenses/gpl-3.0  GNU General Public License 3 (GPLv3)
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\ReleaseTooling\Flow;
+
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Constraint\ConstraintUpdate;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\ComposerJsonConstraintWriter;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning\ConstraintEditPlan;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class ComposerJsonConstraintWriterTest extends TestCase
+{
+    private string $tmpFile = '';
+
+    protected function tearDown(): void
+    {
+        if ($this->tmpFile !== '' && is_file($this->tmpFile)) {
+            unlink($this->tmpFile);
+        }
+    }
+
+    public function testReplacesExactPinnedConstraint(): void
+    {
+        $this->tmpFile = $this->writeTempJson(<<<'JSON'
+{
+  "name": "o3-shop/o3-shop",
+  "require": {
+    "o3-shop/shop-ce": "v1.6.0",
+    "o3-shop/shop-facts": "v1.0.4"
+  }
+}
+JSON);
+        $writer = new ComposerJsonConstraintWriter();
+        $staged = $writer->apply($this->tmpFile, [
+            $this->edit('o3-shop/o3-shop', 'require', 'o3-shop/shop-ce', 'v1.6.0', 'v1.6.1-RC1'),
+        ]);
+
+        $this->assertSame(['composer.json'], $staged);
+        $contents = file_get_contents($this->tmpFile);
+        $this->assertStringContainsString('"o3-shop/shop-ce": "v1.6.1-RC1"', $contents);
+        $this->assertStringContainsString('"o3-shop/shop-facts": "v1.0.4"', $contents);
+        $this->assertStringNotContainsString('"o3-shop/shop-ce": "v1.6.0"', $contents);
+    }
+
+    public function testReplacesMultipleConstraintsInOnePass(): void
+    {
+        $this->tmpFile = $this->writeTempJson(<<<'JSON'
+{
+  "require": {
+    "o3-shop/shop-ce": "v1.6.0",
+    "o3-shop/shop-facts": "v1.0.4",
+    "o3-shop/usercentrics": "v1.0.0"
+  }
+}
+JSON);
+        $writer = new ComposerJsonConstraintWriter();
+        $writer->apply($this->tmpFile, [
+            $this->edit('o3-shop/o3-shop', 'require', 'o3-shop/shop-ce', 'v1.6.0', 'v1.6.1-RC1'),
+            $this->edit('o3-shop/o3-shop', 'require', 'o3-shop/shop-facts', 'v1.0.4', 'v1.0.5'),
+            $this->edit('o3-shop/o3-shop', 'require', 'o3-shop/usercentrics', 'v1.0.0', 'v1.2.2'),
+        ]);
+
+        $contents = file_get_contents($this->tmpFile);
+        $this->assertStringContainsString('"o3-shop/shop-ce": "v1.6.1-RC1"', $contents);
+        $this->assertStringContainsString('"o3-shop/shop-facts": "v1.0.5"', $contents);
+        $this->assertStringContainsString('"o3-shop/usercentrics": "v1.2.2"', $contents);
+    }
+
+    public function testThrowsWhenExpectedConstraintNotFound(): void
+    {
+        $this->tmpFile = $this->writeTempJson(<<<'JSON'
+{
+  "require": {
+    "o3-shop/shop-ce": "v1.6.0"
+  }
+}
+JSON);
+        $writer = new ComposerJsonConstraintWriter();
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('expected pattern not found');
+        $writer->apply($this->tmpFile, [
+            $this->edit('o3-shop/o3-shop', 'require', 'o3-shop/shop-ce', 'v1.5.0', 'v1.6.1-RC1'),
+        ]);
+    }
+
+    public function testEmptyEditListIsNoOp(): void
+    {
+        $this->tmpFile = $this->writeTempJson('{"require":{}}');
+        $writer = new ComposerJsonConstraintWriter();
+        $staged = $writer->apply($this->tmpFile, []);
+        $this->assertSame([], $staged);
+    }
+
+    public function testPreservesOriginalFormattingOutsideEditedLine(): void
+    {
+        $original = <<<'JSON'
+{
+    "name": "o3-shop/o3-shop",
+    "minimum-stability": "RC",
+    "require": {
+        "composer/semver": "3.3.2",
+        "o3-shop/shop-ce": "v1.6.0",
+        "monolog/monolog": "^v2.10"
+    },
+    "scripts": {
+        "post-install-cmd": ["echo hi"]
+    }
+}
+JSON;
+        $this->tmpFile = $this->writeTempJson($original);
+        $writer = new ComposerJsonConstraintWriter();
+        $writer->apply($this->tmpFile, [
+            $this->edit('o3-shop/o3-shop', 'require', 'o3-shop/shop-ce', 'v1.6.0', 'v1.6.1-RC1'),
+        ]);
+
+        $contents = file_get_contents($this->tmpFile);
+        // Surrounding lines preserved verbatim.
+        $this->assertStringContainsString('"composer/semver": "3.3.2"', $contents);
+        $this->assertStringContainsString('"monolog/monolog": "^v2.10"', $contents);
+        $this->assertStringContainsString('"minimum-stability": "RC"', $contents);
+        $this->assertStringContainsString('"post-install-cmd": ["echo hi"]', $contents);
+        // 4-space indentation kept.
+        $this->assertStringContainsString('    "require": {', $contents);
+    }
+
+    public function testMissingFileThrows(): void
+    {
+        $writer = new ComposerJsonConstraintWriter();
+        $this->expectException(RuntimeException::class);
+        $writer->apply('/nonexistent/composer.json', [
+            $this->edit('o3-shop/o3-shop', 'require', 'o3-shop/shop-ce', 'v1.6.0', 'v1.6.1-RC1'),
+        ]);
+    }
+
+    private function edit(
+        string $parent,
+        string $key,
+        string $dep,
+        string $oldConstraint,
+        string $newConstraint
+    ): ConstraintEditPlan {
+        $update = new ConstraintUpdate(
+            $oldConstraint,
+            $newConstraint,
+            ConstraintUpdate::SHAPE_EXACT_REPLACED
+        );
+        return new ConstraintEditPlan($parent, $key, $dep, $update);
+    }
+
+    private function writeTempJson(string $contents): string
+    {
+        $path = sys_get_temp_dir() . '/composer-writer-test-' . bin2hex(random_bytes(4)) . '.json';
+        file_put_contents($path, $contents);
+        return $path;
+    }
+}

--- a/tests/Unit/Internal/ReleaseTooling/Flow/LiveExecutorTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Flow/LiveExecutorTest.php
@@ -1,0 +1,370 @@
+<?php
+
+/**
+ * This file is part of O3-Shop.
+ *
+ * O3-Shop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * O3-Shop is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with O3-Shop.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * @copyright  Copyright (c) 2026 O3-Shop (https://www.o3-shop.com)
+ * @license    https://www.gnu.org/licenses/gpl-3.0  GNU General Public License 3 (GPLv3)
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\ReleaseTooling\Flow;
+
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Constraint\ConstraintUpdate;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\ComposerJsonConstraintWriter;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\LiveExecutor;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\PerRepoActions;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\ProcessOutcome;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning\CandidatePlan;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning\ConstraintEditPlan;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning\DefaultBranchResolver;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning\ReleasePlan;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Snapshot\FromSnapshot;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Tag\TagCutResult;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Version\VersionResolution;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for §15 — live execution orchestration.
+ *
+ * Each test builds a small ReleasePlan, two on-disk fake repo dirs
+ * with a real composer.json (so the writer has something to mutate),
+ * and lets LiveExecutor run end-to-end with a FakeProcessExecutor
+ * recording every gh / git invocation.
+ */
+final class LiveExecutorTest extends TestCase
+{
+    /** @var array<int,string> dirs created during the test, cleaned up in tearDown */
+    private array $tmpDirs = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tmpDirs as $dir) {
+            $this->rmrf($dir);
+        }
+        $this->tmpDirs = [];
+    }
+
+    public function testCandidateThenOrchestratorIsTaggedInOrderAndDraftReleaseCreated(): void
+    {
+        $shopCePath = $this->mkRepo('{"require":{"o3-shop/shop-doctrine-migration-wrapper":"v1.0.2"}}');
+        $o3ShopPath = $this->mkRepo('{"require":{"o3-shop/shop-ce":"v1.6.0"}}');
+        $exec = new FakeProcessExecutor([], new ProcessOutcome(0, 'https://github.com/o3-shop/X/releases/tag/Y', ''));
+
+        $plan = $this->buildPlan(
+            'v1.6.0',
+            'v1.6.1-RC1',
+            [
+                $this->cuttingCandidate('o3-shop/shop-ce', 'v1.6.0', 'v1.6.1-RC1'),
+            ],
+            [
+                $this->edit('o3-shop/shop-ce', 'require', 'o3-shop/shop-doctrine-migration-wrapper', 'v1.0.2', 'v1.0.3'),
+                $this->edit('o3-shop/o3-shop', 'require', 'o3-shop/shop-ce', 'v1.6.0', 'v1.6.1-RC1'),
+            ],
+            'AGGREGATED-NOTES-BODY'
+        );
+
+        $executor = new LiveExecutor(
+            new PerRepoActions($exec),
+            new ComposerJsonConstraintWriter(),
+            new DefaultBranchResolver()
+        );
+        $executor->execute($plan, [
+            'o3-shop/shop-ce' => $shopCePath,
+            'o3-shop/o3-shop' => $o3ShopPath,
+        ]);
+
+        $commands = $this->cmdStrings($exec);
+        // Order: shop-ce gets touched (commit + tag + push + release) BEFORE o3-shop.
+        $shopCeCommitIdx = $this->indexOfFirst($commands, 'git commit -m');
+        $shopCeReleaseIdx = $this->indexOfNth($commands, 'gh release create v1.6.1-RC1', 1);
+        $o3ShopCommitIdx = $this->indexOfNth($commands, 'git commit -m', 2);
+        $o3ShopReleaseIdx = $this->indexOfNth($commands, 'gh release create v1.6.1-RC1', 2);
+
+        $this->assertGreaterThan(-1, $shopCeCommitIdx);
+        $this->assertGreaterThan($shopCeCommitIdx, $shopCeReleaseIdx);
+        $this->assertGreaterThan($shopCeReleaseIdx, $o3ShopCommitIdx);
+        $this->assertGreaterThan($o3ShopCommitIdx, $o3ShopReleaseIdx);
+
+        // o3-shop release uses --notes (override) with the aggregated body
+        $aggregatedReleaseCall = $this->callAt($exec, $o3ShopReleaseIdx);
+        $this->assertContains('--notes', $aggregatedReleaseCall['command']);
+        $notesArgIdx = array_search('--notes', $aggregatedReleaseCall['command'], true);
+        $this->assertSame('AGGREGATED-NOTES-BODY', $aggregatedReleaseCall['command'][$notesArgIdx + 1]);
+
+        // shop-ce release uses --generate-notes (no override)
+        $shopCeReleaseCall = $this->callAt($exec, $shopCeReleaseIdx);
+        $this->assertContains('--generate-notes', $shopCeReleaseCall['command']);
+
+        // composer.json constraint actually got rewritten on disk
+        $this->assertStringContainsString('"o3-shop/shop-doctrine-migration-wrapper": "v1.0.3"', file_get_contents($shopCePath . '/composer.json'));
+        $this->assertStringContainsString('"o3-shop/shop-ce": "v1.6.1-RC1"', file_get_contents($o3ShopPath . '/composer.json'));
+
+        // Release URLs captured for partial-state recovery
+        $this->assertSame([
+            'o3-shop/shop-ce' => 'https://github.com/o3-shop/X/releases/tag/Y',
+            'o3-shop/o3-shop' => 'https://github.com/o3-shop/X/releases/tag/Y',
+        ], $executor->releaseUrls());
+    }
+
+    public function testRcShopToDoesNotOpenMergeBackPrs(): void
+    {
+        $shopCePath = $this->mkRepo('{"require":{}}');
+        $o3ShopPath = $this->mkRepo('{"require":{}}');
+        $exec = new FakeProcessExecutor([], new ProcessOutcome(0, 'https://example.invalid/draft', ''));
+
+        $plan = $this->buildPlan(
+            'v1.6.0',
+            'v1.6.1-RC1',
+            [
+                $this->cuttingCandidate('o3-shop/shop-ce', 'v1.6.0', 'v1.6.1-RC1'),
+            ],
+            [],
+            ''
+        );
+
+        $executor = new LiveExecutor(
+            new PerRepoActions($exec),
+            new ComposerJsonConstraintWriter(),
+            new DefaultBranchResolver()
+        );
+        $executor->execute($plan, [
+            'o3-shop/shop-ce' => $shopCePath,
+            'o3-shop/o3-shop' => $o3ShopPath,
+        ]);
+
+        $commands = $this->cmdStrings($exec);
+        foreach ($commands as $cmd) {
+            $this->assertStringNotContainsString('gh pr create', $cmd, 'no merge-back PR for RC');
+        }
+        $this->assertSame([], $executor->mergeBackUrls());
+    }
+
+    public function testFinalShopToOpensMergeBackPrForCandidatesAndOrchestrator(): void
+    {
+        $shopCePath = $this->mkRepo('{"require":{}}');
+        $o3ShopPath = $this->mkRepo('{"require":{}}');
+        $exec = new FakeProcessExecutor([], new ProcessOutcome(0, 'https://example.invalid/url', ''));
+
+        $plan = $this->buildPlan(
+            'v1.6.0',
+            'v1.6.1',
+            [
+                $this->cuttingCandidate('o3-shop/shop-ce', 'v1.6.0', 'v1.6.1'),
+            ],
+            [],
+            ''
+        );
+
+        $executor = new LiveExecutor(
+            new PerRepoActions($exec),
+            new ComposerJsonConstraintWriter(),
+            new DefaultBranchResolver()
+        );
+        $executor->execute($plan, [
+            'o3-shop/shop-ce' => $shopCePath,
+            'o3-shop/o3-shop' => $o3ShopPath,
+        ]);
+
+        $prCalls = array_values(array_filter(
+            $exec->commands(),
+            static fn (array $cmd): bool => isset($cmd[1]) && $cmd[1] === 'pr' && $cmd[2] === 'create'
+        ));
+        // One per candidate + one for o3-shop = 2
+        $this->assertCount(2, $prCalls);
+        $repoSlugs = array_map(static fn (array $cmd): string => $cmd[array_search('--repo', $cmd, true) + 1], $prCalls);
+        $this->assertContains('o3-shop/shop-ce', $repoSlugs);
+        $this->assertContains('o3-shop/o3-shop', $repoSlugs);
+        $this->assertCount(2, $executor->mergeBackUrls());
+    }
+
+    public function testMissingRepoPathForCandidateThrows(): void
+    {
+        $exec = new FakeProcessExecutor();
+        $plan = $this->buildPlan(
+            'v1.6.0',
+            'v1.6.1-RC1',
+            [
+                $this->cuttingCandidate('o3-shop/shop-ce', 'v1.6.0', 'v1.6.1-RC1'),
+            ],
+            [],
+            ''
+        );
+
+        $executor = new LiveExecutor(
+            new PerRepoActions($exec),
+            new ComposerJsonConstraintWriter(),
+            new DefaultBranchResolver()
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('no local repo path supplied for o3-shop/shop-ce');
+        // No repo paths supplied
+        $executor->execute($plan, []);
+    }
+
+    public function testNextBumpDeletionIsTriggeredFromCandidatesTagCutResult(): void
+    {
+        $shopFactsPath = $this->mkRepo('{"require":{}}');
+        $o3ShopPath = $this->mkRepo('{"require":{}}');
+        $exec = new FakeProcessExecutor([], new ProcessOutcome(0, 'https://example.invalid/url', ''));
+
+        $candidate = new CandidatePlan(
+            'o3-shop/shop-facts',
+            'v1.0.4',
+            'v1.0.5',
+            new VersionResolution('o3-shop/shop-facts', VersionResolution::CASE_NEEDS_NEW_TAG, null, [], 'v1.0.4'),
+            new TagCutResult('v1.0.5', /* deleteNextBump = */ true, TagCutResult::SOURCE_NEXT_BUMP_FILE)
+        );
+        $plan = $this->buildPlan('v1.6.0', 'v1.6.1-RC1', [$candidate], [], '');
+
+        $executor = new LiveExecutor(
+            new PerRepoActions($exec),
+            new ComposerJsonConstraintWriter(),
+            new DefaultBranchResolver()
+        );
+        $executor->execute($plan, [
+            'o3-shop/shop-facts' => $shopFactsPath,
+            'o3-shop/o3-shop' => $o3ShopPath,
+        ]);
+
+        $commands = $this->cmdStrings($exec);
+        $hasRm = false;
+        foreach ($commands as $cmd) {
+            if (strpos($cmd, 'git rm --ignore-unmatch .next-bump') !== false) {
+                $hasRm = true;
+                break;
+            }
+        }
+        $this->assertTrue($hasRm, 'expected `git rm --ignore-unmatch .next-bump` for shop-facts');
+    }
+
+    /* -------- helpers -------- */
+
+    /**
+     * @param array<int,CandidatePlan>      $candidates
+     * @param array<int,ConstraintEditPlan> $edits
+     */
+    private function buildPlan(
+        string $fromTag,
+        string $toTag,
+        array $candidates,
+        array $edits,
+        string $aggregatedNotes
+    ): ReleasePlan {
+        return new ReleasePlan(
+            $fromTag,
+            $toTag,
+            new FromSnapshot([], false, null),
+            $candidates,
+            $edits,
+            $aggregatedNotes,
+            []
+        );
+    }
+
+    private function cuttingCandidate(string $package, string $fromPin, string $newTag): CandidatePlan
+    {
+        return new CandidatePlan(
+            $package,
+            $fromPin,
+            $newTag,
+            new VersionResolution($package, VersionResolution::CASE_NEEDS_NEW_TAG, null, [], $fromPin),
+            new TagCutResult($newTag, false, TagCutResult::SOURCE_DEFAULT_PATCH)
+        );
+    }
+
+    private function edit(
+        string $parent,
+        string $key,
+        string $dep,
+        string $oldConstraint,
+        string $newConstraint
+    ): ConstraintEditPlan {
+        return new ConstraintEditPlan(
+            $parent,
+            $key,
+            $dep,
+            new ConstraintUpdate($oldConstraint, $newConstraint, ConstraintUpdate::SHAPE_EXACT_REPLACED)
+        );
+    }
+
+    private function mkRepo(string $composerJson): string
+    {
+        $dir = sys_get_temp_dir() . '/live-executor-test-' . bin2hex(random_bytes(4));
+        mkdir($dir);
+        mkdir($dir . '/.git');
+        file_put_contents($dir . '/composer.json', $composerJson);
+        $this->tmpDirs[] = $dir;
+        return $dir;
+    }
+
+    private function rmrf(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $entry;
+            is_dir($path) ? $this->rmrf($path) : @unlink($path);
+        }
+        @rmdir($dir);
+    }
+
+    /** @return array<int,string> joined commands per call, for substring assertions */
+    private function cmdStrings(FakeProcessExecutor $exec): array
+    {
+        $strings = [];
+        foreach ($exec->commands() as $cmd) {
+            $strings[] = implode(' ', $cmd);
+        }
+        return $strings;
+    }
+
+    /** @param array<int,string> $strings */
+    private function indexOfFirst(array $strings, string $needle): int
+    {
+        foreach ($strings as $i => $s) {
+            if (strpos($s, $needle) !== false) {
+                return $i;
+            }
+        }
+        return -1;
+    }
+
+    /** @param array<int,string> $strings */
+    private function indexOfNth(array $strings, string $needle, int $nth): int
+    {
+        $count = 0;
+        foreach ($strings as $i => $s) {
+            if (strpos($s, $needle) !== false) {
+                $count++;
+                if ($count === $nth) {
+                    return $i;
+                }
+            }
+        }
+        return -1;
+    }
+
+    /** @return array{command:array<int,string>,cwd:string|null,timeout:int} */
+    private function callAt(FakeProcessExecutor $exec, int $idx): array
+    {
+        return $exec->calls[$idx];
+    }
+}


### PR DESCRIPTION
## Summary

Closes the §15 gap — `bin/release` without `--dry-run` now actually
performs the cut. The dry-run path was already implemented in §11;
this PR adds the live orchestration on top.

## What's new

- **`ComposerJsonConstraintWriter`** — applies §8 constraint edits
  to a local clone's `composer.json`. Text-based regex replacement
  (no `json_decode`/`json_encode` round-trip) so hand-curated
  formatting survives. Throws on unexpected pattern absence so a
  mid-release hand-edit doesn't get silently overwritten.

- **`LiveExecutor`** — orchestrates the per-repo walk:

  1. Group constraint edits by parent package
  2. Walk candidates leaves-first (topological order from §5):
     `commit + push` → `tag + push` → `draft release`
     (`--generate-notes` for tier-0/1)
  3. Handle `o3-shop/o3-shop` (never a candidate, always tagged with
     `--to`, draft body = aggregated cross-repo markdown via `--notes`)
  4. Open merge-back PRs (final releases only, per `MergeBackPolicy`)

- **`ReleaseCommand` updates**:

  - `--repo-path <pkg>=/abs/path` (repeatable). Validated as an
    existing git working tree.
  - Live mode without `--repo-path` returns `USAGE_ERROR` with a
    hint to use `--dry-run` for a preview.
  - Default-planner factory builds the full §10 `PreFlightRunner`
    with all 6 gates when any `--repo-path` is supplied
    (`TestSuiteGate` registers a no-op resolver — maintainers can
    plug a per-repo test command later).
  - Pre-flight abort short-circuits before the executor instantiates.
  - Captured release URLs + merge-back PR URLs dumped on completion
    or failure so partial-state recovery is log-friendly.

## Tests

- `ComposerJsonConstraintWriterTest` — 6 cases: exact-pin replace,
  multi-edit one-pass, missing-pattern throws, empty edit list no-op,
  formatting preserved outside the edited line, missing file throws.
- `LiveExecutorTest` — 5 cases: candidate-then-orchestrator order
  with `--notes` vs `--generate-notes`, RC `--to` skips merge-back,
  final `--to` opens merge-back for candidates AND orchestrator,
  missing repo path throws, `.next-bump` deletion fires when
  `TagCutResult` says so.
- `ReleaseCommandTest` — updated to remove the obsolete "Section 15
  wiring pending" assertion. Added 4 new live-mode cases.

## §15 sub-tasks closed

§15.1 (--repo-path flag), §15.2 (PreFlightRunner + LiveExecutor),
§15.3 (repo paths threaded through), §15.4 (pre-flight abort path),
§15.5 (topological candidate walk + orchestrator), §15.6 (progress
streaming + URL capture), §15.7 (unit tests), §15.8 (wiring-pending
branch removed).

## Test plan

- [x] PHP syntax-checked (`php -l`) on all new + modified files
- [x] cs-fixer pass-through (one minor empty-closure-body fix
      auto-applied)
- [ ] Full unit suite (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)