### PR TITLE
166 sourcebootstrapphp rewrite hard references exithandler breaks composer install for any 13x 16x upgrade with a non empty vendor

### DIFF
--- a/source/bootstrap.php
+++ b/source/bootstrap.php
@@ -239,11 +239,12 @@ $configFile = new \OxidEsales\Eshop\Core\ConfigFile(OX_BASE_PATH . 'config.inc.p
  * Registry::set() (see tests/Unit/ExitHandlerTestTrait.php) so exit() calls
  * in the code under test do not tear down the PHPUnit process.
  */
+if(class_exists(\OxidEsales\Eshop\Core\ExitHandlerInterface::class)) {
 \OxidEsales\Eshop\Core\Registry::set(
     \OxidEsales\Eshop\Core\ExitHandlerInterface::class,
     new \OxidEsales\Eshop\Core\ExitHandler()
 );
-
+}
 /**
  * Ensure tmp directory exists for shop functionality.
  * This directory is required for caching, Smarty compilation, and other temporary files.

--- a/source/bootstrap.php
+++ b/source/bootstrap.php
@@ -239,11 +239,11 @@ $configFile = new \OxidEsales\Eshop\Core\ConfigFile(OX_BASE_PATH . 'config.inc.p
  * Registry::set() (see tests/Unit/ExitHandlerTestTrait.php) so exit() calls
  * in the code under test do not tear down the PHPUnit process.
  */
-if(class_exists(\OxidEsales\Eshop\Core\ExitHandlerInterface::class)) {
-\OxidEsales\Eshop\Core\Registry::set(
-    \OxidEsales\Eshop\Core\ExitHandlerInterface::class,
-    new \OxidEsales\Eshop\Core\ExitHandler()
-);
+if (class_exists(\OxidEsales\Eshop\Core\ExitHandlerInterface::class)) {
+    \OxidEsales\Eshop\Core\Registry::set(
+        \OxidEsales\Eshop\Core\ExitHandlerInterface::class,
+        new \OxidEsales\Eshop\Core\ExitHandler()
+    );
 }
 /**
  * Ensure tmp directory exists for shop functionality.


### PR DESCRIPTION
Summary                                                                                     
                                                                                              
  source/bootstrap.php hard-referenced ExitHandlerInterface and ExitHandler unconditionally.  
  During a 1.3.x → 1.6.x upgrade with a non-empty vendor/ directory, Composer's bootstrap     
  scripts may load bootstrap.php before those classes are registered in the autoloader,       
  causing a fatal class-not-found error that aborts composer install.                         
                                                                                              
  - Wrap the ExitHandlerInterface registration in a class_exists() guard so bootstrap.php is  
  safe to load even before the full class tree is available                                   
                                                                                              
  Changes                                                                                     
                                                                                              
  - source/bootstrap.php — guard Registry::set(ExitHandlerInterface::class, ...) behind       
  class_exists(\OxidEsales\Eshop\Core\ExitHandlerInterface::class) to prevent a fatal error   
  when the class is not yet autoloadable                                                      
                                                                                              
  Test plan                                                                                   
                                                                                              
  - [ ] Run composer install on a fresh 1.6.x checkout — no regression                        
  - [ ] Simulate upgrade scenario: start with non-empty 1.3.x vendor/, run composer install   
  for 1.6.x — no fatal error from bootstrap.php                                               
  - [ ] Full unit test suite passes (./docker.sh test)                                        
                                                                                              
  Fixes #166                                           