### PR TITLE
Setup mod_rewrite check false-negatives behind reverse proxy / DDEV (blocks install)

### DIFF
--- a/.claude/memory/testing-patterns.md
+++ b/.claude/memory/testing-patterns.md
@@ -20,6 +20,15 @@ type: reference
 - PHPSpec Prophecy (`phpspec/prophecy-phpunit`)
 - Use `$this->prophesize(SomeClass::class)` — not PHPUnit's built-in mocks
 - Reveal the mock: `$mock->reveal()`
+- Exception: legacy `\OxidTestCase`-based tests (e.g. `tests/Unit/Core/*`) use PHPUnit's built-in
+  mocks (`getMockBuilder(...)->onlyMethods([...])`). Match the style already in the file.
+
+## Calling protected/`_`-prefixed methods from tests
+- `Core\Base::__call` (active when `OXID_PHP_UNIT` is defined) maps a `UNIT`-prefixed call to the
+  underscore method: `$obj->UNITcheckModRewrite($x)` invokes the protected `_checkModRewrite($x)`.
+- To unit-test the logic of a protected method that does I/O, extract the I/O into its own protected
+  `_`-method, then partial-mock that seam: `getMockBuilder(Cls)->onlyMethods(['_doIo'])` and stub it,
+  while calling the method under test via its `UNIT...` alias so the real logic runs.
 
 ## Bootstrap
 - Fast mode uses `vendor/o3-shop/testing-library/bootstrap.php`

--- a/source/Core/SystemRequirements.php
+++ b/source/Core/SystemRequirements.php
@@ -466,8 +466,28 @@ class SystemRequirements
     {
         // got here from setup dir
         $sScript = $_SERVER['SCRIPT_NAME'];
-        $iPort = (int) $_SERVER['SERVER_PORT'];
-        $blSsl = (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on'));
+
+        // Behind a reverse proxy / TLS terminator (DDEV, Traefik, nginx ingress, load balancer) the
+        // PHP process sees the *internal* scheme/port (typically plain HTTP on 80) while the client
+        // reached the proxy over HTTPS. Honor the forwarded headers so the mod_rewrite self-probe
+        // dials the public scheme/port the proxy serves and loops back cleanly, instead of hitting an
+        // HTTP->HTTPS redirect that would make the probe undeterminable. These headers are only used
+        // for the local loopback probe (never for auth or URL generation), so trusting them here is
+        // harmless: a spoofed value at worst makes the probe fail and degrade to a warning.
+        $blForwardedHttps = (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])
+                && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https')
+            || (isset($_SERVER['HTTP_X_FORWARDED_SSL'])
+                && strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) === 'on');
+        $blSsl = $blForwardedHttps || (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on'));
+
+        if (!empty($_SERVER['HTTP_X_FORWARDED_PORT'])) {
+            $iPort = (int) $_SERVER['HTTP_X_FORWARDED_PORT'];
+        } elseif (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) || isset($_SERVER['HTTP_X_FORWARDED_SSL'])) {
+            // a proxy terminated the connection: SERVER_PORT is the internal port, not the public one
+            $iPort = $blSsl ? 443 : 80;
+        } else {
+            $iPort = (int) $_SERVER['SERVER_PORT'];
+        }
         if (!$iPort) {
             $iPort = $blSsl ? 443 : 80;
         }
