### PR TITLE
fix(#140): use bundled composer in ComposerInstallGate

### DIFF
--- a/source/Internal/ReleaseTooling/Command/ReleaseCommand.php
+++ b/source/Internal/ReleaseTooling/Command/ReleaseCommand.php
@@ -359,11 +359,30 @@ class ReleaseCommand extends Command
             new WorkingTreeGate($exec),
             new BranchGate($exec),
             new UpToDateGate($exec),
-            new ComposerInstallGate($exec, 'composer', $skipAudit),
+            new ComposerInstallGate($exec, $this->resolveBundledComposer(), $skipAudit),
             new TestSuiteGate($exec, $skipTestsResolver),
             new IncomingPrGate($exec),
             new MergeBackPrGate($exec),
         ]);
+    }
+
+    /**
+     * Returns the path to shop-ce's bundled composer
+     * (`vendor/bin/composer`, composer 2.2.x via the transitive
+     * `o3-shop/shop-composer-plugin` dep) when present, otherwise
+     * falls back to `composer` from PATH. Using the bundled binary
+     * makes the pre-flight gate's composer behavior consistent
+     * across maintainer machines and identical to production
+     * `o3-shop` installs.
+     */
+    private function resolveBundledComposer(): string
+    {
+        // From source/Internal/ReleaseTooling/Command/ → shop-ce root.
+        $candidate = realpath(__DIR__ . '/../../../../vendor/bin/composer');
+        if ($candidate !== false && is_executable($candidate)) {
+            return $candidate;
+        }
+        return 'composer';
     }
 
     private function buildDefaultLiveExecutor(?callable $progress = null): LiveExecutor

--- a/source/Internal/ReleaseTooling/Flow/Gates/ComposerInstallGate.php
+++ b/source/Internal/ReleaseTooling/Flow/Gates/ComposerInstallGate.php
@@ -41,12 +41,19 @@ use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\ProcessExecutor;
  *     installs, so the gate stays out of the way.
  *
  * Audit:
- *   - Modern composer runs a security audit by default and aborts on
- *     anything in the public advisories DB. That's noisy for legacy
- *     deps that the org chooses to keep on a known version. The
+ *   - Composer 2.7+ runs a security audit during install. The
  *     `$skipAudit` constructor flag (wired to the `--no-audit` CLI
- *     flag) lets the maintainer opt out per release. Default: audit
- *     stays on.
+ *     flag on `bin/release`) appends `--no-audit` to the install
+ *     command, suppressing the post-install advisory report.
+ *     Default: audit stays on.
+ *
+ * Composer binary:
+ *   - The default `$composerBin` is just `'composer'` (PATH lookup),
+ *     but `ReleaseCommand` resolves shop-ce's bundled
+ *     `vendor/bin/composer` (composer 2.2.x via the transitive
+ *     `o3-shop/shop-composer-plugin` dep) and passes that here.
+ *     Using the bundled composer avoids host-PATH version skew —
+ *     production o3-shop installs run the same 2.2.x.
  */
 class ComposerInstallGate implements PreFlightGate
 {


### PR DESCRIPTION
## Summary

The first `bin/release ... --no-audit` live run aborted on shop-ce
with `The "--no-audit" option does not exist`. Root cause: the
gate was invoking the host's PATH composer, which on the
maintainer's machine was composer **2.9.7** — a version that
renamed/dropped `--no-audit` in favor of `--no-security-blocking`.

More fundamentally, the gate was validating against a different
composer version than production o3-shop installs actually use.

## Fix

`ReleaseCommand` now resolves shop-ce's bundled
`vendor/bin/composer` (composer **2.2.x** via the transitive
`o3-shop/shop-composer-plugin` dep) and passes that absolute path
to `ComposerInstallGate`. That binary:

- **matches production** — same composer version o3-shop installs run
- **predates the resolver-time advisory block** (introduced in 2.7+)
  so legacy pinned deps (smarty/smarty 2.6.x and similar) don't
  trigger spurious aborts during release pre-flight
- **accepts `--no-audit`** as the gate has always used

The user-facing `--no-audit` flag on `bin/release` is unchanged.

Falls back to PATH `composer` only if shop-ce's vendor binary
isn't present (fresh-clone-before-composer-install edge case).

## Test plan

- [x] `php -l` clean on both files
- [x] `./docker.sh test --fast` on `GateBehaviorTest` — 22 / 45, all green
- [x] `./docker.sh test-all-coverage` — 9602 tests / 17748 assertions,
      coverage 90.86% overall (unchanged)
- [x] cs-fixer pass-through (no changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)