### PR TITLE
B 1.6 claude and scripts

### DIFF
--- a/.claude/skills/push-pr/SKILL.md
+++ b/.claude/skills/push-pr/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: push-pr
+description: Stop docker, remove worktree, rename branch (strip worktree- prefix), push and open a GitHub PR with the issue title and a standard body.
+---
+
+# Push & PR
+
+> **Only run this skill when the user explicitly types `/push-pr`.** Never invoke it automatically.
+
+Use this skill when implementation is done and you are ready to push your worktree branch and open a pull request.
+
+## Steps
+
+### 1. Stop your Docker environment
+
+Run from inside the worktree:
+
+```bash
+./docker.sh stop
+```
+
+### 2. Collect branch and issue info
+
+```bash
+WORKTREE_PATH=$(git rev-parse --show-toplevel)
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+```
+
+Strip the `worktree-` prefix to get the target branch name:
+
+```bash
+# e.g. worktree-157-short-description → 157-short-description
+TARGET_BRANCH="${CURRENT_BRANCH#worktree-}"
+```
+
+Extract the issue number from the branch name (leading digits):
+
+```bash
+ISSUE_NUMBER=$(echo "$TARGET_BRANCH" | grep -oE '^[0-9]+')
+```
+
+### 3. Fetch the issue title from GitHub
+
+```bash
+ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --repo o3-shop/o3-shop --json title --jq '.title')
+```
+
+If the issue can't be fetched (e.g. no network), ask the user for the PR title instead.
+
+### 4. Rename the branch
+
+```bash
+git branch -m "$CURRENT_BRANCH" "$TARGET_BRANCH"
+```
+
+### 5. Push
+
+```bash
+git push -u origin "$TARGET_BRANCH"
+```
+
+### 6. Create the PR
+
+Fill in the Summary bullets from `git log --oneline origin/b-1.6..HEAD`. Fill in the test plan from what you actually ran.
+
+```bash
+gh pr create \
+  --title "$ISSUE_TITLE" \
+  --base b-1.6 \
+  --body "$(cat <<EOF
+Closes #${ISSUE_NUMBER}
+
+## Summary
+
+- <bullet summarising what changed>
+- <bullet summarising why>
+
+## Test plan
+
+- [ ] \`./docker.sh test --fast <relevant test file>\` — all tests pass
+- [ ] \`./docker.sh cs-fixer\` — no changes
+- [ ] Manual verification: <describe the scenario>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### 7. Remove the worktree
+
+Move to the main repo root, then remove:
+
+```bash
+MAIN_ROOT=$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)
+cd "$MAIN_ROOT"
+git worktree remove "$WORKTREE_PATH"
+git worktree prune
+```
+
+### 8. Report
+
+Print the PR URL and confirm the worktree is gone.

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ oxideshop.log
 # pre-archive path (now archived to openspec/changes/archive/...).
 # Tracked in archive; not in active openspec/changes.
 /openspec/changes/fix-internal-shim-call-sites/
+/.claude/worktrees/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Workflow skills are bundled in `.claude/skills/` and trigger automatically. See 
 | `requesting-code-review` | Before merging |
 | `receiving-code-review` | After getting review feedback |
 | `/finish` | Quality gate: cs-fixer + full tests + coverage |
+| `/push-pr` | Only if the user prompt to run it |
 
 ## Quick Start
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,12 @@ Adminer: http://localhost:8081 | Mailpit: http://localhost:8025
 
 Coverage reports land in `coverage/` (clover XML, HTML, JUnit XML).
 
+Always pull up your own docker environment with `./docker.sh start` before running any commands. The `test` commands assume the environment is up and will fail if it's not.
+
+If you want to run any `docker exec ...` command manually, pull up your own container and run it inside it. The naming is following: o3shop-{worktree-name}-1. For example, if your worktree is `feature/123-new-feature`, the container will be `o3shop-feature-123-new-feature-1`.
+
+Should your own docker environment not work, say it to me, I fix it for you.
+
 ## Project Structure
 
 ```

--- a/docker.sh
+++ b/docker.sh
@@ -190,6 +190,8 @@ run_php_cs_fixer() {
       echo -e "${RED}php-cs-fixer not found in shop container. Please install it!${NC}"
       exit 1
   fi
+
+  cd "$MY_DIR"
 }
 
 run_quarantine_tests() {
@@ -279,6 +281,8 @@ run_npm_audits() {
       fi
       echo -e "${GREEN}✓ npm audit clean for ${theme}.${NC}"
   done
+
+  cd "$MY_DIR"
 }
 
 run_full_test_with_cs_fixer() {
@@ -308,7 +312,10 @@ run_full_test_with_coverage() {
   echo "---------------------------"
   echo "Checking coverage threshold:"
   echo "---------------------------"
-  docker exec -i o3shop-app php /var/www/html/bin/check-coverage-threshold.php \
+
+  check_docker_compose
+
+  $DOCKER_COMPOSE exec shop php /var/www/html/bin/check-coverage-threshold.php \
     --clover /var/www/html/coverage/coverage.xml \
     --threshold "${COVERAGE_THRESHOLD:-90}"
 }

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -128,7 +128,7 @@ install_o3_theme() {
 # Function to install dependencies
 install_dependencies() {
     log "${YELLOW}Installing Composer dependencies...${NC}"
-    COMPOSER_ROOT_VERSION=dev-b-1.5 composer install --no-interaction --optimize-autoloader || handle_error "Composer installation failed"
+    COMPOSER_ROOT_VERSION=dev-b-1.6 composer install --no-interaction --optimize-autoloader || handle_error "Composer installation failed"
     log "${GREEN}Dependencies installed successfully${NC}"
 }
 


### PR DESCRIPTION
Summary

- Add /push-pr skill for streamlined branch management and PR creation from worktrees
- Expand CLAUDE.md with container naming convention so agents can target the right Docker instance
- Fix docker/entrypoint.sh branch reference (dev-b-1.5 → dev-b-1.6)
- Fix docker.sh test commands to run with the correct working directory context
- Gitignore Claude worktree directories

Test plan

- /push-pr skill loads and executes without errors
- ./docker.sh test --fast <file> runs correctly from any working directory
- Docker containers start cleanly on b-1.6 (entrypoint uses correct branch)
- .claude/worktrees/ is not tracked by git
