### PR TITLE
fix: export SHOP_CONTAINER for playwright suite after #148 rename

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -411,6 +411,7 @@ case "$1" in
             npm install || exit 127
             npx playwright install chromium || exit 127
         fi
+        export SHOP_CONTAINER="${COMPOSE_PROJECT_NAME}-shop-1"
         npx playwright test "$@" || exit 127
         ;;
     *)


### PR DESCRIPTION
## Summary

- Multi-worktree Docker (#148) renamed the shop container from `o3shop-app` to `${COMPOSE_PROJECT_NAME}-shop-1`, but the Playwright helpers in `tests/Acceptance/playwright/helpers/config.ts` kept `o3shop-app` as their fallback default.
- `./docker.sh playwright` did not export `SHOP_CONTAINER`, so any spec shelling into the container via `docker exec` (category seed/cleanup helpers used by the #141 2nd-level menu suite) failed with `Error response from daemon: No such container: o3shop-app`.
- Fix exports `SHOP_CONTAINER="${COMPOSE_PROJECT_NAME}-shop-1"` from `docker.sh:414` before launching Playwright. The `SHOP_CONTAINER` env-var override knob in `config.ts:13` still works for anyone driving Playwright outside `docker.sh`.

## Test plan

- [x] `./docker.sh playwright tests/storefront/menu/` — all 10 specs now pass (previously 2 failed + 8 skipped as dependents).
- [x] Full `./docker.sh playwright` previously: 30 passed / 2 failed / 6 did not run; with this fix the menu/db-shelling failures are resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)