@@ -553,33 +573,67 @@ class SystemRequirements
      */
     protected function _checkModRewrite($aHostInfo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     {
-        $sHostname = ($aHostInfo['ssl'] ? 'ssl://' : '') . $aHostInfo['host'];
-        if ($rFp = @fsockopen($sHostname, $aHostInfo['port'], $iErrNo, $sErrStr, 10)) {
-            $sReq = "POST {$aHostInfo['dir']}oxseo.php?mod_rewrite_module_is=off HTTP/1.1\r\n";
-            $sReq .= "Host: {$aHostInfo['host']}\r\n";
-            $sReq .= "User-Agent: O3-Shop setup\r\n";
-            $sReq .= "Content-Type: application/x-www-form-urlencoded\r\n";
-            $sReq .= "Content-Length: 0\r\n"; // empty post
-            $sReq .= "Connection: close\r\n\r\n";
+        $sOut = $this->_getModRewriteResponse($aHostInfo);
 
-            $sOut = '';
-            fwrite($rFp, $sReq);
-            while (!feof($rFp)) {
-                $sOut .= fgets($rFp, 100);
+        if ($sOut !== false) {
+            // The probe (POST oxseo.php?mod_rewrite_module_is=off) reached a server that answered.
+            // Classify three ways instead of two, so an undeterminable answer does not block setup:
+            //   - 'mod_rewrite_on'  -> the RewriteRule rewrote off->on, mod_rewrite is confirmed working
+            //   - 'mod_rewrite_off' -> the request reached oxseo.php unrewritten, mod_rewrite is genuinely off
+            //   - neither marker    -> a redirect / reverse proxy / TLS terminator (e.g. DDEV) answered;
+            //                          we cannot tell, so warn instead of blocking the install
+            if (strpos($sOut, 'mod_rewrite_on') !== false) {
+                $iModStat = static::MODULE_STATUS_OK;
+            } elseif (strpos($sOut, 'mod_rewrite_off') !== false) {
+                $iModStat = static::MODULE_STATUS_BLOCKS_SETUP;
+            } else {
+                $iModStat = static::MODULE_STATUS_UNABLE_TO_DETECT;
             }
-            fclose($rFp);
-
-            $iModStat = (strpos($sOut, 'mod_rewrite_on') !== false) ? 2 : 0;
         } else {
             if (function_exists('apache_get_modules')) {
-                // it does not assure that mod_rewrite is enabled on current host, so setting 1
-                $iModStat = in_array('mod_rewrite', apache_get_modules()) ? 1 : 0;
+                // mod_rewrite missing from the loaded modules is positive proof it is absent;
+                // its presence does not assure it is enabled for this host, so only flag the minimum.
+                $iModStat = in_array('mod_rewrite', apache_get_modules())
+                    ? static::MODULE_STATUS_FITS_MINIMUM_REQUIREMENTS
+                    : static::MODULE_STATUS_BLOCKS_SETUP;
             } else {
-                $iModStat = -1;
+                $iModStat = static::MODULE_STATUS_UNABLE_TO_DETECT;
             }
         }
 
         return $iModStat;
+    }
+
+    /**
+     * Performs the mod_rewrite self-probe: opens a socket back to the shop and POSTs to
+     * oxseo.php?mod_rewrite_module_is=off, returning the raw HTTP response.
+     *
+     * @param array $aHostInfo host info (host, port, dir, ssl)
+     *
+     * @return string|false the raw response, or false if the socket could not be opened
+     */
+    protected function _getModRewriteResponse($aHostInfo) // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        $sHostname = ($aHostInfo['ssl'] ? 'ssl://' : '') . $aHostInfo['host'];
+        if (!($rFp = @fsockopen($sHostname, $aHostInfo['port'], $iErrNo, $sErrStr, 10))) {
+            return false;
+        }
+
+        $sReq = "POST {$aHostInfo['dir']}oxseo.php?mod_rewrite_module_is=off HTTP/1.1\r\n";
+        $sReq .= "Host: {$aHostInfo['host']}\r\n";
+        $sReq .= "User-Agent: O3-Shop setup\r\n";
+        $sReq .= "Content-Type: application/x-www-form-urlencoded\r\n";
+        $sReq .= "Content-Length: 0\r\n"; // empty post
+        $sReq .= "Connection: close\r\n\r\n";
+
+        $sOut = '';
+        fwrite($rFp, $sReq);
+        while (!feof($rFp)) {
+            $sOut .= fgets($rFp, 100);
+        }
+        fclose($rFp);
+
+        return $sOut;
     }
 
     /**

--- a/tests/Unit/Core/SystemRequirementsTest.php
+++ b/tests/Unit/Core/SystemRequirementsTest.php
@@ -59,6 +59,63 @@ class SystemRequirementsTest extends \OxidTestCase
     }
 
     /**
+     * Probe reached oxseo.php and the RewriteRule fired: mod_rewrite is confirmed working.
+     */
+    public function testCheckModRewriteReturnsOkWhenRewriteFired()
+    {
+        $systemRequirements = $this->getMockBuilder(SystemRequirements::class)
+            ->onlyMethods(['_getModRewriteResponse'])
+            ->getMock();
+        $systemRequirements->method('_getModRewriteResponse')
+            ->willReturn("HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nmod_rewrite_on");
+
+        $this->assertSame(
+            SystemRequirements::MODULE_STATUS_OK,
+            $systemRequirements->UNITcheckModRewrite($this->getModRewriteHostInfoStub())
+        );
+    }
+
+    /**
+     * Probe reached oxseo.php but the RewriteRule did NOT fire: mod_rewrite is genuinely off.
+     */
+    public function testCheckModRewriteBlocksSetupWhenRewriteDidNotFire()
+    {
+        $systemRequirements = $this->getMockBuilder(SystemRequirements::class)
+            ->onlyMethods(['_getModRewriteResponse'])
+            ->getMock();
+        $systemRequirements->method('_getModRewriteResponse')
+            ->willReturn("HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nmod_rewrite_off");
+
+        $this->assertSame(
+            SystemRequirements::MODULE_STATUS_BLOCKS_SETUP,
+            $systemRequirements->UNITcheckModRewrite($this->getModRewriteHostInfoStub())
+        );
+    }
+
+    /**
+     * Probe got a response that contains neither marker (e.g. a reverse-proxy / DDEV 301 redirect):
+     * the result is undeterminable and must NOT block setup.
+     */
+    public function testCheckModRewriteIsUndeterminableWhenNeitherMarkerIsPresent()
+    {
+        $systemRequirements = $this->getMockBuilder(SystemRequirements::class)
+            ->onlyMethods(['_getModRewriteResponse'])
+            ->getMock();
+        $systemRequirements->method('_getModRewriteResponse')
+            ->willReturn("HTTP/1.1 301 Moved Permanently\r\nLocation: https://example.ddev.site/oxseo.php\r\nConnection: close\r\n\r\n");
+
+        $this->assertSame(
+            SystemRequirements::MODULE_STATUS_UNABLE_TO_DETECT,
+            $systemRequirements->UNITcheckModRewrite($this->getModRewriteHostInfoStub())
+        );
+    }
+
+    private function getModRewriteHostInfoStub(): array
+    {
+        return ['host' => '127.0.0.1', 'port' => 80, 'dir' => '/', 'ssl' => false];
+    }
+
+    /**
      * Testing SystemRequirements::checkServerPermissions()
      */
     public function testCheckServerPermissions()
@@ -308,6 +365,63 @@ class SystemRequirementsTest extends \OxidTestCase
             ],
             $systemRequirements->UNITgetShopHostInfoFromServerVars()
         );
