### PR TITLE
fix: use INSERT IGNORE for o3-theme oxconfigdisplay block in initial_…

### DIFF
--- a/source/Setup/Sql/initial_data.sql
+++ b/source/Setup/Sql/initial_data.sql
@@ -572,7 +572,7 @@ VALUES ('0d8f69efe8c663a61ce8933924bdbcdc', 'theme:wave', 'sShoppingLanguage', '
        ('fabba377ba7d7bd8925c8c4eae460ee5', 'theme:wave', 'blUseGAPageTracker', 'googleanalytics', '', 1);
 
 
-INSERT INTO `oxconfigdisplay` (`OXID`, `OXCFGMODULE`, `OXCFGVARNAME`, `OXGROUPING`, `OXVARCONSTRAINT`, `OXPOS`)
+INSERT IGNORE INTO `oxconfigdisplay` (`OXID`, `OXCFGMODULE`, `OXCFGVARNAME`, `OXGROUPING`, `OXVARCONSTRAINT`, `OXPOS`)
 VALUES ('091fa9cc622351c270d5522741a21695', 'theme:o3-theme', 'sYouTubeUrl', 'footer', '', 1),
        ('0b92e29245168b65f136ab55c30471b7', 'theme:o3-theme', 'sShippingDaysOnStock', 'googlets', '', 1),
        ('0d91c1227bca0842b946b67270e1f7e4', 'theme:o3-theme', 'sSliderInterval', 'slider', '', 1),


### PR DESCRIPTION
demodata.sql runs before initial_data.sql in the setup wizard and inserts all theme:o3-theme oxconfigdisplay rows with fixed OXIDs. The plain INSERT INTO on the o3-theme block aborts on the first PK conflict, preventing the 8 color settings (added in #165) from being created.

INSERT IGNORE lets the duplicates from demodata.sql be silently skipped while ensuring the color entries are inserted correctly.

Related: o3-shop/shop-demodata-ce#183