### PR TITLE
fix(#166): guard ExitHandler registration with interface_exists()

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -26,3 +26,4 @@ Shared memory for all Claude agents working in this repository. Read this first,
 - [o3-theme npm audit](project_o3-theme-dep-audit.md) — pre-existing brace-expansion vulnerability blocks test-all-coverage; use test --fast for PHP-only changes
 - [bin/release intermediate-node re-tag gap](release-tooling-intermediate-node-retag-gap.md) — resolver "reuses" an intermediate fat node (the metapackage) while bumping its child pin → orphaned edit; force a re-tag during the fold-out cut (#169)
 - [!] [cs-fixer dirties nested clones](cs-fixer-pollutes-nested-clones.md) — ./docker.sh cs-fixer reformats testing-library/themes/demodata clones → aborts bin/release pre-flight; clean them before a cut
+- [!] [ExitHandler interface-guard bug](shop-ce-exithandler-interface-guard-bug.md) — bootstrap.php uses class_exists() on the ExitHandlerInterface (always false) → fresh-install Setup redirect dies in a DB-error loop; fix: interface_exists()

--- a/.claude/memory/shop-ce-exithandler-interface-guard-bug.md
+++ b/.claude/memory/shop-ce-exithandler-interface-guard-bug.md
@@ -1,0 +1,50 @@
+---
+name: shop-ce-exithandler-interface-guard-bug
+description: bootstrap.php guards ExitHandler registration with class_exists() on an INTERFACE name (always false) → fresh-install Setup redirect dies in a DB-error loop
+type: reference
+---
+
+# `class_exists()` on an interface breaks fresh-install Setup (shop-ce, PR #156)
+
+Symptom: a fresh `composer create-project o3-shop/o3-shop` of **v1.6.1-RC8**
+(and any shop-ce carrying PR #156 / issue #166) shows the **Maintenance page**
+with an endless `DatabaseNotConfiguredException` loop, instead of redirecting to
+**/Setup** (RC3 worked). Unrelated to the metapackage fold-out (#169) — RC8 just
+ships the newer shop-ce.
+
+Root cause in `source/bootstrap.php`:
+
+```php
+if (class_exists(\OxidEsales\Eshop\Core\ExitHandlerInterface::class)) {   // <-- BUG
+    \OxidEsales\Eshop\Core\Registry::set(
+        \OxidEsales\Eshop\Core\ExitHandlerInterface::class,
+        new \OxidEsales\Eshop\Core\ExitHandler()
+    );
+}
+```
+
+`ExitHandlerInterface` is an **interface**, and `class_exists()` returns **false**
+for interfaces (`interface_exists()` is the right check). So the guard is never
+true and the `ExitHandler` is never registered.
+
+`source/overridablefunctions.php::redirectIfShopNotConfigured()` (the
+fresh-install → Setup redirect) ends with:
+
+```php
+\OxidEsales\Eshop\Core\Registry::get(\OxidEsales\Eshop\Core\ExitHandlerInterface::class)->exit(0, $message);
+```
+
+With no registered handler, `Registry::get()` falls through to
+`oxNew(ExitHandlerInterface)` → `ModuleChainsGenerator` → `getModuleVarFromDB('aModules')`
+→ DB → `DatabaseNotConfiguredException` on a not-yet-configured shop → uncaught →
+global `ExceptionHandler::exitApplication()` does the *same* `Registry::get` →
+same cascade → infinite loop → Maintenance page. (The global exception-exit path
+hits the identical wall, so even non-Setup errors loop on a DB-less shop.)
+
+Fix (one word): `class_exists(` → `interface_exists(` in `source/bootstrap.php`
+(or `class_exists($x) || interface_exists($x)`). Verified in a container install:
+`Registry::get(ExitHandlerInterface)` then returns the `ExitHandler`, and
+`curl /` returns `302 → Setup/index.php` with a clean (empty) log.
+
+Lesson: never use `class_exists()` to probe a name that may be an interface or
+trait — use `interface_exists()` / `trait_exists()`, or all three.

--- a/source/bootstrap.php
+++ b/source/bootstrap.php
@@ -238,8 +238,14 @@ $configFile = new \OxidEsales\Eshop\Core\ConfigFile(OX_BASE_PATH . 'config.inc.p
  * Register the default exit handler. Tests swap this for a throwing fake via
  * Registry::set() (see tests/Unit/ExitHandlerTestTrait.php) so exit() calls
  * in the code under test do not tear down the PHPUnit process.
+ *
+ * The guard skips registration when the unified namespace has not been
+ * generated yet (e.g. mid composer install). ExitHandlerInterface is an
+ * INTERFACE, so it MUST be probed with interface_exists(): class_exists()
+ * returns false for interfaces, which would leave the handler unregistered
+ * and break the fresh-install Setup redirect (see o3-shop/o3-shop#166).
  */
-if (class_exists(\OxidEsales\Eshop\Core\ExitHandlerInterface::class)) {
+if (interface_exists(\OxidEsales\Eshop\Core\ExitHandlerInterface::class)) {
     \OxidEsales\Eshop\Core\Registry::set(
         \OxidEsales\Eshop\Core\ExitHandlerInterface::class,
         new \OxidEsales\Eshop\Core\ExitHandler()

--- a/tests/Unit/Core/ExitHandlerTest.php
+++ b/tests/Unit/Core/ExitHandlerTest.php
@@ -26,6 +26,53 @@ class ExitHandlerTest extends UnitTestCase
         );
     }
 
+    /**
+     * Regression guard for o3-shop/o3-shop#166.
+     *
+     * ExitHandlerInterface is an interface, so class_exists() returns false
+     * for it — interface_exists() is the correct probe. bootstrap.php relies
+     * on this when deciding whether to register the default ExitHandler; the
+     * wrong probe leaves it unregistered and breaks the fresh-install Setup
+     * redirect with a DatabaseNotConfiguredException loop.
+     */
+    public function testExitHandlerInterfaceIsDetectedByInterfaceExistsNotClassExists()
+    {
+        $interface = \OxidEsales\Eshop\Core\ExitHandlerInterface::class;
+
+        $this->assertTrue(
+            interface_exists($interface),
+            'unified-namespace ExitHandlerInterface must resolve as an interface'
+        );
+        $this->assertFalse(
+            class_exists($interface),
+            'ExitHandlerInterface is an interface; class_exists() is always false for it (see #166)'
+        );
+    }
+
+    /**
+     * Regression guard for o3-shop/o3-shop#166: bootstrap.php must probe the
+     * ExitHandlerInterface with interface_exists() before registering the
+     * default ExitHandler. Probing with class_exists() (as shipped in
+     * shop-ce#156) is always false for an interface, so the handler is never
+     * registered. This asserts the source guard directly — it would have
+     * failed on the broken fix.
+     */
+    public function testBootstrapRegistersDefaultExitHandlerViaInterfaceExists()
+    {
+        $bootstrap = file_get_contents(dirname(__DIR__, 3) . '/source/bootstrap.php');
+
+        $this->assertStringNotContainsString(
+            'class_exists(\OxidEsales\Eshop\Core\ExitHandlerInterface::class)',
+            $bootstrap,
+            'bootstrap.php must not guard ExitHandler registration with class_exists() on the interface (#166)'
+        );
+        $this->assertStringContainsString(
+            'interface_exists(\OxidEsales\Eshop\Core\ExitHandlerInterface::class)',
+            $bootstrap,
+            'bootstrap.php must guard ExitHandler registration with interface_exists() (#166)'
+        );
+    }
+
     public function testFakeHandlerFromTraitThrowsExitCalledException()
     {
         $this->installFakeExitHandler();


### PR DESCRIPTION
Fixes the regression behind o3-shop/o3-shop#166 (re-opened — the fix in #156 was incorrect).

## Problem

`source/bootstrap.php` registered the default `ExitHandler` only:

```php
if (class_exists(\OxidEsales\Eshop\Core\ExitHandlerInterface::class)) { ... }
```

`ExitHandlerInterface` is an **interface**, and `class_exists()` returns **false** for interfaces — so the guard never fired and the handler was **never registered**.

On a DB-less fresh `composer create-project`, `redirectIfShopNotConfigured()` terminates with `Registry::get(ExitHandlerInterface)->exit()`. With no registered handler, `Registry::get()` falls through to `oxNew()` → module-chain resolution → `getModuleVarFromDB('aModules')` → DB → `DatabaseNotConfiguredException` (uncaught) → the global `ExceptionHandler` repeats the same call → endless loop → **Maintenance page instead of the `/Setup` redirect** (v1.6.1-RC3 registered the handler unconditionally, so it landed on Setup).

## Fix

`class_exists(` → `interface_exists(` (keeps #156's intent — skip registration before the unified namespace is generated — but uses the correct probe for an interface).

## Tests

Two regression guards added to `tests/Unit/Core/ExitHandlerTest.php`:
- `testExitHandlerInterfaceIsDetectedByInterfaceExistsNotClassExists` — documents the interface vs `class_exists()` trap.
- `testBootstrapRegistersDefaultExitHandlerViaInterfaceExists` — asserts the source guard directly; **would have failed on #156's broken fix.**

## Verification

In a fresh container install of the affected build: with the old guard `Registry::get(ExitHandlerInterface)` throws `DatabaseNotConfiguredException`; with the fix it returns `…\Core\ExitHandler`, and `curl /` returns `302 → Setup/index.php` with a clean log. (Local `./docker.sh test` not run here — dev env was down; CI runs the full suite.)

## Note

v1.6.1-RC8 ships this bug and will need a re-cut.

Refs o3-shop/o3-shop#166

🤖 Generated with [Claude Code](https://claude.com/claude-code)
