### PR TITLE
fix(#125): Config::reinitialize must clear in-memory params before re-init

### DIFF
--- a/source/Core/Config.php
+++ b/source/Core/Config.php
@@ -477,7 +477,22 @@ class Config extends \OxidEsales\Eshop\Core\Base
      */
     public function reinitialize()
     {
+        // Clear the in-memory caches before re-running init(). Otherwise a
+        // value loaded during the FIRST init() survives into the SECOND
+        // init() if no row with the same key happens to be returned by the
+        // second load — which is exactly the case when the active theme
+        // (or shop) changes between the two inits. Concretely: a setting
+        // seeded only for theme:o3-theme leaked into a subsequent
+        // initializeConfig() run that targeted theme:wave, because the
+        // second LIKE 'theme:wave%' filter didn't return that key and the
+        // first init's value was never cleared. See o3-shop/o3-shop#125.
+        //
+        // Callers that genuinely want a value to survive a reinitialize()
+        // need to re-apply it after the call — `reinitialize` is by name
+        // a full reset, not a merge.
         $this->_blInit = false;
+        $this->_aConfigParams = [];
+        $this->_aThemeConfigParams = [];
         $this->init();
     }
 

--- a/tests/Unit/Core/ConfigTest.php
+++ b/tests/Unit/Core/ConfigTest.php
@@ -2803,6 +2803,67 @@ class ConfigTest extends OxidTestCase
     }
 
     /**
+     * Regression for o3-shop/o3-shop#125: a value set in memory via
+     * setConfigParam() (no DB row backing it) must be cleared by
+     * reinitialize() — reinitialize is a full reset, not a merge with
+     * the prior in-memory state.
+     */
+    public function testReinitializeClearsInMemoryConfigParamsWithoutDbBacking()
+    {
+        $config = oxNew('oxConfig');
+        $config->init();
+        $config->setConfigParam('o3IssueOneTwoFiveLeakedKey', 'leaked-value');
+        $this->assertSame('leaked-value', $config->getConfigParam('o3IssueOneTwoFiveLeakedKey'));
+
+        $config->reinitialize();
+
+        $this->assertNull(
+            $config->getConfigParam('o3IssueOneTwoFiveLeakedKey'),
+            'reinitialize() must clear in-memory params; otherwise values from '
+            . 'an earlier init/setConfigParam survive a fresh init — see '
+            . 'o3-shop/o3-shop#125 (the testing-library bootstrap calls '
+            . 'initializeConfig() twice with different active themes).'
+        );
+    }
+
+    /**
+     * Regression for o3-shop/o3-shop#125: a value loaded from DB during
+     * the FIRST init() — whose DB row is then deleted before the SECOND
+     * init() — must NOT survive into the second init.
+     */
+    public function testReinitializeDropsValuesWhoseDbRowDisappeared()
+    {
+        $sShopId = $this->getConfig()->getShopId();
+        $db = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
+        // oxconfig.oxvarvalue was migrated to plaintext text in
+        // Version20230322213324 — no ENCODE() wrapper needed.
+        $insertSql = "INSERT INTO oxconfig (oxid, oxshopid, oxmodule, oxvarname, oxvartype, oxvarvalue)
+                      VALUES ('o3-125-leak-test', '$sShopId', '', 'o3IssueOneTwoFiveDbKey', 'str',
+                              'first-init-value')";
+        $db->execute($insertSql);
+
+        try {
+            $config = oxNew('oxConfig');
+            $config->init();
+            $this->assertSame('first-init-value', $config->getConfigParam('o3IssueOneTwoFiveDbKey'));
+
+            // Drop the row that backed the value, then reinitialize.
+            $db->execute("DELETE FROM oxconfig WHERE oxid = 'o3-125-leak-test'");
+            $config->reinitialize();
+
+            $this->assertNull(
+                $config->getConfigParam('o3IssueOneTwoFiveDbKey'),
+                'reinitialize() must drop values whose DB row no longer exists; '
+                . 'otherwise the testing-library theme-swap bootstrap (and any '
+                . 'production code that toggles config + reinits) reads stale '
+                . 'values — see o3-shop/o3-shop#125.'
+            );
+        } finally {
+            $db->execute("DELETE FROM oxconfig WHERE oxid = 'o3-125-leak-test'");
+        }
+    }
+
+    /**
      * Test method getRequestControllerId
      */
     public function testGetRequestControllerId()


### PR DESCRIPTION
## Summary

`Config::reinitialize()` only toggled `_blInit` and re-ran `init()` — it didn't clear `_aConfigParams` or `_aThemeConfigParams`. So any value loaded during the **first** `init()` survived into the **second** `init()` if no DB row with the same key happened to be returned by the second load.

The `initializeConfig()`-called-twice pattern in the testing-library bootstrap (with a different active theme between the two calls) is exactly the scenario this trips: an `iPasswordLength=10` seeded only for `theme:o3-theme` leaked into a subsequent `theme:wave` run because the second `LIKE 'theme:wave%'` filter didn't return that key. `InputValidator::getPasswordLength` then saw `'10'` instead of the system default of 6, breaking unrelated tests like `ForgotpwdTest::testUpdatePasswordProblemsWithPass`.

## Fix

```php
public function reinitialize()
{
    $this->_blInit = false;
    $this->_aConfigParams = [];          // ← new
    $this->_aThemeConfigParams = [];     // ← new
    $this->init();
}
```

`reinitialize` is named for a reason: full reset, not a merge with prior state.

## Risk audit

The naive concern is "callers who did `setConfigParam` and expected the value to survive a reinit". Actual breakdown of `setConfigParam + reinitialize` in the same file:

| File | Real risk? |
|---|---|
| `Config.php` itself | N/A (definitions) |
| `api-signature-snapshot.json` | N/A (BC inventory) |
| `tests/Unit/Core/ConfigTest.php` | One test file — full suite stays green post-fix |

Production `reinitialize()` callers (besides `Config.php`):

| File | Want stale params kept? |
|---|---|
| `ClassExtensionChainBridge.php` | No — module activation, wants fresh state |
| `ModuleActivationBridge.php` | No — same |

So the fix is the *correct* semantic for the existing production callers, not a regression for them.

## Tests added

Both in `tests/Unit/Core/ConfigTest.php`:

- **`testReinitializeClearsInMemoryConfigParamsWithoutDbBacking`** — `setConfigParam` then `reinitialize`, assert the value is null. Covers the simple in-memory leak.
- **`testReinitializeDropsValuesWhoseDbRowDisappeared`** — insert a real `oxconfig` row, init (loads it), delete the row, reinitialize, assert the value is null. Covers the actual #125 scenario.

The existing `testReinitialize` (value in DB during second init gets picked up) continues to pass — happy path unchanged.

## Verification

`./docker.sh test-all-coverage`: **9617 tests, 17787 assertions, OK**. Coverage 90.86% (unchanged). Nothing in the rest of the suite was depending on the bug.

## Follow-up (separate PR)

The `iPasswordLength` skip workaround in `source/Setup/Sql/initial_data.sql` (added in #118 to dampen this leak's blast radius) becomes unnecessary once this lands. Worth a small cleanup PR — flagging here, not bundling.

Refs: o3-shop/o3-shop#125, #118, #122, #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)