### PR TITLE
bin/release: print a click-and-finish checklist at end of a live run

### DIFF
--- a/source/Internal/ReleaseTooling/Command/ReleaseCommand.php
+++ b/source/Internal/ReleaseTooling/Command/ReleaseCommand.php
@@ -265,8 +265,7 @@ class ReleaseCommand extends Command
             $this->printPartialState($executor, $output);
             return self::EXIT_PLAN_ERROR;
         }
-        $this->printPartialState($executor, $output);
-        $output->writeln('<info>Live execution complete. Publish the draft GitHub releases manually.</info>');
+        $this->printFinishChecklist($executor, $output);
         return self::EXIT_OK;
     }
 
@@ -486,6 +485,57 @@ class ReleaseCommand extends Command
         }
         $repoPaths[$package] = $path;
         return null;
+    }
+
+    /**
+     * Success-path summary: the manual steps that finish the release,
+     * each as a click-to-finish URL — draft releases to publish first,
+     * then the merge-back PRs (final releases only). The failure path
+     * keeps printPartialState()'s neutral "here's what got created
+     * before the error" framing instead, so a crash never reads as a
+     * completed release.
+     */
+    private function printFinishChecklist(LiveExecutor $executor, OutputInterface $output): void
+    {
+        $groups = [];
+        $releases = $executor->releaseUrls();
+        if ($releases !== []) {
+            $groups[] = [
+                'Publish the draft GitHub releases (open each, then click "Publish release"):',
+                $releases,
+            ];
+        }
+        $mergeBacks = $executor->mergeBackUrls();
+        if ($mergeBacks !== []) {
+            $groups[] = [
+                'Review and merge the merge-back PRs (release branch -> main):',
+                $mergeBacks,
+            ];
+        }
+
+        $output->writeln('');
+        if ($groups === []) {
+            $output->writeln('<info>Live execution complete. Nothing to publish or merge.</info>');
+            return;
+        }
+
+        // Align every URL under the widest package name across all groups
+        // so the two lists read as one column.
+        $width = 0;
+        foreach ($groups as [, $urls]) {
+            foreach (array_keys($urls) as $package) {
+                $width = max($width, strlen($package));
+            }
+        }
+
+        $output->writeln('<info>To finish the release:</info>');
+        foreach ($groups as $index => [$label, $urls]) {
+            $output->writeln('');
+            $output->writeln(sprintf('  %d. %s', $index + 1, $label));
+            foreach ($urls as $package => $url) {
+                $output->writeln(sprintf('       %s  %s', str_pad($package, $width), $url));
+            }
+        }
     }
 
     private function printPartialState(LiveExecutor $executor, OutputInterface $output): void

--- a/tests/Unit/Internal/ReleaseTooling/Command/ReleaseCommandTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Command/ReleaseCommandTest.php
@@ -346,7 +346,7 @@ class ReleaseCommandTest extends TestCase
 
     /* ---------- partial-state printing on live success ---------- */
 
