### PR TITLE
feat(#145): auto-bump theme.php version line at release time

### DIFF
--- a/source/Internal/ReleaseTooling/Command/ReleaseCommand.php
+++ b/source/Internal/ReleaseTooling/Command/ReleaseCommand.php
@@ -39,6 +39,7 @@ use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\PreFlightRunner;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\RepoCloneUrlResolver;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\RepoPathDiscovery;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\SymfonyProcessExecutor;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\ThemeFileVersionWriter;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Graph\DepTreeWalker;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Notes\GhCliReleaseNotesProvider;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Notes\ReleaseNotesAggregator;
@@ -381,6 +382,7 @@ class ReleaseCommand extends Command
             new PerRepoActions($exec),
             new ComposerJsonConstraintWriter(),
             new DefaultBranchResolver(),
+            new ThemeFileVersionWriter(),
             $progress
         );
     }

--- a/source/Internal/ReleaseTooling/Flow/LiveExecutor.php
+++ b/source/Internal/ReleaseTooling/Flow/LiveExecutor.php
@@ -57,6 +57,7 @@ class LiveExecutor
 
     private PerRepoActions $actions;
     private ComposerJsonConstraintWriter $writer;
+    private ThemeFileVersionWriter $themeWriter;
     private DefaultBranchResolver $branchResolver;
     /** @var callable(string):void */
     private $progress;
@@ -71,10 +72,12 @@ class LiveExecutor
         PerRepoActions $actions,
         ComposerJsonConstraintWriter $writer,
         DefaultBranchResolver $branchResolver,
