### PR TITLE
fix(#140): drop --no-audit; bundled composer 2.2.x predates audit feature

### DIFF
--- a/source/Internal/ReleaseTooling/Command/ReleaseCommand.php
+++ b/source/Internal/ReleaseTooling/Command/ReleaseCommand.php
@@ -165,15 +165,6 @@ class ReleaseCommand extends Command
                 . 'when a clone lives outside the conventional layout.'
             )
             ->addOption(
-                'no-audit',
-                null,
-                InputOption::VALUE_NONE,
-                'Skip the composer security audit during the '
-                . 'composer-resolution pre-flight gate. Use sparingly: '
-                . 'opts out of the public-advisories block. Default '
-                . 'leaves audit enabled.'
-            )
-            ->addOption(
                 'dry-run',
                 null,
                 InputOption::VALUE_NONE,
@@ -187,7 +178,6 @@ class ReleaseCommand extends Command
         $to = $input->getOption('to');
         $bumps = $input->getOption('bump') ?: [];
         $dryRun = (bool) $input->getOption('dry-run');
-        $noAudit = (bool) $input->getOption('no-audit');
 
         if (!is_string($from) || $from === '') {
             $this->writeUsageError($output, '--from is required.');
@@ -235,7 +225,7 @@ class ReleaseCommand extends Command
             return self::EXIT_USAGE_ERROR;
         }
 
-        $planner = $this->planner ?? $this->buildDefaultPlanner($progress, $repoPaths !== [], $noAudit);
+        $planner = $this->planner ?? $this->buildDefaultPlanner($progress, $repoPaths !== []);
 
         $output->writeln(sprintf(
             '<info>Planning release: --from %s --to %s%s</info>',
@@ -315,8 +305,7 @@ class ReleaseCommand extends Command
 
     private function buildDefaultPlanner(
         ?callable $progress = null,
-        bool $withPreFlight = false,
-        bool $skipAudit = false
+        bool $withPreFlight = false
     ): ReleasePlanner {
         $exec = new SymfonyProcessExecutor();
         $composerJsonFetcher = new HttpsRawComposerJsonFetcher();
@@ -331,7 +320,7 @@ class ReleaseCommand extends Command
         $constraintUpdater = new ConstraintUpdater();
         $notesAggregator = new ReleaseNotesAggregator(new GhCliReleaseNotesProvider(), $progress);
 
-        $preFlight = $withPreFlight ? $this->buildDefaultPreFlightRunner($exec, $skipAudit) : null;
+        $preFlight = $withPreFlight ? $this->buildDefaultPreFlightRunner($exec) : null;
 
         return new ReleasePlanner(
             $snapshotBuilder,
@@ -346,7 +335,7 @@ class ReleaseCommand extends Command
         );
     }
 
-    private function buildDefaultPreFlightRunner(SymfonyProcessExecutor $exec, bool $skipAudit = false): PreFlightRunner
+    private function buildDefaultPreFlightRunner(SymfonyProcessExecutor $exec): PreFlightRunner
     {
         // No per-repo test command resolver yet; TestSuiteGate is
         // registered with a resolver that always returns null (= skip
@@ -359,7 +348,7 @@ class ReleaseCommand extends Command
             new WorkingTreeGate($exec),
             new BranchGate($exec),
             new UpToDateGate($exec),
-            new ComposerInstallGate($exec, $this->resolveBundledComposer(), $skipAudit),
+            new ComposerInstallGate($exec, $this->resolveBundledComposer()),
             new TestSuiteGate($exec, $skipTestsResolver),
             new IncomingPrGate($exec),
             new MergeBackPrGate($exec),

--- a/source/Internal/ReleaseTooling/Flow/Gates/ComposerInstallGate.php
+++ b/source/Internal/ReleaseTooling/Flow/Gates/ComposerInstallGate.php
@@ -40,20 +40,18 @@ use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\ProcessExecutor;
  *     "resolve from scratch" mode which doesn't reflect production
  *     installs, so the gate stays out of the way.
  *
- * Audit:
- *   - Composer 2.7+ runs a security audit during install. The
- *     `$skipAudit` constructor flag (wired to the `--no-audit` CLI
- *     flag on `bin/release`) appends `--no-audit` to the install
- *     command, suppressing the post-install advisory report.
- *     Default: audit stays on.
- *
- * Composer binary:
- *   - The default `$composerBin` is just `'composer'` (PATH lookup),
- *     but `ReleaseCommand` resolves shop-ce's bundled
+ * Composer binary + audit:
+ *   - The default `$composerBin` is `'composer'` (PATH lookup), but
+ *     `ReleaseCommand` resolves shop-ce's bundled
  *     `vendor/bin/composer` (composer 2.2.x via the transitive
  *     `o3-shop/shop-composer-plugin` dep) and passes that here.
  *     Using the bundled composer avoids host-PATH version skew —
  *     production o3-shop installs run the same 2.2.x.
+ *   - Composer 2.2.x predates the audit feature (added in 2.6+),
+ *     so no audit-skip flag is passed. If the bundled composer is
+ *     ever upgraded past 2.6, the gate will need a version-aware
+ *     audit-skip flag (`--no-audit` for 2.7-2.8, `--no-security-
+ *     blocking` for 2.9+).
  */
 class ComposerInstallGate implements PreFlightGate
 {
@@ -61,16 +59,13 @@ class ComposerInstallGate implements PreFlightGate
 
     private ProcessExecutor $exec;
     private string $composerBin;
-    private bool $skipAudit;
 
     public function __construct(
         ProcessExecutor $exec,
-        string $composerBin = 'composer',
-        bool $skipAudit = false
+        string $composerBin = 'composer'
     ) {
         $this->exec = $exec;
         $this->composerBin = $composerBin;
-        $this->skipAudit = $skipAudit;
     }
 
     public function name(): string
@@ -87,9 +82,6 @@ class ComposerInstallGate implements PreFlightGate
         }
 
         $args = [$this->composerBin, 'install', '--dry-run', '--no-scripts', '--no-interaction'];
-        if ($this->skipAudit) {
-            $args[] = '--no-audit';
-        }
         $outcome = $this->exec->execute($args, $repoPath, 300);
         if ($outcome->isSuccess()) {
             return GateOutcome::passed(self::NAME);

--- a/tests/Unit/Internal/ReleaseTooling/Flow/Gates/GateBehaviorTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Flow/Gates/GateBehaviorTest.php
@@ -133,26 +133,12 @@ class GateBehaviorTest extends TestCase
         }
     }
 
-    public function testComposerInstallGateAddsNoAuditFlagWhenSkipAuditTrue(): void
+    public function testComposerInstallGateNeverPassesAuditSkipFlag(): void
     {
-        $tmp = sys_get_temp_dir() . '/release-cmd-test-' . bin2hex(random_bytes(4));
-        mkdir($tmp);
-        file_put_contents($tmp . '/composer.lock', '{}');
-        try {
-            $exec = new FakeProcessExecutor([], new ProcessOutcome(0, '', ''));
-            $gate = new ComposerInstallGate($exec, 'composer', true);
-            $outcome = $gate->evaluate($tmp, 'b-1.6', 'o3-shop/shop-ce');
-            $this->assertTrue($outcome->isPassed());
-            $cmd = implode(' ', $exec->commands()[0]);
-            $this->assertStringContainsString('--no-audit', $cmd);
-        } finally {
-            @unlink($tmp . '/composer.lock');
-            @rmdir($tmp);
-        }
-    }
-
-    public function testComposerInstallGateDoesNotAddNoAuditByDefault(): void
-    {
+        // The bundled composer (2.2.x via shop-composer-plugin's
+        // transitive dep) predates the audit feature, so the gate
+        // never passes any `--no-audit` / `--no-security-blocking`
+        // flag — composer would reject the unknown option.
         $tmp = sys_get_temp_dir() . '/release-cmd-test-' . bin2hex(random_bytes(4));
         mkdir($tmp);
         file_put_contents($tmp . '/composer.lock', '{}');
@@ -161,6 +147,7 @@ class GateBehaviorTest extends TestCase
             (new ComposerInstallGate($exec))->evaluate($tmp, 'b-1.6', 'o3-shop/shop-ce');
             $cmd = implode(' ', $exec->commands()[0]);
             $this->assertStringNotContainsString('--no-audit', $cmd);
+            $this->assertStringNotContainsString('--no-security-blocking', $cmd);
         } finally {
             @unlink($tmp . '/composer.lock');
             @rmdir($tmp);


### PR DESCRIPTION
## Summary

After PR #129 routed the gate to shop-ce's bundled
`vendor/bin/composer` (composer 2.2.27 via shop-composer-plugin's
transitive dep), the second live attempt at v1.6.1-RC1 surfaced
this:

```
[composer-resolution] composer install --dry-run failed in
/Users/.../shop-ce (exit 1):
  The "--no-audit" option does not exist.
```

Composer 2.2.x **predates the audit feature** (audit was added
in 2.6+). The gate was unconditionally appending `--no-audit` when
`$skipAudit=true`, which 2.2.x rejects.

## Why this is a no-op fix

With bundled composer 2.2.x there is no audit to skip — the
feature simply doesn't exist. The whole `--no-audit` machinery was
added (#128) to bypass composer 2.7+'s post-install advisory
report; it's dead code in the bundled-composer world.

Dropping it cleanly:

- `bin/release --no-audit` CLI flag removed
- `ComposerInstallGate` constructor's `$skipAudit` parameter removed
- Plumbing through `buildDefaultPlanner` →
  `buildDefaultPreFlightRunner` simplified
- Gate test consolidated: previous "adds `--no-audit` when
  `skipAudit=true`" case removed; remaining test asserts the gate
  never appends any audit-skip flag (covers both `--no-audit`
  AND `--no-security-blocking` for safety)

## Reserved for future

If the bundled composer is ever upgraded past 2.6, the gate will
need a version-aware audit-skip flag (`--no-audit` for 2.7-2.8,
`--no-security-blocking` for 2.9+). Recorded in the gate's
docblock for future maintainers.

## Test plan

- [x] `php -l` clean
- [x] Targeted gate test green
- [x] `./docker.sh test-all-coverage` — 9601 tests / 17747
      assertions, 0 failures, coverage 90.86% (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)