+    }
+
+    /**
+     * Behind a reverse proxy / TLS terminator (DDEV, Traefik, nginx ingress, load balancer) the PHP
+     * process sees the internal scheme/port while the client spoke HTTPS to the proxy. The forwarded
+     * headers must take precedence so the mod_rewrite self-probe dials the public scheme/port.
+     *
+     * @dataProvider providerGetShopHostInfoFromServerVarsBehindProxy
+     */
+    public function testGetShopHostInfoFromServerVarsBehindProxy(array $server, array $expected)
+    {
+        $backup = $_SERVER;
+
+        $_SERVER['SCRIPT_NAME'] = '/setup/index.php';
+        $_SERVER['HTTP_HOST'] = 'shop.ddev.site';
+        $_SERVER['HTTPS'] = null;
+        $_SERVER['SERVER_PORT'] = 80;
+        unset(
+            $_SERVER['HTTP_X_FORWARDED_PROTO'],
+            $_SERVER['HTTP_X_FORWARDED_PORT'],
+            $_SERVER['HTTP_X_FORWARDED_SSL']
+        );
+        foreach ($server as $key => $value) {
+            $_SERVER[$key] = $value;
+        }
+
+        $systemRequirements = new SystemRequirements();
+        try {
+            $this->assertEquals(
+                $expected + ['host' => 'shop.ddev.site', 'dir' => '/'],
+                $systemRequirements->UNITgetShopHostInfoFromServerVars()
+            );
+        } finally {
+            $_SERVER = $backup;
+        }
+    }
+
+    public function providerGetShopHostInfoFromServerVarsBehindProxy(): array
+    {
+        return [
+            'X-Forwarded-Proto https, default https port' => [
+                ['HTTP_X_FORWARDED_PROTO' => 'https'],
+                ['port' => 443, 'ssl' => true],
+            ],
+            'X-Forwarded-Proto https with explicit forwarded port' => [
+                ['HTTP_X_FORWARDED_PROTO' => 'https', 'HTTP_X_FORWARDED_PORT' => '8443'],
+                ['port' => 8443, 'ssl' => true],
+            ],
+            'X-Forwarded-Ssl on' => [
+                ['HTTP_X_FORWARDED_SSL' => 'on'],
+                ['port' => 443, 'ssl' => true],
+            ],
+            'X-Forwarded-Proto http stays plain on internal port' => [
+                ['HTTP_X_FORWARDED_PROTO' => 'http'],
+                ['port' => 80, 'ssl' => false],
+            ],
+        ];
     }
 
     public function testCheckTemplateBlockIfTemplateDoNotExists()