+        ?ThemeFileVersionWriter $themeWriter = null,
         ?callable $progress = null
     ) {
         $this->actions = $actions;
         $this->writer = $writer;
+        $this->themeWriter = $themeWriter ?? new ThemeFileVersionWriter();
         $this->branchResolver = $branchResolver;
         $this->progress = $progress ?? static function (string $_msg): void {
         };
@@ -179,6 +182,12 @@ class LiveExecutor
 
         $this->log(sprintf('[%s] applying %d constraint edit(s)', $package, count($edits)));
         $stagePaths = $this->writer->apply($repoPath . '/composer.json', $edits);
+
+        $themePaths = $this->themeWriter->apply($repoPath, $chosenVersion);
+        if ($themePaths !== []) {
+            $this->log(sprintf('[%s] bumped theme.php version to %s', $package, $chosenVersion));
+            $stagePaths = array_merge($stagePaths, $themePaths);
+        }
 
         $commitMessage = $this->buildCommitMessage($package, $chosenVersion, $shopTo, count($edits));
 

--- a/source/Internal/ReleaseTooling/Flow/ThemeFileVersionWriter.php
+++ b/source/Internal/ReleaseTooling/Flow/ThemeFileVersionWriter.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * This file is part of O3-Shop.
+ *
+ * O3-Shop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * O3-Shop is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with O3-Shop.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * @copyright  Copyright (c) 2026 O3-Shop (https://www.o3-shop.com)
+ * @license    https://www.gnu.org/licenses/gpl-3.0  GNU General Public License 3 (GPLv3)
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow;
+
+use RuntimeException;
+
+/**
+ * Rewrites a theme repo's `theme.php` `'version' => '…'` line to match
+ * the tag bin/release is about to cut. Keeps the admin → Theme list's
+ * displayed version in sync with the tag at release time — without
+ * adding any runtime dependency on composer's package metadata, so the
+ * "developer uploads their own theme into an existing installation"
+ * workflow keeps working unchanged (their own theme.php remains the
+ * source of truth).
+ *
+ * Edits theme.php as text (not via `include` + `var_export`) to
+ * preserve key order, indentation, and any inline comments — these
+ * files are hand-authored and we don't want a release commit to also
+ * reflow them.
+ *
+ *   - Non-theme repos (no `theme.php` at the repo root) → returns []
+ *     (no work, no exception). `bin/release` walks many non-theme
+ *     packages.
+ *   - Theme repos whose value is already current → returns [] (no
+ *     edit needed, no commit churn).
+ *   - Theme repos that need a bump → rewrites the line and returns
+ *     `['theme.php']` so the orchestrator stages it alongside any
+ *     `composer.json` edits.
+ *   - Theme repos whose `theme.php` is missing the `'version'` line
+ *     entirely → throws. The contract is broken; better to fail loud
+ *     than silently skip.
+ */
+final class ThemeFileVersionWriter
+{
+    /**
+     * @param string $repoPath   absolute path to the repo's working tree
+     * @param string $newVersion the tag being cut (e.g. "v1.3.2"); a
+     *                           leading "v"/"V" is stripped before writing
+     *                           since theme.php stores bare semver
+     *
+     * @return array<int,string> repo-relative paths staged: ['theme.php']
+     *                            when the line was rewritten, [] otherwise
+     *
+     * @throws RuntimeException when theme.php exists but the expected
+     *         `'version' => '…'` pattern is missing, or when filesystem
+     *         I/O fails.
+     */
+    public function apply(string $repoPath, string $newVersion): array
+    {
+        $themeFilePath = rtrim($repoPath, '/') . '/theme.php';
+        if (!is_file($themeFilePath)) {
+            return [];
+        }
+        $bareVersion = ltrim($newVersion, 'vV');
+
+        $contents = file_get_contents($themeFilePath);
+        if ($contents === false) {
+            throw new RuntimeException(sprintf(
+                'failed to read theme.php: %s',
+                $themeFilePath
+            ));
+        }
+
+        $pattern = "/(['\"])version\\1(\\s*=>\\s*)(['\"])([^'\"]*)\\3/";
+        if (!preg_match($pattern, $contents, $m)) {
+            throw new RuntimeException(sprintf(
+                "theme.php missing expected `'version' => '…'` line: %s",
+                $themeFilePath
+            ));
+        }
+        if ($m[4] === $bareVersion) {
+            return [];
+        }
+
+        $rewritten = preg_replace_callback(
+            $pattern,
+            static function (array $match) use ($bareVersion): string {
+                return $match[1] . 'version' . $match[1]
+                    . $match[2]
+                    . $match[3] . $bareVersion . $match[3];
+            },
+            $contents,
+            1
+        );
+        if ($rewritten === null || $rewritten === $contents) {
+            throw new RuntimeException(sprintf(
+                'regex rewrite produced no change in %s',
+                $themeFilePath
+            ));
+        }
+        if (file_put_contents($themeFilePath, $rewritten) === false) {
+            throw new RuntimeException(sprintf(
+                'failed to write theme.php: %s',
+                $themeFilePath
+            ));
+        }
+        return ['theme.php'];
+    }
+}

--- a/tests/Unit/Internal/ReleaseTooling/Flow/LiveExecutorTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Flow/LiveExecutorTest.php
@@ -254,6 +254,85 @@ final class LiveExecutorTest extends TestCase
         $this->assertTrue($hasRm, 'expected `git rm --ignore-unmatch .next-bump` for shop-facts');
     }
 
+    public function testThemeRepoGetsThemePhpVersionLineRewrittenAndStagedAlongsideComposerJson(): void
+    {
+        $themePath = $this->mkRepo('{"require":{}}');
+        file_put_contents($themePath . '/theme.php', "<?php\n\$aTheme = ['id' => 'o3-theme', 'version' => '1.0.0'];");
+        $o3ShopPath = $this->mkRepo('{"require":{}}');
+        $exec = new FakeProcessExecutor([], new ProcessOutcome(0, 'https://example.invalid/url', ''));
+
+        $plan = $this->buildPlan(
+            'v1.6.0',
+            'v1.6.1-RC1',
+            [$this->cuttingCandidate('o3-shop/o3-theme', 'v1.3.0', 'v1.3.1')],
+            [],
+            ''
+        );
+
+        $executor = new LiveExecutor(
+            new PerRepoActions($exec),
+            new ComposerJsonConstraintWriter(),
+            new DefaultBranchResolver()
+        );
+        $executor->execute($plan, [
+            'o3-shop/o3-theme' => $themePath,
+            'o3-shop/o3-shop' => $o3ShopPath,
+        ]);
+
+        // theme.php was rewritten on disk: leading 'v' stripped, line updated
+        $this->assertStringContainsString(
+            "'version' => '1.3.1'",
+            file_get_contents($themePath . '/theme.php')
+        );
+        // ... and was staged in the same per-repo commit (git add args include theme.php)
+        $addCalls = array_values(array_filter(
+            $exec->commands(),
+            static fn (array $cmd): bool => isset($cmd[0], $cmd[1]) && $cmd[0] === 'git' && $cmd[1] === 'add'
+        ));
+        $themeAddSeen = false;
+        foreach ($addCalls as $cmd) {
+            if (in_array('theme.php', $cmd, true)) {
+                $themeAddSeen = true;
+                break;
+            }
+        }
+        $this->assertTrue($themeAddSeen, 'expected `git add` to include theme.php for the theme repo');
+    }
+
+    public function testNonThemeRepoDoesNotStageThemeFile(): void
+    {
+        $shopCePath = $this->mkRepo('{"require":{}}'); // no theme.php
+        $o3ShopPath = $this->mkRepo('{"require":{}}');
+        $exec = new FakeProcessExecutor([], new ProcessOutcome(0, 'https://example.invalid/url', ''));
+
+        $plan = $this->buildPlan(
+            'v1.6.0',
+            'v1.6.1-RC1',
+            [$this->cuttingCandidate('o3-shop/shop-ce', 'v1.6.0', 'v1.6.1-RC1')],
+            [],
+            ''
+        );
+
+        $executor = new LiveExecutor(
+            new PerRepoActions($exec),
+            new ComposerJsonConstraintWriter(),
+            new DefaultBranchResolver()
+        );
+        $executor->execute($plan, [
+            'o3-shop/shop-ce' => $shopCePath,
+            'o3-shop/o3-shop' => $o3ShopPath,
+        ]);
+
+        $allStagedArgs = [];
+        foreach ($exec->commands() as $cmd) {
+            if (isset($cmd[0], $cmd[1]) && $cmd[0] === 'git' && $cmd[1] === 'add') {
+                $allStagedArgs = array_merge($allStagedArgs, array_slice($cmd, 2));
+            }
+        }
+        $this->assertNotContains('theme.php', $allStagedArgs, 'non-theme repo must not stage theme.php');
+        $this->assertFalse(is_file($shopCePath . '/theme.php'), 'sanity: no theme.php fixture');
+    }
+
     /* -------- helpers -------- */
 
     /**

--- a/tests/Unit/Internal/ReleaseTooling/Flow/ThemeFileVersionWriterTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Flow/ThemeFileVersionWriterTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * This file is part of O3-Shop.
+ *
+ * O3-Shop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * O3-Shop is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with O3-Shop.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * @copyright  Copyright (c) 2026 O3-Shop (https://www.o3-shop.com)
+ * @license    https://www.gnu.org/licenses/gpl-3.0  GNU General Public License 3 (GPLv3)
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\ReleaseTooling\Flow;
+
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\ThemeFileVersionWriter;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class ThemeFileVersionWriterTest extends TestCase
+{
+    /** @var array<int,string> */
+    private array $tmpDirs = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tmpDirs as $dir) {
+            $this->rmrf($dir);
+        }
+        $this->tmpDirs = [];
+    }
+
+    public function testRewritesVersionLineAndStagesThemeFile(): void
+    {
+        $repo = $this->mkRepoWithTheme(<<<'PHP'
+<?php
+$aTheme = [
+    'id'      => 'o3-theme',
+    'title'   => 'O3-Theme',
+    'version' => '1.0.0',
+    'author'  => '<a>O3-Shop</a>',
+];
+PHP);
+        $writer = new ThemeFileVersionWriter();
+        $staged = $writer->apply($repo, 'v1.3.1');
+
+        $this->assertSame(['theme.php'], $staged);
+        $contents = file_get_contents($repo . '/theme.php');
+        $this->assertStringContainsString("'version' => '1.3.1',", $contents);
+        $this->assertStringNotContainsString("'version' => '1.0.0',", $contents);
+    }
+
+    public function testStripsLeadingVFromTag(): void
+    {
+        $repo = $this->mkRepoWithTheme("<?php\n\$aTheme = ['version' => '1.0.0'];");
+        (new ThemeFileVersionWriter())->apply($repo, 'V1.2.3');
+
+        $this->assertStringContainsString("'version' => '1.2.3'", file_get_contents($repo . '/theme.php'));
+    }
+
+    public function testHandlesPreReleaseTagWithRcSuffix(): void
+    {
+        $repo = $this->mkRepoWithTheme("<?php\n\$aTheme = ['version' => '1.0.0'];");
+        (new ThemeFileVersionWriter())->apply($repo, 'v1.6.1-RC1');
+
+        $this->assertStringContainsString("'version' => '1.6.1-RC1'", file_get_contents($repo . '/theme.php'));
+    }
+
+    public function testReturnsEmptyWhenNoThemeFileExists(): void
+    {
+        $repo = $this->mkRepoWithoutTheme();
+        $staged = (new ThemeFileVersionWriter())->apply($repo, 'v1.6.1');
+
+        $this->assertSame([], $staged);
+        $this->assertFalse(is_file($repo . '/theme.php'));
+    }
+
+    public function testReturnsEmptyWhenVersionAlreadyCurrent(): void
+    {
+        $repo = $this->mkRepoWithTheme("<?php\n\$aTheme = ['version' => '1.3.1'];");
+        $staged = (new ThemeFileVersionWriter())->apply($repo, 'v1.3.1');
+
+        $this->assertSame([], $staged);
+        // File contents unchanged (mtime check would be flaky; content equality is enough)
+        $this->assertSame(
+            "<?php\n\$aTheme = ['version' => '1.3.1'];",
+            file_get_contents($repo . '/theme.php')
+        );
+    }
+
+    public function testThrowsWhenThemeFileLacksVersionLine(): void
+    {
+        $repo = $this->mkRepoWithTheme(<<<'PHP'
+<?php
+$aTheme = [
+    'id'    => 'broken-theme',
+    'title' => 'Broken',
+];
+PHP);
+        $writer = new ThemeFileVersionWriter();
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("missing expected `'version' => '…'` line");
+        $writer->apply($repo, 'v1.3.1');
+    }
+
+    public function testAcceptsDoubleQuotedVersionLine(): void
+    {
+        $repo = $this->mkRepoWithTheme("<?php\n\$aTheme = [\"version\" => \"1.0.0\"];");
+        (new ThemeFileVersionWriter())->apply($repo, 'v1.4.0');
+
+        $this->assertStringContainsString('"version" => "1.4.0"', file_get_contents($repo . '/theme.php'));
+    }
+
+    public function testPreservesSurroundingFormattingAndKeyOrder(): void
+    {
+        $original = <<<'PHP'
+<?php
+$aTheme = [
+    'id'          => 'o3-theme',
+    'title'       => 'O3-Theme',
+    'description' => 'Demo',
+    'thumbnail'   => 'theme.png',
+    'version'     => '1.0.0',
+    'author'      => '<a>O3-Shop</a>',
+    'settings'    => [
+        ['group' => 'mode', 'name' => 'sShowMode'],
+    ],
+];
+PHP;
+        $repo = $this->mkRepoWithTheme($original);
+        (new ThemeFileVersionWriter())->apply($repo, 'v1.3.1');
+
+        $expected = str_replace("'version'     => '1.0.0',", "'version'     => '1.3.1',", $original);
+        $this->assertSame($expected, file_get_contents($repo . '/theme.php'));
+    }
+
+    private function mkRepoWithTheme(string $themeFileContents): string
+    {
+        $repo = $this->mkRepoWithoutTheme();
+        file_put_contents($repo . '/theme.php', $themeFileContents);
+        return $repo;
+    }
+
+    private function mkRepoWithoutTheme(): string
+    {
+        $repo = sys_get_temp_dir() . '/theme-writer-test-' . bin2hex(random_bytes(4));
+        mkdir($repo);
+        $this->tmpDirs[] = $repo;
+        return $repo;
+    }
+
+    private function rmrf(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path) && !is_link($path)) {
+                $this->rmrf($path);
+            } else {
+                @unlink($path);
+            }
+        }
+        @rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary

