### PR TITLE
chore(#148): drop unused symfony/expression-language dep

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "symfony/dependency-injection": "^3.4.26",
         "symfony/config": "~3.3 || ~4.0",
         "symfony/yaml": "~3.4 || ~4.0",
-        "symfony/expression-language": "^4.4.30",
         "symfony/lock": "^3.4",
         "symfony/console": "^v3.4.15",
         "webmozart/path-util": "^2.3",


### PR DESCRIPTION
## Summary

`symfony/expression-language` has been on shop-ce's composer.json without any user. The audit during v1.6.1-RC1 prep (filed at o3-shop/o3-shop#148) found:

- 0 references in `source/`
- 0 references in `tests/`
- 0 `@=expression()` uses in any YAML config
- 0 transitive requirers

Re-verified here. One require line removed; no code changes.

Companion `o3-shop/composer.json` cleanup (4 more deps — `symfony/expression-language` + the obsolete `paragonie/random_compat`, `symfony/polyfill-php70`, `symfony/polyfill-php73` polyfills) ships as a separate PR per the issue's "Suggested PR scope".

## Verification

- `grep -r 'expression-language|ExpressionLanguage|@=expression' source/ tests/` — empty
- `./docker.sh test-all-coverage` — 9617 tests / 17773 assertions, OK, coverage unchanged at 90.86%

Refs: o3-shop/o3-shop#148

🤖 Generated with [Claude Code](https://claude.com/claude-code)