### PR TITLE
fix: guard image-decode failures in resize helpers (PHP 8 TypeError → HTTP 500)

### DIFF
--- a/source/Core/utils/oxpicgenerator.php
+++ b/source/Core/utils/oxpicgenerator.php
@@ -157,7 +157,14 @@ if (!function_exists('resizeGif')) {
         if (is_array($aResult)) {
             list($iNewWidth, $iNewHeight) = $aResult;
             $hDestinationImage = imagecreatetruecolor($iNewWidth, $iNewHeight);
-            $hSourceImage = imagecreatefromgif($sSrc);
+            $hSourceImage = @imagecreatefromgif($sSrc);
+            if ($hSourceImage === false) {
+                \OxidEsales\Eshop\Core\Registry::getLogger()->error(
+                    __FUNCTION__ . " - Could not decode source GIF '$sSrc'."
+                );
+                imagedestroy($hDestinationImage);
+                return false;
+            }
 
             $iFillColor = imagecolorresolve($hDestinationImage, 255, 255, 255);
             imagefill($hDestinationImage, 0, 0, $iFillColor);
@@ -198,7 +205,13 @@ if (!function_exists('resizePng')) {
             if ($hDestinationImage === null) {
                 $hDestinationImage = imagecreatetruecolor($iNewWidth, $iNewHeight);
             }
-            $hSourceImage = imagecreatefrompng($sSrc);
+            $hSourceImage = @imagecreatefrompng($sSrc);
+            if ($hSourceImage === false) {
+                \OxidEsales\Eshop\Core\Registry::getLogger()->error(
+                    __FUNCTION__ . " - Could not decode source PNG '$sSrc'."
+                );
+                return false;
+            }
             if (!imageistruecolor($hSourceImage)) {
                 $hDestinationImage = imagecreate($iNewWidth, $iNewHeight);
                 // fix for transparent images sets image to transparent
@@ -246,7 +259,13 @@ if (!function_exists('resizeJpeg')) {
             if ($hDestinationImage === null) {
                 $hDestinationImage = imagecreatetruecolor($iNewWidth, $iNewHeight);
             }
-            $hSourceImage = imagecreatefromstring(file_get_contents($sSrc));
+            $hSourceImage = @imagecreatefromstring((string) @file_get_contents($sSrc));
+            if ($hSourceImage === false) {
+                \OxidEsales\Eshop\Core\Registry::getLogger()->error(
+                    __FUNCTION__ . " - Could not decode source JPEG '$sSrc'."
+                );
+                return false;
+            }
             if (copyAlteredImage($hDestinationImage, $hSourceImage, $iNewWidth, $iNewHeight, $aImageInfo, $sTarget, $iGdVer)) {
                 imagejpeg($hDestinationImage, $sTarget, $iDefQuality);
                 imagedestroy($hDestinationImage);

--- a/tests/Unit/Core/UtilsPicTest.php
+++ b/tests/Unit/Core/UtilsPicTest.php
@@ -122,6 +122,51 @@ class UtilsPicTest extends \OxidTestCase
         $this->assertTrue($this->_resizeImageTest($sTestImageFilePNG, $sTestImageFileResizedPNG, 21, 10));
     }
 
+    /**
+     * resizePng()/resizeJpeg()/resizeGif() must not throw a TypeError when the
+     * source image cannot be decoded (imagecreatefrom*() returns false under
+     * PHP 8). They must return false so the picture pipeline can fall back to a
+     * 404 / placeholder instead of bubbling up as an HTTP 500.
+     *
+     * @see https://github.com/o3-shop/o3-shop/issues/174
+     */
+    public function testResizeFunctionsReturnFalseForUndecodableSource()
+    {
+        // Ensure the procedural resize functions from oxpicgenerator.php are loaded.
+        \OxidEsales\Eshop\Core\Registry::getUtilsPic();
+
+        $sDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR;
+        $iGdVer = getGdVersion();
+        // Pretend the source is 200x200 so a resize down to 100x100 is actually triggered.
+        $aImageInfo = [200, 200];
+
+        $aResizers = [
+            'png' => function ($sSrc, $sTarget) use ($aImageInfo, $iGdVer) {
+                return resizePng($sSrc, $sTarget, 100, 100, $aImageInfo, $iGdVer, null);
+            },
+            'jpg' => function ($sSrc, $sTarget) use ($aImageInfo, $iGdVer) {
+                return resizeJpeg($sSrc, $sTarget, 100, 100, $aImageInfo, $iGdVer, null, 90);
+            },
+            'gif' => function ($sSrc, $sTarget) use ($iGdVer) {
+                return resizeGif($sSrc, $sTarget, 100, 100, 200, 200, $iGdVer);
+            },
+        ];
+
+        foreach ($aResizers as $sExt => $callResizer) {
+            $sSrc = $sDir . 'o3_174_broken_source.' . $sExt;
+            $sTarget = $sDir . 'o3_174_broken_target.' . $sExt;
+            file_put_contents($sSrc, 'this is not a valid image'); // imagecreatefrom*() -> false
+
+            $mResult = $callResizer($sSrc, $sTarget);
+
+            $this->assertFalse($mResult, "resize for '$sExt' must return false for an undecodable source");
+            $this->assertFalse(is_file($sTarget), "resize for '$sExt' must not write a target from an undecodable source");
+
+            @unlink($sSrc);
+            @unlink($sTarget);
+        }
+    }
+
     protected function _resizeImageTest($sTestImageFile, $sTestImageFileResized, $iWidth = 100, $iHeight = 48)
     {
         $sDir = __DIR__ . '/../testData/misc' . DIRECTORY_SEPARATOR;


### PR DESCRIPTION
Fixes o3-shop/o3-shop#174.

`resizePng()` / `resizeJpeg()` / `resizeGif()` in `source/Core/utils/oxpicgenerator.php` passed the result of `imagecreatefrompng()` / `imagecreatefromstring()` / `imagecreatefromgif()` straight into GD functions (`imageistruecolor()`, `imagecopyresampled()`) without checking for `false`. Under PHP 8, when a source image cannot be decoded the loader returns `false` and the GD call throws:

```
TypeError: imageistruecolor(): Argument #1 ($image) must be of type GdImage, bool given
```

The exception bubbles through `DynamicImageGenerator::outputImage()` and the bare `getimg.php` entrypoint, so the client gets an HTTP **500** with no useful indication of which master file is broken.

## Fix
Each resize helper now:
- suppresses the loader's own GD warning,
- logs a clear error (e.g. `Could not decode source PNG '<path>'.`) via `Registry::getLogger()`,
- returns `false`.

The picture pipeline already converts a `false` from `_generateImage()` into a **404** (`getImagePath()` → `outputImage()`), so the request now degrades gracefully instead of 500ing. No change to `getimg.php` is required for this bug.

## Test
Adds `UtilsPicTest::testResizeFunctionsReturnFalseForUndecodableSource`, covering all three helpers with an undecodable source. It reproduces the exact `TypeError` before the fix and passes after. Existing real-fixture resize tests and `DynImgGeneratorTest` still pass; full unit suite green.

## Scope
Kept tightly scoped to the `TypeError`, as the issue recommends. The upstream causes noted in the issue (mismatched filename extension on upload, zero-byte master files) and a top-level `getimg.php` try/catch are left as separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