-    public function testLiveSuccessPrintsCapturedReleaseAndMergeBackUrls(): void
+    public function testLiveSuccessPrintsFinishChecklist(): void
     {
         $tmpRepoPath = $this->makeFakeGitRepo();
         $stub = new StubReleasePlanner(new ReleasePlan(
@@ -360,7 +360,10 @@ class ReleaseCommandTest extends TestCase
         ));
         $executor = new RecordingLiveExecutor(
             false,
-            ['o3-shop/shop-ce' => 'https://github.com/o3-shop/shop-ce/releases/draft/v1.6.1'],
+            [
+                'o3-shop/shop-ce' => 'https://github.com/o3-shop/shop-ce/releases/draft/v1.6.1',
+                'o3-shop/o3-shop' => 'https://github.com/o3-shop/o3-shop/releases/draft/v1.6.1',
+            ],
             ['o3-shop/shop-ce' => 'https://github.com/o3-shop/shop-ce/pull/200']
         );
         $tester = new CommandTester(new ReleaseCommand($stub, null, $executor));
@@ -372,10 +375,73 @@ class ReleaseCommandTest extends TestCase
 
         $display = $tester->getDisplay();
         $this->assertSame(ReleaseCommand::EXIT_OK, $status);
-        $this->assertStringContainsString('Draft GitHub releases created:', $display);
-        $this->assertStringContainsString('o3-shop/shop-ce -> https://github.com/o3-shop/shop-ce/releases/draft/v1.6.1', $display);
-        $this->assertStringContainsString('Merge-back PRs opened:', $display);
-        $this->assertStringContainsString('o3-shop/shop-ce -> https://github.com/o3-shop/shop-ce/pull/200', $display);
+        $this->assertStringContainsString('To finish the release:', $display);
+        $this->assertStringContainsString('Publish the draft GitHub releases', $display);
+        $this->assertStringContainsString('https://github.com/o3-shop/shop-ce/releases/draft/v1.6.1', $display);
+        $this->assertStringContainsString('https://github.com/o3-shop/o3-shop/releases/draft/v1.6.1', $display);
+        $this->assertStringContainsString('Review and merge the merge-back PRs', $display);
+        $this->assertStringContainsString('https://github.com/o3-shop/shop-ce/pull/200', $display);
+        // Success path drops the neutral partial-state framing.
+        $this->assertStringNotContainsString('Draft GitHub releases created:', $display);
+        $this->cleanupFakeGitRepo($tmpRepoPath);
+    }
+
+    public function testLiveSuccessOmitsMergeBackGroupForPreRelease(): void
+    {
+        $tmpRepoPath = $this->makeFakeGitRepo();
+        $stub = new StubReleasePlanner(new ReleasePlan(
+            'v1.6.0',
+            'v1.6.1-RC1',
+            new FromSnapshot([]),
+            [],
+            [],
+            '',
+            []
+        ));
+        $executor = new RecordingLiveExecutor(
+            false,
+            ['o3-shop/shop-ce' => 'https://github.com/o3-shop/shop-ce/releases/draft/v1.6.1-RC1'],
+            []
+        );
+        $tester = new CommandTester(new ReleaseCommand($stub, null, $executor));
+        $status = $tester->execute([
+            '--from' => 'v1.6.0',
+            '--to' => 'v1.6.1-RC1',
+            '--repo-path' => ['o3-shop/shop-ce=' . $tmpRepoPath],
+        ]);
+
+        $display = $tester->getDisplay();
+        $this->assertSame(ReleaseCommand::EXIT_OK, $status);
+        $this->assertStringContainsString('To finish the release:', $display);
+        $this->assertStringContainsString('Publish the draft GitHub releases', $display);
+        $this->assertStringNotContainsString('Review and merge the merge-back PRs', $display);
+        $this->cleanupFakeGitRepo($tmpRepoPath);
+    }
+
+    public function testLiveSuccessWithNothingToFinishPrintsNothingMessage(): void
+    {
+        $tmpRepoPath = $this->makeFakeGitRepo();
+        $stub = new StubReleasePlanner(new ReleasePlan(
+            'v1.6.0',
+            'v1.6.1',
+            new FromSnapshot([]),
+            [],
+            [],
+            '',
+            []
+        ));
+        $executor = new RecordingLiveExecutor(false, [], []);
+        $tester = new CommandTester(new ReleaseCommand($stub, null, $executor));
+        $status = $tester->execute([
+            '--from' => 'v1.6.0',
+            '--to' => 'v1.6.1',
+            '--repo-path' => ['o3-shop/shop-ce=' . $tmpRepoPath],
+        ]);
+
+        $display = $tester->getDisplay();
+        $this->assertSame(ReleaseCommand::EXIT_OK, $status);
+        $this->assertStringContainsString('Nothing to publish or merge.', $display);
+        $this->assertStringNotContainsString('To finish the release:', $display);
         $this->cleanupFakeGitRepo($tmpRepoPath);
     }
 


### PR DESCRIPTION
## What

On a **successful** `bin/release` live run, replace the raw two-list dump + the `Publish the draft GitHub releases manually.` line with a single action-labeled **"To finish the release:"** block — the two groups of click-to-finish URLs, nothing else.

```
To finish the release:

  1. Publish the draft GitHub releases (open each, then click "Publish release"):
       o3-shop/shop-ce              https://github.com/o3-shop/shop-ce/releases/tag/untagged-…
       o3-shop/shop-metapackage-ce  https://github.com/o3-shop/shop-metapackage-ce/releases/tag/untagged-…
       o3-shop/o3-shop              https://github.com/o3-shop/o3-shop/releases/tag/untagged-…

  2. Review and merge the merge-back PRs (release branch -> main):
       o3-shop/shop-ce              https://github.com/o3-shop/shop-ce/pull/168
```

## Details

- New private `ReleaseCommand::printFinishChecklist()`, called on the success path.
- **Failure path unchanged** — keeps `printPartialState()`'s neutral "here's what got created before the error" framing, so a crash never reads as a completed release.
- **Pre-release runs** (no merge-back PRs) omit group 2; an all-`unchanged` run prints `Nothing to publish or merge.`.
- Package names left-padded so URLs align in one column.
- **No change to `LiveExecutor`** — the captured publish/PR URLs are reused verbatim.

## Tests

`tests/Unit/Internal/ReleaseTooling/Command/ReleaseCommandTest.php` (TDD): success path asserts the new headers + both groups' URLs; a pre-release case asserts group 2 is omitted; an all-empty case asserts `Nothing to publish or merge.`; the failure-path test is untouched.

Targeted suite green (40 tests, 87 assertions); cs-fixer clean.

Closes o3-shop/o3-shop#188