### PR TITLE
fix(#140): bump CI composer pin 2.2.21 → 2.2.28 (GHSA-f9f8-rm49-7jv2)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           echo "::group::Install Composer"
           php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-          php composer-setup.php --version=2.2.21
+          php composer-setup.php --version=2.2.28
           php -r "unlink('composer-setup.php');"
           sudo mv composer.phar /usr/local/bin/composer
           composer --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           echo "::group::Install Composer"
           php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-          php composer-setup.php --version=2.2.21
+          php composer-setup.php --version=2.2.28
           php -r "unlink('composer-setup.php');"
           sudo mv composer.phar /usr/local/bin/composer
           composer --version


### PR DESCRIPTION
## Summary

Bump the manual composer install in both CI workflows from `2.2.21` to `2.2.28` — the patched release of [GHSA-f9f8-rm49-7jv2](https://github.com/composer/composer/security/advisories/GHSA-f9f8-rm49-7jv2) (*GitHub Actions issued GITHUB_TOKEN disclosure in GitHub Actions logs*, High).

```diff
- php composer-setup.php --version=2.2.21
+ php composer-setup.php --version=2.2.28
```

Affected ranges per the advisory:

```
>= 2.3.0, < 2.9.8
>= 2.0.0, < 2.2.28
>= 1.0,   < 1.10.28
```

2.2.21 was inside the middle window. 2.2.28 is the patched 2.2.x LTS release, fully API-compatible — no behavioural change for `composer install --prefer-dist --no-progress`.

## Mechanism (per advisory)

1. Composer validates GitHub tokens with the regex `^[.A-Za-z0-9_]+$` — **no hyphen**.
2. Modern `ghs_<id>_<base64url-JWT>` tokens contain hyphens → regex fails.
3. On failure, Composer interpolates the literal token into an `UnexpectedValueException` printed to stderr. GitHub Actions' log masker can't always redact it (line-wrap / ANSI escapes), so it ends up in the public Actions log.

## Why bump even though current exposure is low

The exploit chain only fires when something registers `GITHUB_TOKEN` into Composer's `auth.json`. Our workflows don't do that:

| Check | Status |
|---|---|
| `shivammathur/setup-php@v2` with `tools: composer` | not set |
| `shivammathur/setup-php@v2` with `token:` | not set |
| `COMPOSER_AUTH` env var | not set |
| Explicit `composer config --auth` / `auth.json` write | none |
| Private / rate-limited composer repositories | none — all deps public on Packagist |
| `GITHUB_TOKEN` piped to a step that invokes composer | none |

So today the chain breaks before composer ever sees a token. Bump removes the foot-gun if a future change adds `tools: composer` / `token:` to `setup-php` without remembering this advisory.

## Files changed

- `.github/workflows/tests.yml` — line 95
- `.github/workflows/code-quality.yml` — line 95

## Verification

- [ ] CI green on this PR (composer install runs against new 2.2.28)
- [ ] `composer --version` in the CI logs reports `Composer version 2.2.28`

Closes #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)