### PR TITLE
Adjust bin/release for the metapackage fold-out

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -24,3 +24,4 @@ Shared memory for all Claude agents working in this repository. Read this first,
 - [!] [Theme repos are external](architecture_theme-repos.md) — wave + o3-theme live in separate GitHub repos; their dirs in shop-ce are gitignored snapshots
 - [!] [o3-theme migration](project_o3-theme-migration.md) — wave → o3-theme cutover before 2026-05-01; keep new storefront templates portable
 - [o3-theme npm audit](project_o3-theme-dep-audit.md) — pre-existing brace-expansion vulnerability blocks test-all-coverage; use test --fast for PHP-only changes
+- [bin/release intermediate-node re-tag gap](release-tooling-intermediate-node-retag-gap.md) — resolver "reuses" an intermediate fat node (the metapackage) while bumping its child pin → orphaned edit; force a re-tag during the fold-out cut (#169)

--- a/.claude/memory/release-tooling-intermediate-node-retag-gap.md
+++ b/.claude/memory/release-tooling-intermediate-node-retag-gap.md
@@ -1,0 +1,40 @@
+---
+name: release-tooling-intermediate-node-retag-gap
+description: bin/release reuses an intermediate compilation node's latest tag even when it will bump that node's child pin → orphaned edit
+type: reference
+---
+
+# bin/release: intermediate "fat" nodes can get an orphaned constraint edit
+
+Discovered during the metapackage fold-OUT (issue o3-shop/o3-shop#169), where
+`o3-shop/shop-metapackage-ce` became a first-class intermediate node again
+(graph: `o3-shop → shop-metapackage-ce → shop-ce → leaves`).
+
+`CandidateVersionResolver` decides reuse-vs-cut per package from the
+**pre-edit** state: if a package's latest tag is newer than its `from_pin`
+and stability-compatible, it returns `CASE_USABLE_TAG` ("reuse-latest-tag")
+— *without* considering that a downstream constraint edit will change that
+package's own `composer.json`.
+
+Concrete symptom in the `--from v1.6.0 --to v1.6.1-RC8` dry-run:
+- `shop-ce` → reuse `v1.6.1-RC6`.
+- `shop-metapackage-ce` → reuse `v1.6.1-RC5`, **but** the plan also emits a
+  constraint edit `metapackage composer.json: shop-ce v1.6.1-RC5 → v1.6.1-RC6`.
+- That edit would commit to the metapackage's `b-1.6` but **no new metapackage
+  tag is cut**, so the published `RC5` still pins shop-ce `RC5`. `o3-shop`
+  keeps pinning metapackage `RC5`. The shop-ce bump is **orphaned** — never
+  reaches an installable artifact.
+
+In the folded-IN world this never bit because `o3-shop` (the only "fat" node)
+is the root and is skipped by the candidate loop (`ReleasePlanner` line ~111),
+so it was never "reused". An intermediate fat node (the metapackage) exposes
+the gap.
+
+**Implication for a clean cut:** force the metapackage (and decide shop-ce /
+the o3-shop tag) explicitly — e.g. `--bump shop-metapackage-ce=<version>` —
+or enhance the resolver so a package with a pending constraint edit is treated
+as `NEEDS_NEW_TAG` rather than reused. Also open: `o3-shop/o3-shop` is NOT a
+candidate (skipped), so how the thin o3-shop project itself gets its release
+tag needs confirming in `LiveExecutor`.
+
+See also [[project_metapackage-fold-out]].

--- a/openspec/changes/2026-05-27-fold-out-metapackage/.openspec.yaml
+++ b/openspec/changes/2026-05-27-fold-out-metapackage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-27

--- a/openspec/changes/2026-05-27-fold-out-metapackage/design.md
+++ b/openspec/changes/2026-05-27-fold-out-metapackage/design.md
@@ -1,0 +1,58 @@
+## Context
+
+See `proposal.md`. The fold-in was applied to `o3-shop` (fat + `replace`)
+but the metapackage was never archived and got re-added as an o3-shop
+dependency, producing a double-`replace` that breaks `create-project`. The
+`bin/release` tooling was written to assume the fold-in completed.
+
+## Decisions
+
+### Metapackage is the compilation; o3-shop is thin (revert to ≤ v1.6.0)
+
+Two topologies fix the double-replace: (A) o3-shop is the sole compilation
+and the metapackage is retired; (B) the metapackage is the sole
+compilation and o3-shop is thin. (A) breaks in-place upgrades for deployed
+installs that require the metapackage by name, so we choose **(B)** —
+which is also exactly what shipped through v1.6.0, so it is a revert, not
+a new design. One `replace` owner (the metapackage) serves both new
+`create-project` installs and existing-install `composer update`.
+
+### Adjust bin/release rather than revert it
+
+`bin/release` was introduced together with the fold-in (v1.6.1-RC1), so a
+git-revert would delete the tool. Instead we remove only the fold-in
+assumptions. The change is almost entirely deletion:
+
+- `FromSnapshotBuilder` no longer `unset`s `shop-metapackage-ce` from
+  `from_pin[]` and no longer runs the synchronous "pre-fold-in
+  indirection" pre-harvest. The metapackage is recursed into like any
+  other node, so it lands in `from_pin[]` (a release candidate) and its
+  children (shop-ce, themes, modules) are still harvested.
+- First-write-wins ordering — the metapackage's exact `shop-ce` pin must
+  beat testing-library's loose `^1.2` — is preserved **without** the
+  pre-harvest because root `require` is merged before `require-dev` and
+  the harvest queue is FIFO: the metapackage (in root `require`) is
+  dequeued before testing-library (in root `require-dev`).
+- `FromSnapshot` drops the `usedPreFoldInIndirection` /
+  `preFoldInMetapackageVersion` metadata; `DryRunPrinter` drops the
+  indirection log line.
+
+The downstream machinery is unchanged: `DepTreeWalker` already recurses
+into any `o3-shop/*` dep, and the pin-location → `ConstraintUpdater`
+cascade already handles both directions (shop-ce re-tag → metapackage's
+pin bumped; metapackage re-tag → o3-shop's pin bumped).
+
+### Tooling handles both --from shapes
+
+The recursion handles a thin `--from` (o3-shop requires the metapackage)
+and a fold-in-era fat `--from` (o3-shop pins components directly) with no
+branching. For the first folded-out cut, pass a pre-fold-in v1.6.0-era tag
+as `--from` for the cleanest diff; do not pass a broken RC5+ tag.
+
+## Risks
+
+- Existing `v1.6.1-RC*` tags are broken; consumers pinning them still
+  fail. Mitigation: delete the broken tags and re-cut — `create-project`
+  takes the highest tag.
+- The metapackage's component pins must be refreshed on `b-1.6` before the
+  cut so the compilation is internally consistent.

--- a/openspec/changes/2026-05-27-fold-out-metapackage/proposal.md
+++ b/openspec/changes/2026-05-27-fold-out-metapackage/proposal.md
@@ -1,0 +1,84 @@
+## Why
+
+`composer create-project o3-shop/o3-shop` is broken: the project package
+and `o3-shop/shop-metapackage-ce` both `replace
+oxid-esales/oxideshop-metapackage-ce`, so Composer refuses to install
+("cannot coexist"). This is the result of a half-finished metapackage
+fold-in (archived change `automate-release-procedure`, issue
+o3-shop/o3-shop#140): the fold-in moved the metapackage's dependency list
+and `replace` clause into `o3-shop/o3-shop` (tags v1.6.1-RC1..RC3, which
+installed), but v1.6.1-RC5 then re-added `require:
+o3-shop/shop-metapackage-ce` on top of o3-shop's own `replace`, creating
+the double-replace.
+
+The fold-in's premise — "the metapackage has zero consumers" — measured
+Packagist + code-search dependents but missed **deployed installs**: every
+shop created from `o3-shop/o3-shop` ≤ v1.6.0 has a root `composer.json`
+that `require`s `o3-shop/shop-metapackage-ce` by name. For those installs
+to `composer update` forward, the metapackage must keep existing and
+advancing. Archiving it (as the fold-in intended, issue #149) breaks
+in-place upgrades.
+
+## What Changes
+
+Reverse the fold-in — restore the architecture that shipped in every
+release ≤ v1.6.0:
+
+- `o3-shop/shop-metapackage-ce` is the single **compilation**: it owns the
+  full pinned dependency list and the `replace:
+  oxid-esales/oxideshop-metapackage-ce` clause. It is NOT archived.
+- `o3-shop/o3-shop` is a **thin project**: `require:
+  { o3-shop/shop-metapackage-ce: <ver> }` only — no `replace`, no inlined
+  deps.
+- `bin/release` is **adjusted** (not deleted — it shipped with the
+  fold-in) so `o3-shop/shop-metapackage-ce` is a permanent, first-class
+  release node again. The fold-in special-casing in `FromSnapshotBuilder`
+  (dropping the metapackage from `from_pin[]`; the "pre-fold-in
+  indirection" one-time path) is removed; the metapackage is recursed into
+  like any other node.
+- The broken/abandoned `v1.6.1-RC*` tags are deleted and one clean
+  coordinated RC is re-cut.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `release-graph-derivation`: the metapackage is a normal recursed node
+  and a first-class release candidate; the pre-fold-in indirection
+  requirement is removed; tier ordering reflects
+  o3-shop → metapackage → shop-ce.
+- `release-orchestration`: the tier-by-tier walk is now four tiers
+  (leaves → shop-ce → metapackage → o3-shop); the `.next-bump`
+  dist-exclude requirement is re-homed here.
+
+### Removed Capabilities
+
+- `metapackage-fold-in`: the whole capability is reversed.
+
+### New Capabilities
+
+- `metapackage-compilation`: documents the folded-out steady state — the
+  metapackage owns the compilation + `replace`; o3-shop is thin; the
+  metapackage stays published for upgrade compatibility.
+
+## Impact
+
+- **shop-ce**: `bin/release` tooling simplified (done on branch
+  `169-fold-out-metapackage`); unit tests inverted/added; OpenSpec specs
+  updated.
+- **o3-shop repo** (`b-1.6`): `composer.json` slimmed to require only the
+  metapackage; `replace` and inlined deps removed.
+- **shop-metapackage-ce repo** (`b-1.6`): stays the fat compilation +
+  `replace`; component pins refreshed; NOT archived.
+- **Tags/releases**: broken `o3-shop` v1.6.1-RC* deleted; clean
+  coordinated RC re-cut via the adjusted `bin/release`.
+- **Issue #149**: rerouted from "archive shop-metapackage-ce" to a phased
+  long-term-removal procedure.
+
+## Long-term
+
+The metapackage's only remaining load-bearing role is in-place upgrade
+compatibility. Removing it for good (the eventual goal) requires migrating
+that path off it — at a major-version boundary or via a documented
+root-`require` swap, with a thin-bridge support window — not archival.
+Tracked in #149.

--- a/openspec/changes/2026-05-27-fold-out-metapackage/specs/metapackage-compilation/spec.md
+++ b/openspec/changes/2026-05-27-fold-out-metapackage/specs/metapackage-compilation/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: shop-metapackage-ce is the single compilation
+
+`o3-shop/shop-metapackage-ce` SHALL own the full pinned dependency list
+for the shop compilation — the exact-version set of framework packages
+(Symfony, Doctrine, Composer, Monolog, …) and o3-shop component packages
+(shop-ce, themes, demodata, bundled modules) — that constitutes a tested
+release.
+
+#### Scenario: Metapackage pins the compilation
+
+- **WHEN** a release is cut
+- **THEN** `shop-metapackage-ce/composer.json` `require` contains the
+  exact-pinned framework deps and the o3-shop component packages for that
+  release
+
+### Requirement: o3-shop is a thin project requiring the metapackage
+
+`o3-shop/o3-shop` SHALL be a `type: project` whose `require` lists only
+`o3-shop/shop-metapackage-ce` (plus dev-tooling in `require-dev`). It SHALL
+NOT inline the compilation dependency list and SHALL NOT declare a
+`replace` clause.
+
+#### Scenario: create-project installs cleanly
+
+- **WHEN** a user runs `composer create-project o3-shop/o3-shop`
+- **THEN** the install resolves: the metapackage is the only package that
+  `replace`s `oxid-esales/oxideshop-metapackage-ce`, so there is no
+  "cannot coexist" conflict
+
+### Requirement: Metapackage owns the OXID-lineage replace clause
+
+`shop-metapackage-ce/composer.json` SHALL declare
+`replace: oxid-esales/oxideshop-metapackage-ce` and SHALL be the only
+package in the install graph that does so.
+
+#### Scenario: No double-replace
+
+- **WHEN** `o3-shop/o3-shop` is installed (which pulls the metapackage)
+- **THEN** exactly one package replaces
+  `oxid-esales/oxideshop-metapackage-ce` (the metapackage), and Composer
+  does not reject the install
+
+### Requirement: Metapackage stays published for upgrade compatibility
+
+`o3-shop/shop-metapackage-ce` SHALL remain a published, version-advancing
+package (NOT archived) for as long as in-place `composer update` from
+installs that require it by name is supported. Deployed installs created
+from `o3-shop/o3-shop` ≤ v1.6.0 have a root `composer.json` that requires
+the metapackage; archiving it would freeze those installs.
+
+#### Scenario: Existing install updates forward
+
+- **WHEN** a project root requires `o3-shop/shop-metapackage-ce` and the
+  constraint is raised to a newer release line
+- **THEN** `composer update` resolves to the newer metapackage tag and
+  pulls the corresponding compilation
+
+### Requirement: Compilation excludes deprecated packages, keeps bundled modules
+
+The metapackage's `require` list SHALL NOT include `flow-theme`,
+`vortex-theme`, the o3-shop fork of `paypal-module`, or
+`tests-deprecated-ce`-style entries. It SHALL include the bundled modules
+`o3-shop/gdpr-optin-module`, `o3-shop/usercentrics`, and
+`o3-shop/tinymce-editor`.
+
+#### Scenario: Deprecated theme absent
+
+- **WHEN** a release is cut
+- **THEN** `shop-metapackage-ce/composer.json` does not require
+  `o3-shop/flow-theme`
+
+#### Scenario: Bundled module present
+
+- **WHEN** a release is cut
+- **THEN** `shop-metapackage-ce/composer.json` requires
+  `o3-shop/gdpr-optin-module`

--- a/openspec/changes/2026-05-27-fold-out-metapackage/specs/metapackage-fold-in/spec.md
+++ b/openspec/changes/2026-05-27-fold-out-metapackage/specs/metapackage-fold-in/spec.md
@@ -1,0 +1,35 @@
+## REMOVED Requirements
+
+### Requirement: shop-metapackage-ce require list moves into o3-shop
+
+**Reason**: The fold-in is reversed. The require list stays in
+`shop-metapackage-ce`; `o3-shop` becomes a thin project requiring it. See
+the new `metapackage-compilation` capability.
+
+### Requirement: Deprecated and removed entries dropped during fold-in
+
+**Reason**: Reversed. The dropped/kept-entries decision now applies to the
+metapackage's own require list and is captured by
+`metapackage-compilation`.
+
+### Requirement: Bundled modules preserved during fold-in
+
+**Reason**: Reversed. Captured by `metapackage-compilation` against the
+metapackage's require list.
+
+### Requirement: Replace clause moves to o3-shop
+
+**Reason**: Reversed. The `replace: oxid-esales/oxideshop-metapackage-ce`
+clause stays on `shop-metapackage-ce` (the single replace owner); o3-shop
+has no `replace`.
+
+### Requirement: shop-metapackage-ce repo archived after fold-in
+
+**Reason**: Reversed. The metapackage stays published and advancing so
+existing installs can `composer update` forward. Long-term removal is
+rerouted to a phased procedure (issue #149), not archival.
+
+### Requirement: Release-eligible repos exclude .next-bump from dist archives
+
+**Reason**: Re-homed to `release-orchestration` (it is independent of the
+fold direction).

--- a/openspec/changes/2026-05-27-fold-out-metapackage/specs/release-graph-derivation/spec.md
+++ b/openspec/changes/2026-05-27-fold-out-metapackage/specs/release-graph-derivation/spec.md
@@ -1,0 +1,58 @@
+## MODIFIED Requirements
+
+### Requirement: Build from_pin[] from --from snapshot
+
+The CLI SHALL read `o3-shop/composer.json` at the `--from` tag and
+recursively build a map `from_pin[repo]` of every `o3-shop/*` package to
+its pinned version, walking through each package's `require`/`require-dev`
+for further `o3-shop/*` deps. `o3-shop/shop-metapackage-ce` is an ordinary
+node in this walk: when o3-shop requires it, it appears in `from_pin[]` as
+a release candidate AND is recursed into so the packages it pins (shop-ce,
+themes, bundled modules, framework deps) are harvested too. This map SHALL
+be the per-repo anchor for the "did anything change?" check and the
+starting point for cross-repo release notes.
+
+#### Scenario: Thin o3-shop requires the metapackage
+
+- **WHEN** `o3-shop/composer.json` at `--from` requires only
+  `o3-shop/shop-metapackage-ce`, which in turn pins shop-ce, themes,
+  demodata, and bundled modules
+- **THEN** `from_pin[]` contains `shop-metapackage-ce` mapped to its
+  pinned version AND an entry for each package the metapackage pins
+
+#### Scenario: Fold-in-era o3-shop pins components directly
+
+- **WHEN** `o3-shop/composer.json` at `--from` pins shop-ce, themes,
+  demodata, and bundled modules directly (a fold-in-era tag with no
+  metapackage require)
+- **THEN** `from_pin[]` contains an entry for each pinned `o3-shop/*`
+  package and no `shop-metapackage-ce` entry
+
+### Requirement: Topological tier ordering
+
+The CLI SHALL topologically sort the dep graph and assign tiers based on
+depth (leaves at tier 0, `o3-shop` at the highest tier). Tier numbers are
+not declared anywhere; they emerge from the sort.
+
+#### Scenario: Leaf is tier 0
+
+- **WHEN** `smarty` has no `o3-shop/*` deps
+- **THEN** `smarty` is in tier 0
+
+#### Scenario: o3-shop is the highest tier
+
+- **WHEN** `o3-shop` requires `shop-metapackage-ce`, which requires
+  `shop-ce` (tier 1) and tier-0 packages
+- **THEN** `shop-metapackage-ce` is one tier below `o3-shop`, and
+  `o3-shop` is at the highest tier
+
+## REMOVED Requirements
+
+### Requirement: Pre-fold-in `--from` triggers metapackage indirection
+
+**Reason**: The fold-in is being reversed. `o3-shop/shop-metapackage-ce`
+is now a permanent first-class node in the graph rather than a one-time
+indirection anchor, so a `--from` that requires the metapackage is the
+normal case (handled by the standard recursive harvest), not a
+transitional special case. The metapackage is no longer dropped from
+`from_pin[]`.

--- a/openspec/changes/2026-05-27-fold-out-metapackage/specs/release-orchestration/spec.md
+++ b/openspec/changes/2026-05-27-fold-out-metapackage/specs/release-orchestration/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Tier-by-tier walk in dependency order
+
+The CLI SHALL process release-eligible repos in topological order: tier 0
+(leaves) first, then each successive tier, ending at `o3-shop` (the
+highest tier). With `o3-shop/shop-metapackage-ce` as the compilation, the
+order is leaves → `shop-ce` → `shop-metapackage-ce` → `o3-shop`. Within a
+tier, order is unspecified. The CLI SHALL not begin tier N+1 work until
+every tier-N repo has completed its release flow.
+
+#### Scenario: Linear chain
+
+- **WHEN** the dep graph is
+  `o3-shop → shop-metapackage-ce → shop-ce → smarty`
+- **THEN** `smarty` completes (or skips) before `shop-ce`, `shop-ce`
+  before `shop-metapackage-ce`, and `shop-metapackage-ce` before `o3-shop`
+
+#### Scenario: Diamond dependency
+
+- **WHEN** the dep graph has `shop-ce` and `testing-library` both
+  requiring `shop-facts`
+- **THEN** `shop-facts` completes before either `shop-ce` or
+  `testing-library` starts
+
+## ADDED Requirements
+
+### Requirement: Release-eligible repos exclude .next-bump from dist archives
+
+Every release-eligible repo's `composer.json` SHALL include
+`"archive": { "exclude": [".next-bump"] }` (additive to any existing
+archive config). This SHALL prevent the `.next-bump` marker from being
+included in dist archives, including dev/branch installs.
+
+#### Scenario: shop-ce composer.json carries the exclude
+
+- **WHEN** the change ships
+- **THEN** `shop-ce/composer.json` has an `archive` block whose `exclude`
+  array contains `.next-bump`
+
+#### Scenario: Dev install does not include .next-bump
+
+- **WHEN** a consumer runs `composer require o3-shop/shop-ce:dev-b-1.6`
+  while `shop-ce`'s release branch contains a `.next-bump` file
+- **THEN** the resulting `vendor/o3-shop/shop-ce` directory does not
+  contain `.next-bump`

--- a/openspec/changes/2026-05-27-fold-out-metapackage/tasks.md
+++ b/openspec/changes/2026-05-27-fold-out-metapackage/tasks.md
@@ -1,0 +1,49 @@
+# Tasks
+
+## 1. Adjust bin/release (shop-ce) — DONE on branch 169-fold-out-metapackage
+
+- [x] 1.1 Remove the metapackage special-casing in `FromSnapshotBuilder`
+      (drop the `unset`, the pre-fold-in pre-harvest, the "never
+      re-introduce" guards, the `METAPACKAGE_PACKAGE` const; rewrite the
+      docblock).
+- [x] 1.2 Reduce `FromSnapshot` to a single-arg constructor; drop the
+      `usedPreFoldInIndirection` / `preFoldInMetapackageVersion` metadata.
+- [x] 1.3 Remove the pre-fold-in log line from `DryRunPrinter`; reword the
+      `ReleaseNotesAggregator` comment.
+- [x] 1.4 Invert the "metapackage dropped" unit-test assertions to
+      "metapackage is a first-class pin"; fix all `new FromSnapshot()`
+      call sites.
+- [x] 1.5 Add a first-write-wins regression test (replacing the deleted
+      pre-harvest) and a folded-out cascade test
+      (o3-shop → metapackage → shop-ce constraint bumps).
+- [x] 1.6 `./docker.sh test --fast tests/Unit/Internal/ReleaseTooling/`
+      green (287 tests); cs-fixer clean on touched files.
+
+## 2. OpenSpec
+
+- [x] 2.1 Modify `release-graph-derivation` and `release-orchestration`;
+      remove `metapackage-fold-in`; add `metapackage-compilation`.
+
+## 3. composer.json (sibling clones, branch b-1.6)
+
+- [ ] 3.1 o3-shop: slim to `require: { o3-shop/shop-metapackage-ce }`;
+      remove the `replace` block and the inlined deps.
+- [ ] 3.2 shop-metapackage-ce: confirm fat compilation + `replace`;
+      refresh component pins (shop-ce, themes, bundled modules).
+
+## 4. Re-cut a clean coordinated RC
+
+- [ ] 4.1 `bin/release --from <pre-fold-in v1.6.0-era tag> --to <clean RC>
+      --dry-run`; review (metapackage is a first-class candidate, no
+      indirection line).
+- [ ] 4.2 Live cut: o3-shop@vX requires metapackage@vX.
+- [ ] 4.3 Delete the broken/abandoned o3-shop `v1.6.1-RC*` tags + draft
+      releases and the stray metapackage `v1.6.1-RC5` tag.
+- [ ] 4.4 Verify `composer create-project o3-shop/o3-shop:<new RC>`
+      resolves, and `composer update` from a metapackage-rooted install
+      resolves forward.
+
+## 5. Issue #149
+
+- [ ] 5.1 Reroute from "archive shop-metapackage-ce" to the phased
+      long-term-removal procedure; correct the "zero consumers" premise.

--- a/source/Internal/ReleaseTooling/Notes/ReleaseNotesAggregator.php
+++ b/source/Internal/ReleaseTooling/Notes/ReleaseNotesAggregator.php
@@ -90,9 +90,10 @@ class ReleaseNotesAggregator
             // Normalize from_pin to a tag name before passing to the
             // provider. GitHub's generate-notes API rejects caret/tilde
             // constraints (`^v1.0.0`) with HTTP 400; we normalize to
-            // the canonical o3-shop tag form (`v1.0.0`) so the call
-            // works for the common pre-fold-in case where from_pin
-            // carries constraint strings instead of exact tags.
+            // the canonical o3-shop tag form (`v1.0.0`). Exact pins
+            // (shop-ce, the metapackage) pass through unchanged; only
+            // caret/tilde pins (themes, dev-tooling) are rewritten to
+            // their floor tag.
             $previousTag = TagFromConstraint::resolve($state->fromPin())
                 ?? $state->fromPin();
             ($this->progress)(sprintf(

--- a/source/Internal/ReleaseTooling/Planning/CandidatePlan.php
+++ b/source/Internal/ReleaseTooling/Planning/CandidatePlan.php
@@ -84,6 +84,11 @@ final class CandidatePlan
 
     public function caseLabel(): string
     {
+        if ($this->tagCut !== null && $this->resolution->case() !== VersionResolution::CASE_NEEDS_NEW_TAG) {
+            // The resolver would have reused a tag, but a downstream
+            // constraint edit forces a fresh cut to capture the change.
+            return 'cut-new-tag (downstream changed)';
+        }
         switch ($this->resolution->case()) {
             case VersionResolution::CASE_UNCHANGED:
                 return 'unchanged';

--- a/source/Internal/ReleaseTooling/Planning/DryRunPrinter.php
+++ b/source/Internal/ReleaseTooling/Planning/DryRunPrinter.php
@@ -39,14 +39,6 @@ class DryRunPrinter
             $plan->toTag()
         ));
 
-        $snapshot = $plan->fromSnapshot();
-        if ($snapshot->usedPreFoldInIndirection()) {
-            $output->writeln(sprintf(
-                '<comment>Step 1: pre-fold-in --from detected; '
-                . 'harvested tier-0 pins from o3-shop/shop-metapackage-ce@%s</comment>',
-                (string) $snapshot->preFoldInMetapackageVersion()
-            ));
-        }
         $output->writeln('');
 
         $this->printBackEdges($plan, $output);

--- a/source/Internal/ReleaseTooling/Planning/ReleasePlanner.php
+++ b/source/Internal/ReleaseTooling/Planning/ReleasePlanner.php
@@ -25,6 +25,7 @@ namespace OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Constraint\ConstraintUpdater;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\PreFlightRunner;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Graph\DepTreeWalker;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Graph\WalkResult;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Notes\CandidateState;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Notes\ReleaseNotesAggregator;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Snapshot\FromSnapshotBuilder;
@@ -105,8 +106,20 @@ class ReleasePlanner
             'Steps 3 + 4: resolving versions for %d candidates',
             count($walkResult->topologicalOrder()) - 1
         ));
-        // Steps 3 + 4 — per candidate (skip the o3-shop project root; it is the orchestrator, not a candidate)
+        // Steps 3 + 4 — per candidate (skip the o3-shop project root; it is the orchestrator, not a candidate).
+        //
+        // A package cuts a new tag when the version resolver asks for one OR
+        // when one of its already-resolved children changed in a way that
+        // edits this package's own composer.json (a "downstream edit"). The
+        // walk is leaves-first, so a child is always resolved before its
+        // parent and the force-decision cascades up the tiers: bumping
+        // shop-ce forces the metapackage to re-tag, which in turn forces its
+        // dependents. Without this, an intermediate node (e.g. the
+        // metapackage) would "reuse" its latest tag while a constraint edit
+        // to its composer.json went un-tagged (orphaned).
         $candidates = [];
+        $chosen = [];   // package => chosen version (children resolved before parents)
+        $changed = [];  // package => did the chosen version differ from from_pin?
         foreach ($walkResult->topologicalOrder() as $package) {
             if ($package === self::O3_SHOP_PROJECT) {
                 continue;
@@ -124,7 +137,14 @@ class ReleasePlanner
             $packageRef = ($this->branchResolver)($package);
             $resolution = $this->versionResolver->resolve($package, $fromPin, $toTag, $packageRef);
 
-            if ($resolution->needsNewTag()) {
+            $forcedByDownstreamEdit = $this->willReceiveDownstreamEdit(
+                $package,
+                $walkResult,
+                $chosen,
+                $changed
+            );
+
+            if ($resolution->needsNewTag() || $forcedByDownstreamEdit) {
                 $tagCut = $this->tagCutter->cut(
                     $package,
                     $resolution->latestTag(),
@@ -133,11 +153,14 @@ class ReleasePlanner
                     $packageRef
                 );
                 $chosenVersion = $tagCut->newTag();
-                $candidates[] = new CandidatePlan($package, $fromPin, $chosenVersion, $resolution, $tagCut);
+                $candidate = new CandidatePlan($package, $fromPin, $chosenVersion, $resolution, $tagCut);
             } else {
                 $chosenVersion = (string) $resolution->chosenVersion();
-                $candidates[] = new CandidatePlan($package, $fromPin, $chosenVersion, $resolution, null);
+                $candidate = new CandidatePlan($package, $fromPin, $chosenVersion, $resolution, null);
             }
+            $candidates[] = $candidate;
+            $chosen[$package] = $chosenVersion;
+            $changed[$package] = $candidate->isChanged();
         }
 
         ($this->progress)('Step 5: checking constraint updates per pin location');
@@ -219,6 +242,42 @@ class ReleasePlanner
             $preFlightReports,
             $walkResult->backEdges()
         );
+    }
+
+    /**
+     * True when an already-resolved child of $package changed in a way that
+     * rewrites $package's own composer.json — i.e. Step 5 will emit a
+     * constraint edit whose parent is $package. Such a package MUST cut a
+     * new tag (its content changes); reusing the old tag would orphan the
+     * edit.
+     *
+     * Mirrors the Step 5 edit computation exactly, so "forced here" iff
+     * "edited there". Relies on the leaves-first order: every child is
+     * resolved (and present in $chosen/$changed) before its parent.
+     *
+     * @param array<string,string> $chosen  package => chosen version
+     * @param array<string,bool>   $changed package => changed flag
+     */
+    private function willReceiveDownstreamEdit(
+        string $package,
+        WalkResult $walkResult,
+        array $chosen,
+        array $changed
+    ): bool {
+        foreach ($walkResult->dependencies($package) as $child) {
+            if (empty($changed[$child]) || !isset($chosen[$child])) {
+                continue;
+            }
+            foreach ($walkResult->pinLocations($child) as $pin) {
+                if ($pin->parentPackage() !== $package) {
+                    continue;
+                }
+                if ($this->constraintUpdater->update($pin->constraint(), $chosen[$child])->changed()) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private function slug(string $package): string

--- a/source/Internal/ReleaseTooling/Snapshot/FromSnapshot.php
+++ b/source/Internal/ReleaseTooling/Snapshot/FromSnapshot.php
@@ -23,47 +23,28 @@ declare(strict_types=1);
 namespace OxidEsales\EshopCommunity\Internal\ReleaseTooling\Snapshot;
 
 /**
- * Result of Algorithm Step 1 — the per-tier-0 anchor map for a given
- * `--from` tag, plus metadata about whether pre-fold-in metapackage
- * indirection had to be applied to assemble it.
+ * Result of Algorithm Step 1 — the anchor map for a given `--from`
+ * tag. The map is recursive across the o3-shop subset of the
+ * dependency tree, so it includes `shop-metapackage-ce` (a first-class
+ * release candidate) alongside the packages it pins.
  */
 final class FromSnapshot
 {
     /** @var array<string,string> repo-slug => version constraint as recorded in composer.json */
     private array $fromPin;
 
-    private bool $usedPreFoldInIndirection;
-
-    private ?string $preFoldInMetapackageVersion;
-
     /**
      * @param array<string,string> $fromPin
      */
-    public function __construct(
-        array $fromPin,
-        bool $usedPreFoldInIndirection = false,
-        ?string $preFoldInMetapackageVersion = null
-    ) {
+    public function __construct(array $fromPin)
+    {
         ksort($fromPin);
         $this->fromPin = $fromPin;
-        $this->usedPreFoldInIndirection = $usedPreFoldInIndirection;
-        $this->preFoldInMetapackageVersion = $preFoldInMetapackageVersion;
     }
 
     /** @return array<string,string> */
     public function fromPin(): array
     {
         return $this->fromPin;
-    }
-
-    public function usedPreFoldInIndirection(): bool
-    {
-        return $this->usedPreFoldInIndirection;
-    }
-
-    /** @return string|null tag of `o3-shop/shop-metapackage-ce` consulted for indirection, or null */
-    public function preFoldInMetapackageVersion(): ?string
-    {
-        return $this->preFoldInMetapackageVersion;
     }
 }

--- a/source/Internal/ReleaseTooling/Snapshot/FromSnapshotBuilder.php
+++ b/source/Internal/ReleaseTooling/Snapshot/FromSnapshotBuilder.php
@@ -28,27 +28,26 @@ use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Composer\TagFromConstraint
 
 /**
  * Algorithm Step 1: read `o3-shop/composer.json` at `--from` and
- * build the `from_pin[]` map of tier-0 dependencies.
+ * build the `from_pin[]` map of dependencies.
  *
  * The walk is recursive across the o3-shop subset of the dep tree
  * so tier-0 leaves of shop-ce (shop-doctrine-migration-wrapper,
  * shop-db-views-generator, etc.) appear in `from_pin[]` even though
- * they're not direct deps of o3-shop or the metapackage. Each
- * child is fetched at the constraint's bare-version form (e.g.
- * `^v1.3.0` → `v1.3.0`); when a constraint can't be resolved to
- * a fetchable ref (wildcards, dev-* etc.) or when a child fetch
- * 404s, the recursion silently skips that subtree — the caller
- * still gets every pin it COULD harvest.
+ * they're not direct deps of o3-shop. Each child is fetched at the
+ * constraint's bare-version form (e.g. `^v1.3.0` → `v1.3.0`); when a
+ * constraint can't be resolved to a fetchable ref (wildcards, dev-*
+ * etc.) or when a child fetch 404s, the recursion silently skips that
+ * subtree — the caller still gets every pin it COULD harvest.
  *
- * Pre-fold-in `--from` (composer.json still requires
- * `o3-shop/shop-metapackage-ce`): the metapackage is included in
- * the recursive walk and its entry is dropped from the final
- * `from_pin[]`. One-time transitional path covering the
- * v1.6.0 → v1.6.1-RC1 cut; bypassed for any post-fold-in `--from`.
+ * `o3-shop/shop-metapackage-ce` is an ordinary node in this walk: the
+ * thin `o3-shop` project requires it, so it lands in `from_pin[]` as a
+ * release candidate and is recursed into to harvest the packages it
+ * pins (shop-ce, themes, bundled modules, framework deps). A `--from`
+ * where o3-shop instead pins those packages directly (a fold-in-era
+ * tag) is handled by the same recursion — the metapackage simply
+ * won't appear.
  *
- * The output `FromSnapshot` is pure data — the CLI layer is responsible
- * for emitting the indirection log line based on the snapshot's
- * `usedPreFoldInIndirection()` flag.
+ * The output `FromSnapshot` is pure data.
  *
  * See: openspec/.../release-graph-derivation/spec.md
  */
@@ -56,7 +55,6 @@ class FromSnapshotBuilder
 {
     public const O3_SHOP_PROJECT = 'o3-shop/o3-shop';
     public const O3_SHOP_PREFIX = 'o3-shop/';
-    public const METAPACKAGE_PACKAGE = 'o3-shop/shop-metapackage-ce';
 
     private RawComposerJsonFetcher $fetcher;
 
@@ -84,57 +82,21 @@ class FromSnapshotBuilder
         $rootRequireDev = $this->extractO3ShopPins($rootManifest['require-dev'] ?? []);
         $fromPin = array_merge($rootRequire, $rootRequireDev);
 
-        $usedIndirection = isset($fromPin['shop-metapackage-ce']);
-        $metapackageVersion = $usedIndirection ? $fromPin['shop-metapackage-ce'] : null;
-        // The metapackage is harvested synchronously (below) but never
-        // appears in the final `from_pin[]` — it is the indirection
-        // anchor, not a release-eligible candidate.
-        unset($fromPin['shop-metapackage-ce']);
-
-        // Pre-fold-in: harvest the metapackage's pins SYNCHRONOUSLY before
-        // any further recursion. The metapackage's tier-0 require list
-        // is the authoritative "what shipped at --from" set; if recursion
-        // through root's require-dev (e.g. testing-library) ran first
-        // and learned a looser constraint for shop-ce (testing-library
-        // declares `require: shop-ce: ^1.2`), first-write-wins would
-        // lock in that loose constraint and the metapackage's exact
-        // `shop-ce: v1.6.0` would never get recorded.
-        $visited = [self::O3_SHOP_PROJECT => true];
-        if ($usedIndirection && $metapackageVersion !== null) {
-            $visited[self::METAPACKAGE_PACKAGE] = true;
-            ($this->progress)(sprintf(
-                '  fetching %s@%s (pre-fold-in indirection)',
-                self::METAPACKAGE_PACKAGE,
-                $metapackageVersion
-            ));
-            try {
-                $metaManifest = $this->fetcher->fetch(
-                    self::METAPACKAGE_PACKAGE,
-                    $metapackageVersion
-                );
-                $metaPins = array_merge(
-                    $this->extractO3ShopPins($metaManifest['require'] ?? []),
-                    $this->extractO3ShopPins($metaManifest['require-dev'] ?? [])
-                );
-                foreach ($metaPins as $slug => $constraint) {
-                    if ($slug === 'shop-metapackage-ce') {
-                        continue;
-                    }
-                    if (!isset($fromPin[$slug])) {
-                        $fromPin[$slug] = $constraint;
-                    }
-                }
-            } catch (RawRepoFetchException $e) {
-                // Metapackage unfetchable — recursion below still runs;
-                // the snapshot will be missing tier-0 pins the metapackage
-                // would have provided.
-            }
-        }
-
         // Recursive harvest: for every o3-shop/* slug currently in
         // fromPin, fetch its composer.json at the constraint's resolved
         // ref and add its o3-shop/* deps. Keeps walking until the queue
-        // is empty.
+        // is empty. `shop-metapackage-ce` is an ordinary node here: when
+        // o3-shop requires it, it lands in from_pin as a release
+        // candidate AND is recursed into so the packages it pins
+        // (shop-ce, themes, bundled modules, …) are harvested too.
+        //
+        // First-write-wins ordering note: root `require` is merged before
+        // `require-dev`, and the queue is FIFO, so the metapackage (in
+        // root `require`) is processed before testing-library (in root
+        // `require-dev`). Its EXACT `shop-ce` pin is therefore recorded
+        // before testing-library's looser `shop-ce: ^1.2` is seen, and
+        // the exact pin wins.
+        $visited = [self::O3_SHOP_PROJECT => true];
         $queue = [];
         foreach ($fromPin as $slug => $constraint) {
             $ref = $this->constraintToRef($constraint);
@@ -166,11 +128,6 @@ class FromSnapshotBuilder
             $requireDev = $this->extractO3ShopPins($manifest['require-dev'] ?? []);
 
             foreach (array_merge($require, $requireDev) as $childSlug => $childConstraint) {
-                if ($childSlug === 'shop-metapackage-ce') {
-                    // Never re-introduce the metapackage to from_pin even
-                    // if some downstream package still references it.
-                    continue;
-                }
                 // First-write wins: parent pins (visited earlier in the
                 // queue) take precedence over deeper-level pins.
                 if (!isset($fromPin[$childSlug])) {
@@ -185,7 +142,7 @@ class FromSnapshotBuilder
             }
         }
 
-        return new FromSnapshot($fromPin, $usedIndirection, $metapackageVersion);
+        return new FromSnapshot($fromPin);
     }
 
     /**

--- a/tests/Unit/Internal/ReleaseTooling/Command/ReleaseCommandTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Command/ReleaseCommandTest.php
@@ -45,7 +45,7 @@ class ReleaseCommandTest extends TestCase
         return new StubReleasePlanner(new ReleasePlan(
             'v1.6.0',
             'v1.6.1-RC1',
-            new FromSnapshot([], false, null),
+            new FromSnapshot([]),
             [],
             [],
             '',
@@ -108,7 +108,7 @@ class ReleaseCommandTest extends TestCase
         $stub = new StubReleasePlanner(new ReleasePlan(
             'v1.6.0',
             'v1.6.1-RC1',
-            new FromSnapshot([], false, null),
+            new FromSnapshot([]),
             [],
             [],
             '',
@@ -136,7 +136,7 @@ class ReleaseCommandTest extends TestCase
         $stub = new StubReleasePlanner(new ReleasePlan(
             'v1.6.0',
             'v1.6.1-RC1',
-            new FromSnapshot([], false, null),
+            new FromSnapshot([]),
             [],
             [],
             '',
@@ -191,7 +191,7 @@ class ReleaseCommandTest extends TestCase
         $stub = new StubReleasePlanner(new ReleasePlan(
             'v1.6.0',
             'v1.6.1-RC1',
-            new FromSnapshot([], false, null),
+            new FromSnapshot([]),
             [],
             [],
             '',
@@ -238,7 +238,7 @@ class ReleaseCommandTest extends TestCase
         $stub = new StubReleasePlanner(new ReleasePlan(
             'v1.6.0',
             'v1.6.1-RC1',
-            new FromSnapshot([], false, null),
+            new FromSnapshot([]),
             [],
             [],
             '',
@@ -352,7 +352,7 @@ class ReleaseCommandTest extends TestCase
         $stub = new StubReleasePlanner(new ReleasePlan(
             'v1.6.0',
             'v1.6.1',
-            new FromSnapshot([], false, null),
+            new FromSnapshot([]),
             [],
             [],
             '',
@@ -385,7 +385,7 @@ class ReleaseCommandTest extends TestCase
         $stub = new StubReleasePlanner(new ReleasePlan(
             'v1.6.0',
             'v1.6.1',
-            new FromSnapshot([], false, null),
+            new FromSnapshot([]),
             [],
             [],
             '',
@@ -484,7 +484,7 @@ class ReleaseCommandTest extends TestCase
         return new ReleasePlan(
             'v1.6.0',
             'v1.6.1-RC1',
-            new FromSnapshot([], false, null),
+            new FromSnapshot([]),
             [],
             [],
             '',

--- a/tests/Unit/Internal/ReleaseTooling/Flow/LiveExecutorTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Flow/LiveExecutorTest.php
@@ -349,7 +349,7 @@ final class LiveExecutorTest extends TestCase
         return new ReleasePlan(
             $fromTag,
             $toTag,
-            new FromSnapshot([], false, null),
+            new FromSnapshot([]),
             $candidates,
             $edits,
             $aggregatedNotes,

--- a/tests/Unit/Internal/ReleaseTooling/Planning/DryRunPrinterTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Planning/DryRunPrinterTest.php
@@ -51,32 +51,12 @@ final class DryRunPrinterTest extends TestCase
         $this->assertStringContainsString('Pre-flight gates: skipped', $rendered);
     }
 
-    public function testPreFoldInIndirectionLineRenderedWhenSnapshotUsedIndirection(): void
-    {
-        $plan = new ReleasePlan(
-            'v1.6.0',
-            'v1.6.1-RC1',
-            new FromSnapshot([], true, 'v1.6.0'),
-            [],
-            [],
-            '',
-            []
-        );
-        $printer = new DryRunPrinter();
-        $output = new BufferedOutput();
-        $printer->print($plan, $output);
-
-        $rendered = $output->fetch();
-        $this->assertStringContainsString('pre-fold-in --from detected', $rendered);
-        $this->assertStringContainsString('shop-metapackage-ce@v1.6.0', $rendered);
-    }
-
     public function testBackEdgesSectionPrintedWhenPresent(): void
     {
         $plan = new ReleasePlan(
             'v1.6.0',
             'v1.6.1-RC1',
-            new FromSnapshot([], false, null),
+            new FromSnapshot([]),
             [],
             [],
             '',
@@ -114,7 +94,7 @@ final class DryRunPrinterTest extends TestCase
         $plan = new ReleasePlan(
             'v1.6.0',
             'v1.6.1-RC1',
-            new FromSnapshot([], false, null),
+            new FromSnapshot([]),
             [$candidate],
             [],
             '',
@@ -145,7 +125,7 @@ final class DryRunPrinterTest extends TestCase
         $plan = new ReleasePlan(
             'v1.6.0',
             'v1.6.1-RC1',
-            new FromSnapshot([], false, null),
+            new FromSnapshot([]),
             [$candidate],
             [],
             '',
@@ -165,7 +145,7 @@ final class DryRunPrinterTest extends TestCase
         $plan = new ReleasePlan(
             'v1.6.0',
             'v1.6.1-RC1',
-            new FromSnapshot([], false, null),
+            new FromSnapshot([]),
             [],
             [
                 new ConstraintEditPlan(
@@ -193,7 +173,7 @@ final class DryRunPrinterTest extends TestCase
         $plan = new ReleasePlan(
             'v1.6.0',
             'v1.6.1-RC1',
-            new FromSnapshot([], false, null),
+            new FromSnapshot([]),
             [],
             [],
             "## o3-shop/shop-ce\n\nWhat's Changed\n* foo by @bar\n",
@@ -223,7 +203,7 @@ final class DryRunPrinterTest extends TestCase
         $plan = new ReleasePlan(
             'v1.6.0',
             'v1.6.1-RC1',
-            new FromSnapshot([], false, null),
+            new FromSnapshot([]),
             [],
             [],
             '',
@@ -251,7 +231,7 @@ final class DryRunPrinterTest extends TestCase
         return new ReleasePlan(
             'v1.6.0',
             'v1.6.1-RC1',
-            new FromSnapshot([], false, null),
+            new FromSnapshot([]),
             [],
             [],
             '',

--- a/tests/Unit/Internal/ReleaseTooling/Planning/ReleasePlannerTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Planning/ReleasePlannerTest.php
@@ -40,10 +40,10 @@ class ReleasePlannerTest extends TestCase
 {
     public function testPlannerProducesExpectedReleasePlanForSimpleScenario(): void
     {
-        // o3-shop@v1.6.0 (pre-fold-in) → metapackage indirection →
-        // tier-0 pins (shop-ce, shop-facts) → planned upgrade to v1.6.1-RC1.
-        // shop-ce is the special case (uses --to verbatim);
-        // shop-facts gets a default-patch bump.
+        // --from o3-shop@v1.6.0 requires the metapackage, which pins the
+        // tier-0 packages (shop-ce, shop-facts). The b-1.6 walk here pins
+        // them directly on o3-shop. shop-ce is the special case (uses
+        // --to verbatim); shop-facts is unchanged.
         $manifests = [
             // --from snapshot (Section 4)
             'o3-shop/o3-shop|v1.6.0' => [
@@ -80,9 +80,9 @@ class ReleasePlannerTest extends TestCase
 
         $plan = $planner->plan('v1.6.0', 'v1.6.1-RC1', []);
 
-        // From-snapshot: pre-fold-in indirection applied
-        $this->assertTrue($plan->fromSnapshot()->usedPreFoldInIndirection());
-        $this->assertSame('v1.6.0', $plan->fromSnapshot()->preFoldInMetapackageVersion());
+        // From-snapshot recurses through the metapackage to harvest the
+        // tier-0 pins; the metapackage itself is also recorded.
+        $this->assertSame('v1.6.0', $plan->fromSnapshot()->fromPin()['shop-metapackage-ce']);
 
         // Two candidates: shop-ce (case-3, --to verbatim) and shop-facts (case-1, unchanged)
         $candidates = $plan->candidates();
@@ -108,6 +108,82 @@ class ReleasePlannerTest extends TestCase
         $this->assertSame('o3-shop/shop-ce', $edits[0]->depPackage());
         $this->assertSame('v1.6.0', $edits[0]->update()->oldConstraint());
         $this->assertSame('v1.6.1-RC1', $edits[0]->update()->newConstraint());
+    }
+
+    public function testFoldedOutWalkMakesMetapackageACandidateAndCascadesConstraints(): void
+    {
+        // Folded-out topology: o3-shop → metapackage → shop-ce. The
+        // metapackage is a first-class candidate; when shop-ce re-tags,
+        // the metapackage's pin on it is bumped, and when the metapackage
+        // re-tags, o3-shop's pin on the metapackage is bumped.
+        $manifests = [
+            // --from snapshot (thin o3-shop)
+            'o3-shop/o3-shop|v1.6.0' => [
+                'require' => ['o3-shop/shop-metapackage-ce' => 'v1.6.0'],
+            ],
+            'o3-shop/shop-metapackage-ce|v1.6.0' => [
+                'require' => ['o3-shop/shop-ce' => 'v1.6.0'],
+            ],
+            // walk on the release branch (folded-out)
+            'o3-shop/o3-shop|b-1.6' => [
+                'require' => ['o3-shop/shop-metapackage-ce' => 'v1.6.0'],
+            ],
+            'o3-shop/shop-metapackage-ce|b-1.6' => [
+                'require' => ['o3-shop/shop-ce' => 'v1.6.0'],
+            ],
+            'o3-shop/shop-ce|b-1.6' => ['require' => []],
+        ];
+
+        $planner = $this->wirePlanner(
+            $manifests,
+            [
+                'o3-shop/shop-ce' => ['v1.6.0' => 'sha-ce'],
+                'o3-shop/shop-metapackage-ce' => ['v1.6.0' => 'sha-meta'],
+            ],
+            [
+                'o3-shop/shop-ce' => ['b-1.6' => 'sha-ce-newer'],               // changed
+                'o3-shop/shop-metapackage-ce' => ['b-1.6' => 'sha-meta-newer'], // changed
+            ]
+        );
+
+        $plan = $planner->plan('v1.6.0', 'v1.6.1-RC1', []);
+
+        $byPackage = [];
+        foreach ($plan->candidates() as $c) {
+            $byPackage[$c->package()] = $c;
+        }
+
+        // The metapackage is a first-class release candidate.
+        $this->assertArrayHasKey('o3-shop/shop-metapackage-ce', $byPackage);
+        $this->assertSame('cut-new-tag', $byPackage['o3-shop/shop-metapackage-ce']->caseLabel());
+        $metaChosen = $byPackage['o3-shop/shop-metapackage-ce']->chosenVersion();
+
+        // shop-ce uses --to verbatim.
+        $this->assertSame('v1.6.1-RC1', $byPackage['o3-shop/shop-ce']->chosenVersion());
+
+        // Cascade: index edits by "<parent>|<dep>".
+        $edits = [];
+        foreach ($plan->constraintEdits() as $e) {
+            $edits[$e->parentPackage() . '|' . $e->depPackage()] = $e;
+        }
+
+        // metapackage's pin on shop-ce bumped to the new shop-ce tag.
+        $this->assertArrayHasKey('o3-shop/shop-metapackage-ce|o3-shop/shop-ce', $edits);
+        $this->assertSame(
+            'v1.6.1-RC1',
+            $edits['o3-shop/shop-metapackage-ce|o3-shop/shop-ce']->update()->newConstraint()
+        );
+
+        // o3-shop's pin on the metapackage bumped to the new metapackage tag.
+        $this->assertArrayHasKey('o3-shop/o3-shop|o3-shop/shop-metapackage-ce', $edits);
+        $this->assertSame(
+            'v1.6.0',
+            $edits['o3-shop/o3-shop|o3-shop/shop-metapackage-ce']->update()->oldConstraint()
+        );
+        $this->assertSame(
+            $metaChosen,
+            $edits['o3-shop/o3-shop|o3-shop/shop-metapackage-ce']->update()->newConstraint()
+        );
     }
 
     public function testPlannerEmitsAggregatedNotesUsingProvidedNotesProvider(): void

--- a/tests/Unit/Internal/ReleaseTooling/Planning/ReleasePlannerTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Planning/ReleasePlannerTest.php
@@ -186,6 +186,73 @@ class ReleasePlannerTest extends TestCase
         );
     }
 
+    public function testParentForcedToRetagWhenChildConstraintEdited(): void
+    {
+        // The metapackage's latest tag (RC5) == its b-1.6 HEAD, so the
+        // resolver would REUSE RC5. But shop-ce changed (v1.6.0 -> RC6) and
+        // the metapackage's b-1.6 still pins shop-ce at the stale "v1.6.0",
+        // so the metapackage's composer.json WILL be edited. It must
+        // therefore be forced to cut a new tag rather than reuse RC5 —
+        // otherwise the shop-ce bump would be orphaned (committed but never
+        // tagged). The cascade then bumps o3-shop's pin on the metapackage.
+        $manifests = [
+            // --from snapshot
+            'o3-shop/o3-shop|v1.6.0' => [
+                'require' => ['o3-shop/shop-metapackage-ce' => 'v1.6.0'],
+            ],
+            'o3-shop/shop-metapackage-ce|v1.6.0' => [
+                'require' => ['o3-shop/shop-ce' => 'v1.6.0'],
+            ],
+            // walk on the release branch (folded-out; stale shop-ce pin)
+            'o3-shop/o3-shop|b-1.6' => [
+                'require' => ['o3-shop/shop-metapackage-ce' => 'v1.6.0'],
+            ],
+            'o3-shop/shop-metapackage-ce|b-1.6' => [
+                'require' => ['o3-shop/shop-ce' => 'v1.6.0'],
+            ],
+            'o3-shop/shop-ce|b-1.6' => ['require' => []],
+        ];
+
+        $planner = $this->wirePlanner(
+            $manifests,
+            [
+                'o3-shop/shop-ce' => ['v1.6.0' => 'sha-ce-0', 'v1.6.1-RC6' => 'sha-ce-6'],
+                'o3-shop/shop-metapackage-ce' => ['v1.6.0' => 'sha-m0', 'v1.6.1-RC5' => 'sha-m5'],
+            ],
+            [
+                'o3-shop/shop-ce' => ['b-1.6' => 'sha-ce-6'],               // == RC6 tag: resolver reuses RC6
+                'o3-shop/shop-metapackage-ce' => ['b-1.6' => 'sha-m5'],    // == RC5 tag: resolver would reuse RC5
+            ]
+        );
+
+        // --bump pins the forced metapackage cut to an exact version so the
+        // assertion does not depend on RC patch-bump semantics.
+        $plan = $planner->plan('v1.6.0', 'v1.6.1-RC8', ['shop-metapackage-ce' => 'v1.6.1-RC8']);
+
+        $byPackage = [];
+        foreach ($plan->candidates() as $c) {
+            $byPackage[$c->package()] = $c;
+        }
+
+        // shop-ce: resolver reuses its latest tag RC6 (not forced — no children).
+        $this->assertNull($byPackage['o3-shop/shop-ce']->tagCut());
+        $this->assertSame('v1.6.1-RC6', $byPackage['o3-shop/shop-ce']->chosenVersion());
+
+        // metapackage: resolver would reuse RC5, but a downstream edit forces a cut.
+        $meta = $byPackage['o3-shop/shop-metapackage-ce'];
+        $this->assertNotNull($meta->tagCut(), 'metapackage must be forced to cut a new tag');
+        $this->assertSame('v1.6.1-RC8', $meta->chosenVersion());
+        $this->assertSame('cut-new-tag (downstream changed)', $meta->caseLabel());
+
+        // Cascade edits: metapackage's shop-ce pin -> RC6; o3-shop's metapackage pin -> RC8.
+        $edits = [];
+        foreach ($plan->constraintEdits() as $e) {
+            $edits[$e->parentPackage() . '|' . $e->depPackage()] = $e->update()->newConstraint();
+        }
+        $this->assertSame('v1.6.1-RC6', $edits['o3-shop/shop-metapackage-ce|o3-shop/shop-ce'] ?? null);
+        $this->assertSame('v1.6.1-RC8', $edits['o3-shop/o3-shop|o3-shop/shop-metapackage-ce'] ?? null);
+    }
+
     public function testPlannerEmitsAggregatedNotesUsingProvidedNotesProvider(): void
     {
         $manifests = [

--- a/tests/Unit/Internal/ReleaseTooling/Snapshot/FromSnapshotBuilderTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Snapshot/FromSnapshotBuilderTest.php
@@ -29,10 +29,12 @@ use PHPUnit\Framework\TestCase;
 
 class FromSnapshotBuilderTest extends TestCase
 {
-    public function testPostFoldInRootBuildsDirectFromPin(): void
+    public function testFatFromBuildsDirectFromPin(): void
     {
-        // o3-shop@v1.6.1 (post-fold-in): tier-0 pins live directly
-        // in the root composer.json. No metapackage involved.
+        // A fold-in-era o3-shop@v1.6.1 pins tier-0 packages directly in
+        // the root composer.json (no metapackage require). The recursion
+        // records them as-is; the metapackage never appears because it
+        // isn't required at this --from.
         $fetcher = new FakeRawComposerJsonFetcher([
             'o3-shop/o3-shop|v1.6.1' => [
                 'require' => [
@@ -57,8 +59,7 @@ class FromSnapshotBuilderTest extends TestCase
 
         $snapshot = (new FromSnapshotBuilder($fetcher))->build('v1.6.1');
 
-        $this->assertFalse($snapshot->usedPreFoldInIndirection());
-        $this->assertNull($snapshot->preFoldInMetapackageVersion());
+        $this->assertArrayNotHasKey('shop-metapackage-ce', $snapshot->fromPin());
         $this->assertSame([
             'gdpr-optin-module' => 'v1.0.1',
             'o3-theme' => '^v1.3.0',
@@ -73,11 +74,12 @@ class FromSnapshotBuilderTest extends TestCase
         ], $snapshot->fromPin());
     }
 
-    public function testPreFoldInRootTriggersMetapackageIndirection(): void
+    public function testThinFromKeepsMetapackageAndHarvestsItsChildren(): void
     {
-        // o3-shop@v1.6.0 (pre-fold-in): the root composer.json only
-        // requires the metapackage. The actual tier-0 pins live one
-        // level deeper in shop-metapackage-ce@v1.6.0.
+        // Folded-out o3-shop: the root composer.json only requires the
+        // metapackage, which pins the tier-0 packages one level deeper.
+        // The metapackage stays in from_pin as a first-class release
+        // candidate AND its children are harvested.
         $fetcher = new FakeRawComposerJsonFetcher([
             'o3-shop/o3-shop|v1.6.0' => [
                 'require' => [
@@ -107,12 +109,10 @@ class FromSnapshotBuilderTest extends TestCase
 
         $snapshot = (new FromSnapshotBuilder($fetcher))->build('v1.6.0');
 
-        $this->assertTrue($snapshot->usedPreFoldInIndirection());
-        $this->assertSame('v1.6.0', $snapshot->preFoldInMetapackageVersion());
-        // Metapackage entry itself is dropped from from_pin.
-        $this->assertArrayNotHasKey('shop-metapackage-ce', $snapshot->fromPin());
-        // Tier-0 pins from the metapackage are present.
         $pins = $snapshot->fromPin();
+        // The metapackage itself is a first-class entry in from_pin.
+        $this->assertSame('v1.6.0', $pins['shop-metapackage-ce']);
+        // Tier-0 pins harvested from the metapackage are present too.
         $this->assertSame('v1.6.0', $pins['shop-ce']);
         $this->assertSame('^v1.3.0', $pins['o3-theme']);
         $this->assertSame('v1.0.1', $pins['gdpr-optin-module']);
@@ -157,6 +157,36 @@ class FromSnapshotBuilderTest extends TestCase
         $snapshot = (new FromSnapshotBuilder($fetcher))->build('v1.6.0');
 
         $this->assertSame('dev-override', $snapshot->fromPin()['shop-ce']);
+        // The metapackage entry survives as a first-class pin.
+        $this->assertSame('v1.6.0', $snapshot->fromPin()['shop-metapackage-ce']);
+    }
+
+    public function testMetapackageExactShopCePinBeatsTestingLibraryLoosePin(): void
+    {
+        // Folded-out root: `require` has only the metapackage (exact
+        // shop-ce pin); `require-dev` has testing-library (loose shop-ce
+        // pin). Root `require` merges before `require-dev` and the queue
+        // is FIFO, so the metapackage is processed first and its exact
+        // pin is recorded before testing-library's loose one — without
+        // any synchronous pre-harvest. Regression guard for the removed
+        // pre-fold-in indirection block.
+        $fetcher = new FakeRawComposerJsonFetcher([
+            'o3-shop/o3-shop|v1.6.0' => [
+                'require' => ['o3-shop/shop-metapackage-ce' => 'v1.6.0'],
+                'require-dev' => ['o3-shop/testing-library' => '^1.2.0'],
+            ],
+            'o3-shop/shop-metapackage-ce|v1.6.0' => [
+                'require' => ['o3-shop/shop-ce' => 'v1.6.0'],
+            ],
+            'o3-shop/testing-library|v1.2.0' => [
+                'require' => ['o3-shop/shop-ce' => '^1.2'],
+            ],
+            'o3-shop/shop-ce|v1.6.0' => ['require' => []],
+        ]);
+
+        $snapshot = (new FromSnapshotBuilder($fetcher))->build('v1.6.0');
+
+        $this->assertSame('v1.6.0', $snapshot->fromPin()['shop-ce']);
     }
 
     public function testNonO3ShopPackagesAreFilteredOut(): void
@@ -207,7 +237,7 @@ class FromSnapshotBuilderTest extends TestCase
 
     public function testRecursiveHarvestPullsTier0LeavesOfShopCe(): void
     {
-        // Pre-fold-in: o3-shop@v1.6.0 → metapackage@v1.6.0 → shop-ce@v1.6.0.
+        // Folded-out: o3-shop@v1.6.0 → metapackage@v1.6.0 → shop-ce@v1.6.0.
         // shop-ce's own require contains shop-doctrine-migration-wrapper
         // and shop-db-views-generator (tier-0 leaves) which neither the
         // root nor the metapackage mention. These MUST end up in
@@ -254,8 +284,8 @@ class FromSnapshotBuilderTest extends TestCase
         $this->assertSame('^v1.0.0', $pin['shop-db-views-generator']);
         $this->assertArrayHasKey('shop-ide-helper', $pin);
         $this->assertSame('^v1.0.0', $pin['shop-ide-helper']);
-        // Metapackage entry never appears in from_pin
-        $this->assertArrayNotHasKey('shop-metapackage-ce', $pin);
+        // Metapackage entry is a first-class pin too.
+        $this->assertSame('v1.6.0', $pin['shop-metapackage-ce']);
     }
 
     public function testRecursiveHarvestSkipsSubtreeOnFetcherFailure(): void


### PR DESCRIPTION
## What

Adjust `bin/release` to drive the **metapackage fold-OUT** (o3-shop/o3-shop#169): `o3-shop/shop-metapackage-ce` becomes a permanent, first-class release node again, reversing the half-finished fold-in that broke `composer create-project` (double `replace`).

## Changes

- **FromSnapshotBuilder / FromSnapshot / DryRunPrinter**: remove the fold-in special-casing (dropping the metapackage from `from_pin[]`, the "pre-fold-in indirection" path, the metadata). The metapackage is now recursed into like any other node — it lands in `from_pin[]` and its children are harvested. First-write-wins ordering is preserved by the existing root-`require`-before-`require-dev` merge + FIFO queue.
- **ReleasePlanner**: force a new tag for any package whose own `composer.json` will receive a downstream constraint edit (a resolved child changed). The leaves-first walk makes the decision cascade up the tiers (shop-ce bump → metapackage re-tag → o3-shop pin bump). Prevents an orphaned edit on an intermediate "fat" node.
- **CandidatePlan**: reports such forced cuts as `cut-new-tag (downstream changed)`.
- **OpenSpec**: new change `2026-05-27-fold-out-metapackage` (modifies release-graph-derivation + release-orchestration, removes metapackage-fold-in, adds metapackage-compilation). `openspec validate` ✓.
- Shared-memory note on the intermediate-node re-tag gap.

## Verification

- Full unit suite green (9672 tests, 17916 assertions); ReleaseTooling 288 tests; cs-fixer clean.
- Dry-run `--from v1.6.0 --to v1.6.1-RC8 --bump shop-metapackage-ce=v1.6.1-RC8` → coherent plan: `o3-shop RC8 → metapackage RC8 → shop-ce RC6`, single `replace` owner, no orphaned edit.

## Cross-repo context (not in this PR)

- `o3-shop/o3-shop@b-1.6` already slimmed to a thin project (pushed separately).
- The live cut, broken-tag cleanup, and issue #149 reroute are tracked in o3-shop/o3-shop#169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
