### PR TITLE
fix: ensure consistent log directory path handling in Config

### DIFF
--- a/source/Core/Config.php
+++ b/source/Core/Config.php
@@ -2207,12 +2207,13 @@ class Config extends \OxidEsales\Eshop\Core\Base
     {
         if ($this->sLogDir === null) {
             $shopDir = $this->getConfigParam('sShopDir');
-            $logDir = $shopDir . 'log/';
+            $this->sLogDir = 'log/';
+            $logDir = $shopDir . $this->sLogDir;
             if ($shopDir && strpos($shopDir, '<') === false) {
                 oxNew(\OxidEsales\EshopCommunity\Core\FileSystem\FileSystem::class)
                     ->createDirIfNotExists($logDir, $shopDir);
             }
-            return $this->sLogDir = $logDir;
+            return $logDir;
         }
 
         return $this->getConfigParam('sShopDir') . $this->sLogDir;

--- a/tests/Unit/Core/ConfigTest.php
+++ b/tests/Unit/Core/ConfigTest.php
@@ -182,10 +182,22 @@ class ConfigTest extends OxidTestCase
     public function testGetLogsDir()
     {
         $this->setConfigParam('sLogDir', 'some/log/dir/');
-        $this->assertEquals($this->getConfig()->getConfigParam('sShopDir') . 'some/log/dir/', $this->getConfig()->getLogsDir());
+        for ($i = 0; $i < 10; $i++) {
+            $this->assertEquals(
+                $this->getConfig()->getConfigParam('sShopDir') . 'some/log/dir/',
+                $this->getConfig()->getLogsDir(),
+                "Iteration $i: expected sShopDir + 'some/log/dir/' when sLogDir is set."
+            );
+        }
 
         $this->setConfigParam('sLogDir', null);
-        $this->assertEquals($this->getConfig()->getConfigParam('sShopDir') . 'log/', $this->getConfig()->getLogsDir());
+        for ($i = 0; $i < 10; $i++) {
+            $this->assertEquals(
+                $this->getConfig()->getConfigParam('sShopDir') . 'log/',
+                $this->getConfig()->getLogsDir(),
+                "Iteration $i: expected sShopDir + 'log/' when sLogDir is null."
+            );
+        }
     }
 
     /*


### PR DESCRIPTION
Closes #168

## Summary

- `Config::getLogsDir()` was storing the full absolute path (`sShopDir . 'log/'`) in `$this->sLogDir`, so a second call prepended `sShopDir` again, producing a doubled path like `/var/www/html/source/var/www/html/source/log/`.
- Fixed by storing only the relative segment (`'log/'`) in `$this->sLogDir` and prepending `sShopDir` at return time, matching the same pattern used for the custom `sLogDir` config param branch.

## Test plan

- [ ] `./docker.sh test --fast tests/Unit/Core/ConfigTest.php` — all tests pass (including `testGetLogsDir` which now runs both variants 10 times each)
- [ ] `./docker.sh cs-fixer` — no changes
- [ ] Manual: call `Config::getLogsDir()` twice in sequence and confirm the returned path is identical on both calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)