### PR TITLE
Wire tinymce-editor module as a dev satellite (#194)

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -27,3 +27,4 @@ Shared memory for all Claude agents working in this repository. Read this first,
 - [bin/release intermediate-node re-tag gap](release-tooling-intermediate-node-retag-gap.md) — resolver "reuses" an intermediate fat node (the metapackage) while bumping its child pin → orphaned edit; force a re-tag during the fold-out cut (#169)
 - [!] [cs-fixer dirties nested clones](cs-fixer-pollutes-nested-clones.md) — ./docker.sh cs-fixer reformats testing-library/themes/demodata clones → aborts bin/release pre-flight; clean them before a cut
 - [!] [ExitHandler interface-guard bug](shop-ce-exithandler-interface-guard-bug.md) — bootstrap.php uses class_exists() on the ExitHandlerInterface (always false) → fresh-install Setup redirect dies in a DB-error loop; fix: interface_exists()
+- [tinymce-editor module](tinymce-editor-module.md) — admin WYSIWYG editor is a sibling repo; vendors TinyMCE in out/, no test suite; TinyMCE 7 upgrade notes (#194)

--- a/.claude/memory/tinymce-editor-module.md
+++ b/.claude/memory/tinymce-editor-module.md
@@ -1,0 +1,56 @@
+---
+name: tinymce-editor-module
+description: tinymce-editor is a sibling repo (not in shop-ce); how it vendors TinyMCE, its build, and the v7 upgrade
+type: reference
+---
+
+# o3-shop/tinymce-editor module
+
+The admin WYSIWYG editor module is a **separate repo**, not in shop-ce. Locally:
+`/Users/nick/o3/tinymce-editor`. It is pulled into the product via the metapackage
+(`shop-metapackage-ce` / `o3-shop`), **not** via `shop-ce/composer.json` (which does not
+require it). The editor source therefore is NOT in this checkout.
+
+## Layout / how it works
+- Vendors the editor under `out/tinymce/` — **committed to git**, not fetched at install.
+- Builds its `tinymce.init({...})` config from PHP classes: `Application/Core/TinyMCE/`
+  `Configuration.php` (assembles options), `Options/*` (one class per init option,
+  implement `OptionInterface`: `getKey`/`get`/`isQuoted`/`requireRegistration`),
+  `PluginList.php` + `Plugins/*`, `Toolbar/*` + `ToolbarList.php`.
+- Custom JS plugins live in `build/plugins/{oxfullscreen,roxy}/plugin.js` and are copied
+  **verbatim** (no minify) to `out/plugins/.../plugin.js`. Keep the two copies identical.
+- `build/3_build.js` just copies dirs into `_module/`; `build/4_publish.js` git-commits.
+- The module has **no automated test suite** — verification is manual admin QA. It does
+  ship `.php-cs-fixer.php` + `phpstan.neon`, but those need the module living inside a shop
+  checkout at `source/modules/o3-shop/tinymce-editor`. Host has php/node/npm for `php -l` /
+  `node --check`.
+
+## v2.0.0 upgrade — TinyMCE 6.4.1 → 7.9.3 (issue #194, CVE-2026-47759/47761/47762)
+- `build/update.sh` (was a dead TinyMCE-4 cloud URL) now does `npm pack tinymce@<ver>` and
+  stages the tree into `out/tinymce/`, **preserving `out/tinymce/langs/`** (npm ships no
+  language packs). Re-run it to bump: `./build/update.sh 7.9.3`.
+- TinyMCE 7.x renamed the license file `license.txt` → `license.md` — update.sh copies both
+  names; ship `license.md` for GPL compliance.
+- **TinyMCE 7 breaking changes that hit this module:** (1) `license_key` now required —
+  added `Options/LicenseKey.php` returning `'gpl'`; (2) `editor.settings` removed — the
+  `roxy` file-picker plugin was ported to `editor.options.register/get/set`; (3) `fullpage`
+  + `legacyoutput` plugins were removed back in 6.0 (phantom 404s) — deleted their PHP
+  classes. `file_picker_callback` is safe to `editor.options.set(...)` because the silver
+  theme registers it before plugins init.
+- Editor license is **GPL-2.0-or-later** — compatible with the module's GPL-3.0; module
+  license stays GPL-3.0.
+- Custom `oxfullscreen` button is named `fullscreen` (toggles the admin frameset) — distinct
+  from the removed `fullpage`.
+- **TinyMCE 7 validates option value types.** The old `MaxHeight`/`MaxWidth` options emitted
+  `'90%'`, which 7.x rejects (`Invalid value passed for the max_height option. The value must
+  be a number.`) — numeric px only. They were inert in 6.x. Dropped both options. If a cap is
+  ever wanted, emit a numeric px value, not a percentage.
+- The editor's `content_css` points at the active theme's compiled CSS
+  (`/out/<theme>/src/css/styles.min.css`). In a dev shop without built theme assets this 404s
+  in the editor console — environmental, NOT a module bug (the storefront 404s it too).
+- **Two clones exist:** the module is checked out both at `/Users/nick/o3/tinymce-editor`
+  (original) and at `/Users/nick/o3/shop-ce/tinymce-editor` (the satellite the shop actually
+  runs via the source/modules symlink). They diverge — the satellite is the live/canonical one
+  for shop QA. Commit/push the #194 branch from the satellite.
+- Follow-up after the module release is tagged: bump the product reference in metapackage /
+  o3-shop, then re-scan the trowow image.

--- a/.gitignore
+++ b/.gitignore
@@ -101,4 +101,10 @@ oxideshop.log
 # Satellite working tree for testing-library (same pattern as shop-demodata-ce).
 /testing-library
 
+# Satellite working tree for the tinymce-editor module (same pattern). The
+# top-level clone is symlinked into source/modules/o3-shop/tinymce-editor by
+# the docker entrypoint, so ignore both the clone and the symlink.
+/tinymce-editor
+/source/modules/o3-shop/tinymce-editor
+
 /graphify-out

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "OxidEsales\\EshopCommunity\\Tests\\": "./tests"
+            "OxidEsales\\EshopCommunity\\Tests\\": "./tests",
+            "O3\\TinyMCE\\": "./source/modules/o3-shop/tinymce-editor"
         }
     },
     "minimum-stability": "dev",

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -322,6 +322,64 @@ setup_db() {
 
 
 
+install_tinymce_editor() {
+    local repo_url="https://github.com/o3-shop/tinymce-editor.git"
+    local satellite_dir="tinymce-editor"
+    local symlink_path="source/modules/o3-shop/tinymce-editor"
+
+    log "${YELLOW}Installing tinymce-editor module satellite...${NC}"
+
+    # Same satellite pattern as testing-library/shop-demodata-ce: the working
+    # tree lives at the project top level (gitignored) so PhpStorm doesn't
+    # auto-exclude it and developers see modified-file indicators without
+    # per-IDE config. tinymce-editor is an oxideshop-module, so its home is
+    # source/modules/<vendor>/<module> (not vendor/); we symlink that path
+    # -> ../../../tinymce-editor so OXID discovers the module from the
+    # working tree.
+
+    if [ -d "$satellite_dir" ] && [ "$(ls -A "$satellite_dir")" ]; then
+        if [ ! -d "$satellite_dir/.git" ]; then
+            handle_error "$(cat <<EOF
+
+Detected detached snapshot at ./${satellite_dir}/ (no .git/ subdirectory).
+The entrypoint expects a git working tree there so tinymce-editor changes
+can be committed and pushed back to ${repo_url} directly.
+
+Run:
+
+    ./docker.sh stop
+    rm -rf ${satellite_dir} ${symlink_path}
+    ./docker.sh start
+
+Aborting so no work is destroyed.
+EOF
+            )"
+        fi
+        log "tinymce-editor: satellite working tree already present, skipping clone"
+    else
+        log "Cloning tinymce-editor from ${repo_url}..."
+        git clone "$repo_url" "$satellite_dir" \
+            || handle_error "Failed to clone tinymce-editor from ${repo_url}"
+    fi
+
+    # Replace any real directory at the module path with a symlink to the
+    # satellite working tree.
+    if [ -e "$symlink_path" ] && [ ! -L "$symlink_path" ]; then
+        log "Replacing real ${symlink_path} with symlink to satellite..."
+        rm -rf "$symlink_path" \
+            || handle_error "Failed to remove ${symlink_path}"
+    fi
+
+    if [ ! -e "$symlink_path" ]; then
+        mkdir -p "$(dirname "$symlink_path")" \
+            || handle_error "Failed to create $(dirname "$symlink_path")"
+        ln -s "../../../${satellite_dir}" "$symlink_path" \
+            || handle_error "Failed to symlink ${symlink_path} -> ../../../${satellite_dir}"
+    fi
+
+    log "${GREEN}tinymce-editor module ready${NC}"
+}
+
 # Main execution
 main() {
     echo "setup is running" > /tmp/o3setup-running
@@ -332,6 +390,7 @@ main() {
     install_dependencies || exit 127
     install_testing_library || exit 127
     install_demodata || exit 127
+    install_tinymce_editor || exit 127
     setup_db || exit 127
     install_theme || exit 127
     install_o3_theme || exit 127


### PR DESCRIPTION
Supporting dev-environment change for o3-shop/o3-shop#194 (TinyMCE 7 upgrade). Wires the `tinymce-editor` module into the local dev/test setup so it can be installed, activated, and QA'd against a running shop — using the same **satellite working-tree** pattern as `testing-library` / `shop-demodata-ce`.

## Changes
- **`docker/entrypoint.sh`** — `install_tinymce_editor()` clones the module at the project top level and symlinks it into `source/modules/o3-shop/tinymce-editor`. (It's an `oxideshop-module`, so its home is `source/modules/<vendor>/`, not `vendor/`.) Includes the same detached-snapshot safety guard as the other satellites.
- **`.gitignore`** — ignore the satellite clone (`/tinymce-editor`) and the module symlink.
- **`composer.json`** — register `O3\TinyMCE\` in `autoload-dev` so the module's classes load and it activates from the working tree.
- **`.claude/memory`** — notes on the module layout, the TinyMCE 7 upgrade, and the v7 option-validation gotchas.

The companion module fix is o3-shop/tinymce-editor#3.

> Note: the unrelated `cve-notice.md` working-tree change is intentionally **not** included in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