Wires `bin/release` to keep `theme.php`'s `'version'` line in sync with the tag it's cutting, so the admin → Theme list always shows the version that was actually installed — no maintainer edit per release, no drift.

Companion to the one-time correction commits:
- [o3-shop/o3-Theme#24](https://github.com/o3-shop/o3-Theme/pull/24) — bumps the stale `1.0.0` → `1.3.1`
- [o3-shop/wave-theme#5](https://github.com/o3-shop/wave-theme/pull/5) — bumps the stale `1.1.0` → `1.2.1`

## Design

`ThemeFileVersionWriter` is a small file-text editor modelled on `ComposerJsonConstraintWriter`:

- **Detection by file presence.** `<repoPath>/theme.php` exists → rewrite. No `theme.php` → no-op. Same convention `Theme::load()` already uses on the runtime side, so there's no theme-package list to maintain anywhere. Adding a new theme to the org Just Works.
- **Edits theme.php as text**, not via `include` + `var_export`, so key order, indentation, and any inline comments stay intact. Theme metadata files are hand-authored.
- **Stages alongside composer.json.** `LiveExecutor::processRepo()` calls the new writer right after `ComposerJsonConstraintWriter::apply()`; both staged paths get committed in the same per-repo release commit.

### Edge behaviour

| Input | Result |
|---|---|
| no `theme.php` at repo root | returns `[]`, no edit, no stage |
| `theme.php` value already current | returns `[]` (no churn) |
| `theme.php` value differs | rewrites, returns `['theme.php']` |
| `theme.php` missing `'version' => '…'` line | throws (broken contract) |
| tag is `v1.3.1` / `V1.3.1` | strips leading `v`/`V`, stores `1.3.1` |
| tag is `v1.6.1-RC1` | stores `1.6.1-RC1` verbatim (RC suffix preserved) |

### Third-party "uploaded into existing install" workflow

Unaffected. Their own `theme.php` is the source of truth at runtime (admin reads it via `Theme::getInfo('version')`). No new runtime dependency on composer's package metadata.

## Test plan

- [x] `ThemeFileVersionWriterTest` — 8 new tests (single-quoted, double-quoted, V-prefix, RC-suffix, missing-file, already-current, missing-version-line, formatting preservation)
- [x] `LiveExecutorTest` — 2 new integration tests (theme repo stages `theme.php`; non-theme repo doesn't)
- [x] `./docker.sh test-all-coverage` — 9617 tests / 17773 assertions, OK
- [ ] Next release that includes a theme cut: confirm the release commit shows `composer.json + theme.php` in the diff and admin → Theme list reflects the new tag immediately after install

Refs: o3-shop/o3-shop#145

🤖 Generated with [Claude Code](https://claude.com/claude-code)