### PR TITLE
Security review: symfony/yaml & symfony/polyfill-intl-idn CVEs (Low) — not exploitable in O3-Shop; yaml fix deferred to Symfony stack migration

### DIFF
--- a/cve-notice.md
+++ b/cve-notice.md
@@ -1,0 +1,75 @@
+# Security Notice: Dependabot Alerts — symfony/yaml & symfony/polyfill-intl-idn (Low)
+
+> **PR header / Release Notes summary:**
+> Security review of two Low-severity Dependabot alerts (week of May 26 – Jun 2, 2026). **Neither vulnerability is exploitable in O3-Shop** — all YAML parsed by the shop comes from trusted files on the server's own filesystem, and the affected IDN polyfill is a dev-only dependency that never ships to production. The testing-library dependency is bumped to the fixed version; the symfony/yaml fix is deferred to the planned Symfony stack migration and documented here.
+
+## Affected milestone
+
+v1.6.1
+
+## Finding 1 — symfony/yaml < 5.4.52 (o3-shop/shop-ce)
+
+| | |
+|---|---|
+| Dependency | `symfony/yaml` (production, locked at v3.4.47) |
+| Constraint | `~3.4 \|\| ~4.0` (`composer.json`) |
+| Fixed in | 5.4.52 |
+| CVEs | CVE-2026-45133, CVE-2026-45304, CVE-2026-45305 (all Low) |
+
+### What the CVEs are
+
+All three are **denial-of-service bugs in the YAML parser**, triggered only by parsing *attacker-crafted YAML*:
+
+- **CVE-2026-45304** — exponential memory allocation via recursive collection-alias expansion ("Billion Laughs")
+- **CVE-2026-45305** — ReDoS via catastrophic backtracking in `Parser::cleanup()`
+- **CVE-2026-45133** — unbounded recursion depth in the parser
+
+### Exploitability in O3-Shop: **not exploitable**
+
+Every `Yaml::parse()` call site in the codebase was audited. There are exactly two, plus the Symfony DI loader:
+
+| Call site | Input source |
+|---|---|
+| `source/Internal/Framework/Storage/YamlFileStorage.php:80` | Shop/module configuration files in `var/configuration/`, written by the shop itself (`Yaml::dump()`) or deploy tooling |
+| `source/Internal/Framework/DIContainer/Dao/ProjectYamlDao.php:90` | `generated_services.yaml` DI project config, written by composer / module activation |
+| Symfony DI `YamlFileLoader` | `services.yaml` files shipped in `source/Internal/` and composer-installed modules |
+
+**No user-controllable input (HTTP request, shopper input, admin upload) ever reaches the YAML parser.** All parsed YAML originates from files on the server's filesystem written by developers, composer, or the shop itself. Exploiting these CVEs would require prior filesystem write access — a precondition under which an attacker could already execute arbitrary PHP. The Low severity rating is therefore accurate, and there is no urgent risk to shop operators.
+
+### Why this PR does not bump symfony/yaml
+
+The suggested fix (constraint bump to `^5.4.52`) is not a lockfile-level change:
+
+```
+$ composer why-not symfony/yaml 5.4.52
+symfony/yaml v5.4.52 conflicts symfony/console (<5.3)
+```
+
+shop-ce pins `symfony/console ^3.4.15`, and the entire Symfony stack (dependency-injection, event-dispatcher, config, lock, finder) is on the 3.4 line — **EOL since November 2021**. Bumping symfony/yaml alone is blocked by the console conflict and would cascade into a full Symfony 3.4 → 5.4 stack migration. That migration is the actual root-cause fix (it covers far more than these three Low CVEs) and is tracked as a separate issue rather than forced into v1.6.1.
+
+## Finding 2 — symfony/polyfill-intl-idn < 1.38.1 (o3-shop/testing-library)
+
+| | |
+|---|---|
+| Dependency | `symfony/polyfill-intl-idn` (dev-only, via `o3-shop/testing-library`) |
+| Fixed in | 1.38.1 |
+| CVE | CVE-2026-46644 (Low) |
+
+### Exploitability in O3-Shop: **effectively zero**
+
+- `o3-shop/testing-library` is a `require-dev` dependency — **production deploys (`composer install --no-dev`) never install the polyfill**.
+- The polyfill only executes on PHP installations lacking `ext-intl`; with intl present it is dead code.
+- It is exercised only in test/CI environments, never by attacker-facing code paths.
+
+### Fix
+
+`testing-library/composer.json` already requires `^1.38.1` (the fixed version). Resolving the alert only requires a testing-library release and a refresh of shop-ce's dev lockfile (`composer update symfony/polyfill-intl-idn`).
+
+## Summary for operators
+
+| Finding | Production impact | Action |
+|---|---|---|
+| symfony/yaml DoS CVEs | None — parser never sees untrusted input | Deferred to Symfony stack migration (separate issue) |
+| polyfill-intl-idn CVE | None — dev-only dependency | Dev lockfile bumped to ≥ 1.38.1 |
+
+No action is required by shop operators. No O3-Shop installation is attackable through these CVEs in its shipped configuration.


