### PR TITLE
refactor(#169): tag shop-metapackage-ce at --to verbatim (drop the --bump workaround)

### DIFF
--- a/openspec/changes/2026-05-27-fold-out-metapackage/specs/release-graph-derivation/spec.md
+++ b/openspec/changes/2026-05-27-fold-out-metapackage/specs/release-graph-derivation/spec.md
@@ -46,6 +46,42 @@ not declared anywhere; they emerge from the sort.
 - **THEN** `shop-metapackage-ce` is one tier below `o3-shop`, and
   `o3-shop` is at the highest tier
 
+### Requirement: Tag-cutting policy — shop-ce uses --to verbatim
+
+The CLI SHALL tag both `o3-shop/shop-ce` and `o3-shop/shop-metapackage-ce`
+at exactly the `--to` value. Both ARE the shop release — the code
+(`shop-ce`) and the compilation (`shop-metapackage-ce`) move in lockstep
+with the shop version. This rule is unconditional: it takes precedence over
+a `--bump` flag or a `.next-bump` file.
+
+#### Scenario: Cutting shop-ce v1.6.2
+
+- **WHEN** the CLI cuts a new tag on `shop-ce` during a release with
+  `--to v1.6.2`
+- **THEN** the new shop-ce tag is `v1.6.2`
+
+#### Scenario: Cutting the metapackage at the shop version
+
+- **WHEN** the CLI cuts a new tag on `o3-shop/shop-metapackage-ce`
+  during a release with `--to v1.6.2`, even when
+  `--bump shop-metapackage-ce=<other>` is supplied
+- **THEN** the new metapackage tag is `v1.6.2`
+
+### Requirement: Tag-cutting policy — every other repo bumps own line
+
+The CLI SHALL tag any repo other than `o3-shop/shop-ce` and
+`o3-shop/shop-metapackage-ce` by bumping its current latest tag on its own
+version line, with the bump level resolved by precedence: a
+`--bump <repo>=<level>` flag, then a `.next-bump` file at the repo's
+release-branch root, then a default `patch`.
+
+#### Scenario: Default patch bump
+
+- **WHEN** the CLI cuts a new tag on `testing-library` whose latest
+  tag is `v1.2.5`, no flag is passed for it, and no `.next-bump` file
+  exists
+- **THEN** the new tag is `v1.2.6`
+
 ## REMOVED Requirements
 
 ### Requirement: Pre-fold-in `--from` triggers metapackage indirection

--- a/source/Internal/ReleaseTooling/Tag/TagCutResult.php
+++ b/source/Internal/ReleaseTooling/Tag/TagCutResult.php
@@ -29,7 +29,7 @@ namespace OxidEsales\EshopCommunity\Internal\ReleaseTooling\Tag;
  */
 final class TagCutResult
 {
-    public const SOURCE_SHOP_VERBATIM = 'shop-ce-verbatim';
+    public const SOURCE_SHOP_VERBATIM = 'shop-version-verbatim';
     public const SOURCE_FLAG = 'flag';
     public const SOURCE_NEXT_BUMP_FILE = 'next-bump-file';
     public const SOURCE_DEFAULT_PATCH = 'default-patch';

--- a/source/Internal/ReleaseTooling/Tag/TagCutter.php
+++ b/source/Internal/ReleaseTooling/Tag/TagCutter.php
@@ -28,7 +28,10 @@ use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Composer\RawRepoFileFetche
 /**
  * Algorithm Step 4: decide what new tag to cut for a candidate.
  *
- *   shop-ce              → --to verbatim (the shop tag IS the shop version)
+ *   shop-ce, shop-metapackage-ce → --to verbatim. Both ARE the shop
+ *                          release — the code (shop-ce) and the
+ *                          compilation (shop-metapackage-ce) move in
+ *                          lockstep with the shop version.
  *   any other candidate  → bump latest_tag by level resolved with
  *                          precedence: --bump flag > .next-bump file > patch
  *
@@ -43,6 +46,7 @@ class TagCutter
 {
     public const O3_SHOP_PREFIX = 'o3-shop/';
     public const SHOP_CE_PACKAGE = 'o3-shop/shop-ce';
+    public const METAPACKAGE_PACKAGE = 'o3-shop/shop-metapackage-ce';
     public const NEXT_BUMP_PATH = '.next-bump';
 
     private RawRepoFileFetcher $fileFetcher;
@@ -55,7 +59,7 @@ class TagCutter
     /**
      * @param string                    $package     e.g. "o3-shop/shop-facts"
      * @param string|null               $latestTag   highest semver tag on the repo (null = no tags yet)
-     * @param string                    $shopTo      --to value, used for shop-ce verbatim case
+     * @param string                    $shopTo      --to value; used for the shop-ce / metapackage verbatim case
      * @param array<string,string>      $bumpFlags   short-slug => raw bump level (e.g. ["shop-facts" => "minor"])
      * @param string                    $packageRef  release branch on this repo (e.g. "b-1.6")
      */
@@ -66,7 +70,10 @@ class TagCutter
         array $bumpFlags,
         string $packageRef
     ): TagCutResult {
-        if ($package === self::SHOP_CE_PACKAGE) {
+        // shop-ce and the metapackage ARE the shop release: tag both at the
+        // --to version so the code and the compilation stay in lockstep.
+        // Unconditional — this beats any --bump flag / .next-bump file.
+        if ($package === self::SHOP_CE_PACKAGE || $package === self::METAPACKAGE_PACKAGE) {
             return new TagCutResult(
                 $shopTo,
                 false,

--- a/tests/Unit/Internal/ReleaseTooling/Planning/ReleasePlannerTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Planning/ReleasePlannerTest.php
@@ -153,10 +153,12 @@ class ReleasePlannerTest extends TestCase
             $byPackage[$c->package()] = $c;
         }
 
-        // The metapackage is a first-class release candidate.
+        // The metapackage is a first-class release candidate, tagged at the
+        // shop version (--to verbatim) in lockstep with shop-ce / o3-shop.
         $this->assertArrayHasKey('o3-shop/shop-metapackage-ce', $byPackage);
         $this->assertSame('cut-new-tag', $byPackage['o3-shop/shop-metapackage-ce']->caseLabel());
         $metaChosen = $byPackage['o3-shop/shop-metapackage-ce']->chosenVersion();
+        $this->assertSame('v1.6.1-RC1', $metaChosen, 'metapackage tags at --to verbatim');
 
         // shop-ce uses --to verbatim.
         $this->assertSame('v1.6.1-RC1', $byPackage['o3-shop/shop-ce']->chosenVersion());
@@ -225,9 +227,9 @@ class ReleasePlannerTest extends TestCase
             ]
         );
 
-        // --bump pins the forced metapackage cut to an exact version so the
-        // assertion does not depend on RC patch-bump semantics.
-        $plan = $planner->plan('v1.6.0', 'v1.6.1-RC8', ['shop-metapackage-ce' => 'v1.6.1-RC8']);
+        // No --bump needed: the metapackage tags at --to verbatim, so the
+        // forced re-tag lands at the shop version (v1.6.1-RC8).
+        $plan = $planner->plan('v1.6.0', 'v1.6.1-RC8', []);
 
         $byPackage = [];
         foreach ($plan->candidates() as $c) {

--- a/tests/Unit/Internal/ReleaseTooling/Tag/TagCutterTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Tag/TagCutterTest.php
@@ -51,6 +51,24 @@ class TagCutterTest extends TestCase
         $this->assertFalse($result->deleteNextBumpFile());
     }
 
+    /* ---------- shop-metapackage-ce uses --to verbatim (lockstep) ---------- */
+
+    public function testMetapackageAlwaysGetsToVerbatim(): void
+    {
+        // The metapackage is the compilation; it ships at the shop version.
+        // --to verbatim beats any --bump flag, just like shop-ce.
+        $result = $this->cutter()->cut(
+            'o3-shop/shop-metapackage-ce',
+            'v1.6.1-RC5',
+            'v1.6.1-RC8',
+            ['shop-metapackage-ce' => 'major'], // ignored: verbatim beats flag
+            'b-1.6'
+        );
+        $this->assertSame('v1.6.1-RC8', $result->newTag());
+        $this->assertSame(TagCutResult::SOURCE_SHOP_VERBATIM, $result->source());
+        $this->assertFalse($result->deleteNextBumpFile());
+    }
+
     /* ---------- 7.2 + 7.7 — default patch ---------- */
 
     public function testDefaultPatchBumpsLatestPatchByOne(): void


### PR DESCRIPTION
Simplifies `bin/release` so the metapackage no longer needs a manual `--bump` on every cut. Follow-up to the fold-out (o3-shop/o3-shop#169).

## Why

Post-fold-out, `o3-shop/shop-metapackage-ce` is the **compilation** — it ships at the shop version, in lockstep with `shop-ce` and `o3-shop`. But `TagCutter` treated it as an ordinary dependency (own version line → default `patch`, e.g. `v1.6.1-RC5 → v1.6.2`), so a clean cut required passing `--bump shop-metapackage-ce=<to>` by hand every time.

## What

- `TagCutter` now tags **both** `shop-ce` and `shop-metapackage-ce` at the `--to` value verbatim — unconditional, beats `--bump` / `.next-bump`. No flag needed.
- Renamed the tag-cut source label `shop-ce-verbatim` → `shop-version-verbatim` (it now covers both packages).
- The cut is now simply:
  ```
  bin/release --from v1.6.1 --to v1.6.2          # metapackage + shop-ce + o3-shop all tag v1.6.2
  ```

## Tests

- New `TagCutterTest::testMetapackageAlwaysGetsToVerbatim` (verbatim beats `--bump`).
- Tightened the folded-out cascade tests in `ReleasePlannerTest` to assert `--to`-verbatim and dropped the now-redundant `--bump`.
- 289 ReleaseTooling tests pass (host run); `openspec validate` clean.

## Spec

The tag-cutting-policy requirements in the fold-out OpenSpec change now cover `shop-metapackage-ce`.

## Follow-up

Once merged, the [Create-a-Release wiki](https://github.com/o3-shop/o3-shop/wiki/Create-a-Release) should drop the `--bump shop-metapackage-ce=<tag>` guidance (it's documented as required there today, matching current `b-1.6`).

Refs o3-shop/o3-shop#169

🤖 Generated with [Claude Code](https://claude.com/claude-code)