### PR DESCRIPTION
Closes o3-shop/o3-shop#195

## Summary

- **Primary fix:** `SystemRequirements::_checkModRewrite()` now classifies the self-probe response three ways instead of two — `mod_rewrite_on` → `MODULE_STATUS_OK`, `mod_rewrite_off` → `MODULE_STATUS_BLOCKS_SETUP`, and **neither marker** → `MODULE_STATUS_UNABLE_TO_DETECT` (warns, does not block). Previously any non-success was treated as "mod_rewrite is off", so a reverse-proxy/DDEV HTTP→HTTPS 301 (whose body contains neither marker) wrongly aborted the install even though mod_rewrite works.
- The inline socket read was extracted into a new protected `_getModRewriteResponse()` seam so the classification is unit-testable.
- **Secondary enhancement:** `_getShopHostInfoFromServerVars()` now honors `X-Forwarded-Proto` / `X-Forwarded-Port` / `X-Forwarded-Ssl`, so behind a TLS terminator (DDEV, Traefik, nginx ingress, load balancer) the probe dials the public scheme/port and loops back cleanly — a clean **pass** rather than just a warning, avoiding the 301 entirely. These headers feed only the local loopback probe (never auth or URL generation), so trusting them is harmless; a spoofed value at worst degrades to the primary fix's warning. Backward compatible when the headers are absent.

## Test plan

- [x] `./docker.sh test --fast tests/Unit/Core/SystemRequirementsTest.php` — all pass (40 tests)
  - 3 classification cases: `mod_rewrite_on` → OK, `mod_rewrite_off` → blocks, 301-redirect body → undeterminable
  - 4 proxy host-info cases: forwarded-https default port, explicit forwarded port, `X-Forwarded-Ssl: on`, forwarded-http stays plain
  - existing no-proxy `testGetShopHostInfoFromServerVars` still passes (backward compatible)
- [x] `./docker.sh test-all-coverage` — full suite green (9693 tests, 17967 assertions), coverage 90.8% (≥90% threshold)
- [x] `./docker.sh cs-fixer` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)