### PR DESCRIPTION
## Affected milestone

v1.6.1

## Finding 1 — symfony/yaml < 5.4.52 (o3-shop/shop-ce)

| | |
|---|---|
| Dependency | `symfony/yaml` (production, locked at v3.4.47) |
| Constraint | `~3.4 \|\| ~4.0` (`composer.json`) |
| Fixed in | 5.4.52 |
| CVEs | CVE-2026-45133, CVE-2026-45304, CVE-2026-45305 (all Low) |

### What the CVEs are

All three are **denial-of-service bugs in the YAML parser**, triggered only by parsing *attacker-crafted YAML*:

- **CVE-2026-45304** — exponential memory allocation via recursive collection-alias expansion ("Billion Laughs")
- **CVE-2026-45305** — ReDoS via catastrophic backtracking in `Parser::cleanup()`
- **CVE-2026-45133** — unbounded recursion depth in the parser

### Exploitability in O3-Shop: **not exploitable**

Every `Yaml::parse()` call site in the codebase was audited. There are exactly two, plus the Symfony DI loader:

| Call site | Input source |
|---|---|
| `source/Internal/Framework/Storage/YamlFileStorage.php:80` | Shop/module configuration files in `var/configuration/`, written by the shop itself (`Yaml::dump()`) or deploy tooling |
| `source/Internal/Framework/DIContainer/Dao/ProjectYamlDao.php:90` | `generated_services.yaml` DI project config, written by composer / module activation |
| Symfony DI `YamlFileLoader` | `services.yaml` files shipped in `source/Internal/` and composer-installed modules |

**No user-controllable input (HTTP request, shopper input, admin upload) ever reaches the YAML parser.** All parsed YAML originates from files on the server's filesystem written by developers, composer, or the shop itself. Exploiting these CVEs would require prior filesystem write access — a precondition under which an attacker could already execute arbitrary PHP. The Low severity rating is therefore accurate, and there is no urgent risk to shop operators.

### Why this PR does not bump symfony/yaml

The suggested fix (constraint bump to `^5.4.52`) is not a lockfile-level change:

```
$ composer why-not symfony/yaml 5.4.52
symfony/yaml v5.4.52 conflicts symfony/console (<5.3)
```

shop-ce pins `symfony/console ^3.4.15`, and the entire Symfony stack (dependency-injection, event-dispatcher, config, lock, finder) is on the 3.4 line — **EOL since November 2021**. Bumping symfony/yaml alone is blocked by the console conflict and would cascade into a full Symfony 3.4 → 5.4 stack migration. That migration is the actual root-cause fix (it covers far more than these three Low CVEs) and is tracked as a separate issue rather than forced into v1.6.1.

## Finding 2 — symfony/polyfill-intl-idn < 1.38.1 (o3-shop/testing-library)

| | |
|---|---|
| Dependency | `symfony/polyfill-intl-idn` (dev-only, via `o3-shop/testing-library`) |
| Fixed in | 1.38.1 |
| CVE | CVE-2026-46644 (Low) |

### Exploitability in O3-Shop: **effectively zero**

- `o3-shop/testing-library` is a `require-dev` dependency — **production deploys (`composer install --no-dev`) never install the polyfill**.
- The polyfill only executes on PHP installations lacking `ext-intl`; with intl present it is dead code.
- It is exercised only in test/CI environments, never by attacker-facing code paths.

### Fix

`testing-library/composer.json` already requires `^1.38.1` (the fixed version). Resolving the alert only requires a testing-library release and a refresh of shop-ce's dev lockfile (`composer update symfony/polyfill-intl-idn`).

## Summary for operators

| Finding | Production impact | Action |
|---|---|---|
| symfony/yaml DoS CVEs | None — parser never sees untrusted input | Deferred to Symfony stack migration (separate issue) |
| polyfill-intl-idn CVE | None — dev-only dependency | Dev lockfile bumped to ≥ 1.38.1 |

No action is required by shop operators. No O3-Shop installation is attackable through these CVEs in its shipped configuration.
