### PR TITLE
setup xdebug in shop-app container for step debugging with IDE

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -30,3 +30,4 @@ Shared memory for all Claude agents working in this repository. Read this first,
 - [!] [cs-fixer dirties nested clones](cs-fixer-pollutes-nested-clones.md) — ./docker.sh cs-fixer reformats testing-library/themes/demodata clones → aborts bin/release pre-flight; clean them before a cut
 - [!] [ExitHandler interface-guard bug](shop-ce-exithandler-interface-guard-bug.md) — bootstrap.php uses class_exists() on the ExitHandlerInterface (always false) → fresh-install Setup redirect dies in a DB-error loop; fix: interface_exists()
 - [tinymce-editor module](tinymce-editor-module.md) — admin WYSIWYG editor is a sibling repo; vendors TinyMCE in out/, no test suite; TinyMCE 7 upgrade notes (#194)
+- [!] [Xdebug step debugging](xdebug-step-debugging.md) — ./docker.sh xdebug on|off|status toggle; Colima needs extra_hosts host-gateway for host.docker.internal (the #82 blocker)

--- a/.claude/memory/xdebug-step-debugging.md
+++ b/.claude/memory/xdebug-step-debugging.md
@@ -1,0 +1,36 @@
+---
+name: xdebug-step-debugging
+description: how the ./docker.sh xdebug toggle works + the Colima host-gateway gotcha that blocked #82
+type: reference
+---
+
+# Xdebug step debugging (#82)
+
+Step debugging is **opt-in** via `./docker.sh xdebug on|off|status`. Off by default =
+coverage-only (`xdebug.mode=coverage`), so the test suite is unaffected.
+
+## How the toggle works
+- `docker-compose.yml` (shop service) sets `PHP_INI_SCAN_DIR=":/var/www/html/docker/xdebug"`.
+  Leading `:` = scan the compiled-in default conf.d **plus** that bind-mounted dir.
+- `xdebug on` copies the committed template `docker/xdebug/zz-xdebug-debug.ini.dist` to the
+  active (gitignored) `docker/xdebug/zz-xdebug-debug.ini`, then `apache2ctl graceful`.
+- PHP only auto-loads files ending in `.ini`, so the `.dist` template is inert until copied.
+  State persists across `./docker.sh start` for free (PHP scans the host file natively).
+- `status` is a pure host-file check (no docker). `on`/`off` need the container running.
+
+## The gotcha that broke every prior attempt (#82)
+On **Colima / plain Linux Docker**, `host.docker.internal` does NOT resolve inside the
+container by default (it's automatic only on Docker Desktop). Xdebug initiates the
+connection *to* the IDE, so without resolution it can never reach it. Fix: the shop service
+has `extra_hosts: ["host.docker.internal:host-gateway"]`. Verified: resolves to the gateway
+(e.g. 192.168.5.2). This single missing entry is why hand-config attempts failed.
+
+## Apply-time costs (easy to forget)
+- Changing compose `environment`/`extra_hosts` → needs a container **recreate** (`up -d`).
+- Changing the baked `xdebug.mode` in the Dockerfile → needs a **rebuild**.
+- The on-config uses `start_with_request=yes`, so while ON every CLI/test process attempts a
+  9003 connection → slow suite. `run_tests()` prints a warning if the active ini is present;
+  run `./docker.sh xdebug off` before the suite.
+
+Dev guide: `docs/development/xdebug-step-debugging.md` (PhpStorm + VS Code). Port 9003,
+path mapping repo-root ↔ `/var/www/html`.

--- a/.claude/memory/xdebug-step-debugging.md
+++ b/.claude/memory/xdebug-step-debugging.md
@@ -25,12 +25,27 @@ connection *to* the IDE, so without resolution it can never reach it. Fix: the s
 has `extra_hosts: ["host.docker.internal:host-gateway"]`. Verified: resolves to the gateway
 (e.g. 192.168.5.2). This single missing entry is why hand-config attempts failed.
 
+## On-config: trigger mode + NO develop (do not revert)
+Active template `docker/xdebug/zz-xdebug-debug.ini.dist` uses `xdebug.mode=debug,coverage`
+and `start_with_request=trigger`. Two hard-won decisions (originally `develop,debug,coverage`
++ `yes`, both caused real pain — see #82 session):
+- **No `develop`**: on PHP 8.2 the old Doctrine DBAL 2.x + Smarty stack emits ~33k
+  `Deprecated` notices PER request; `develop` streams every one to the IDE as an error
+  notification → floods the debug session AND makes PhpStorm pop bogus "path mapping
+  misconfiguration" warnings for the `vendor/` files those notices reference.
+- **`trigger`, not `yes`**: `yes` opens a debug session on EVERY page request and EVERY CLI
+  command (oe-console, composer, even `php -r`). The IDE grabs+pauses them → apache worker
+  pool fills with stuck requests → whole site hangs; CLI commands freeze. `trigger` only
+  activates when a request carries `XDEBUG_TRIGGER` (browser "Xdebug Helper" ext,
+  `?XDEBUG_TRIGGER=1`, or `-e XDEBUG_TRIGGER=1` for CLI).
+
+PhpStorm path mapping: local `source/` → `/var/www/html/source` (DocumentRoot is `source/`).
+
 ## Apply-time costs (easy to forget)
 - Changing compose `environment`/`extra_hosts` → needs a container **recreate** (`up -d`).
 - Changing the baked `xdebug.mode` in the Dockerfile → needs a **rebuild**.
-- The on-config uses `start_with_request=yes`, so while ON every CLI/test process attempts a
-  9003 connection → slow suite. `run_tests()` prints a warning if the active ini is present;
-  run `./docker.sh xdebug off` before the suite.
+- Toggling the ini → `apache2ctl graceful` (the toggle does this). A stuck paused session
+  needs a **hard** `apache2ctl -k restart` to clear workers; graceful won't free them.
 
 Dev guide: `docs/development/xdebug-step-debugging.md` (PhpStorm + VS Code). Port 9003,
 path mapping repo-root ↔ `/var/www/html`.

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,10 @@ composer.lock
 /var/generated/generated_services.yaml
 docker/database/data
 docker/mailpit/data
+
+# Active xdebug step-debugging drop-in, toggled by ./docker.sh xdebug on|off.
+# The .dist template stays tracked; the activated copy is local state.
+docker/xdebug/zz-xdebug-debug.ini
 coverage
 
 !/source/tmp/!.gitkeep

--- a/docker.sh
+++ b/docker.sh
@@ -212,6 +212,59 @@ run_quarantine_tests() {
   $DOCKER_COMPOSE exec shop ./run-tests.sh --quarantine
 }
 
+toggle_xdebug() {
+  GREEN='\033[0;32m'
+  YELLOW='\033[1;33m'
+  RED='\033[0;31m'
+  NC='\033[0m'
+
+  MY_DIR=$(getMyPath)
+  local dist="$MY_DIR/docker/xdebug/zz-xdebug-debug.ini.dist"
+  local active="$MY_DIR/docker/xdebug/zz-xdebug-debug.ini"
+
+  # status needs no container and no docker — just report host-file presence.
+  if [ "$1" = "status" ]; then
+      if [ -f "$active" ]; then
+          echo -e "${GREEN}xdebug step debugging: ON${NC}"
+      else
+          echo -e "${YELLOW}xdebug step debugging: OFF${NC} (coverage-only default)"
+      fi
+      return 0
+  fi
+
+  if [ "$1" != "on" ] && [ "$1" != "off" ]; then
+      echo "Usage: $0 xdebug <on|off|status>"
+      exit 1
+  fi
+
+  cd "$MY_DIR/docker" || { echo "Error: Docker directory not found"; exit 1; }
+  check_docker_compose
+
+  if ! $DOCKER_COMPOSE ps shop 2>/dev/null | grep -q "Up\|running"; then
+      echo -e "${RED} ✗ shop container is NOT running – start it first with './docker.sh start'. ${NC}"
+      exit 1
+  fi
+
+  if [ "$1" = "on" ]; then
+      if [ ! -f "$dist" ]; then
+          echo -e "${RED}Template not found: $dist${NC}"
+          exit 1
+      fi
+      cp "$dist" "$active" || { echo -e "${RED}Failed to write $active${NC}"; exit 1; }
+      $DOCKER_COMPOSE exec shop apache2ctl graceful
+      echo -e "${GREEN}✓ xdebug step debugging ENABLED.${NC}"
+      echo -e "${YELLOW}  → Start your IDE's debug listener on port 9003, then load a page.${NC}"
+      echo -e "${YELLOW}  → Connection log: $DOCKER_COMPOSE exec shop cat /tmp/xdebug.log${NC}"
+      echo -e "${YELLOW}  → Setup guide: docs/development/xdebug-step-debugging.md${NC}"
+  else
+      rm -f "$active"
+      $DOCKER_COMPOSE exec shop apache2ctl graceful
+      echo -e "${GREEN}✓ xdebug step debugging DISABLED (coverage-only).${NC}"
+  fi
+
+  cd "$MY_DIR"
+}
+
 run_npm_audits() {
   GREEN='\033[0;32m'
   RED='\033[0;31m'
@@ -403,6 +456,10 @@ case "$1" in
     cs-fixer)
         run_php_cs_fixer || exit 127
         ;;
+    xdebug)
+        shift
+        toggle_xdebug "$@" || exit 127
+        ;;
     playwright)
         shift
         cd "$MY_DIR/tests/Acceptance/playwright" || exit 127
@@ -426,6 +483,7 @@ case "$1" in
         echo "  test-all     Run php-cs-fixer, then full test suite"
         echo "  test-all-coverage  Run php-cs-fixer, then full test suite with coverage report"
         echo "  cs-fixer     Run php-cs-fixer on the entire codebase"
+        echo "  xdebug       Toggle step debugging: $0 xdebug <on|off|status>"
         echo "  quarantine   Run slow/special @group quarantine tests only"
         echo "  playwright   Run the Playwright browser test suite (auto-installs deps on first run)"
         echo ""

--- a/docker.sh
+++ b/docker.sh
@@ -142,6 +142,7 @@ rebuild_containers() {
 
 run_tests() {
   GREEN='\033[0;32m'
+  YELLOW='\033[1;33m'
   RED='\033[0;31m'
   NC='\033[0m'
 
@@ -155,6 +156,13 @@ run_tests() {
   fi
 
   echo -e "${GREEN}✓ shop container is running – executing tests${NC}"
+
+  # Warn if step debugging is left on: start_with_request=yes makes every CLI/test
+  # process attempt a debugger connection on port 9003, slowing the whole suite.
+  if [ -f "$MY_DIR/docker/xdebug/zz-xdebug-debug.ini" ]; then
+      echo -e "${YELLOW}⚠ Xdebug step debugging is ON – the suite may be slow.${NC}"
+      echo -e "${YELLOW}  Run './docker.sh xdebug off' before the test suite for normal speed.${NC}"
+  fi
 
   # Clear the application cache before the suite — stale Smarty / module /
   # container caches have masked real failures in the past (a stale class map
@@ -251,14 +259,16 @@ toggle_xdebug() {
           exit 1
       fi
       cp "$dist" "$active" || { echo -e "${RED}Failed to write $active${NC}"; exit 1; }
-      $DOCKER_COMPOSE exec shop apache2ctl graceful
+      $DOCKER_COMPOSE exec shop apache2ctl graceful \
+          || { echo -e "${RED}Failed to reload Apache – xdebug may not be active.${NC}"; exit 1; }
       echo -e "${GREEN}✓ xdebug step debugging ENABLED.${NC}"
       echo -e "${YELLOW}  → Start your IDE's debug listener on port 9003, then load a page.${NC}"
       echo -e "${YELLOW}  → Connection log: $DOCKER_COMPOSE exec shop cat /tmp/xdebug.log${NC}"
       echo -e "${YELLOW}  → Setup guide: docs/development/xdebug-step-debugging.md${NC}"
   else
       rm -f "$active"
-      $DOCKER_COMPOSE exec shop apache2ctl graceful
+      $DOCKER_COMPOSE exec shop apache2ctl graceful \
+          || { echo -e "${RED}Failed to reload Apache – xdebug may still be active.${NC}"; exit 1; }
       echo -e "${GREEN}✓ xdebug step debugging DISABLED (coverage-only).${NC}"
   fi
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
 
 RUN pecl install xdebug \
     && docker-php-ext-enable xdebug \
-    && echo "xdebug.mode=coverage,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+    && echo "xdebug.mode=coverage" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 # Node.js 20 LTS + global gulp-cli (o3-theme build pipeline) and grunt-cli
 # (wave-theme build pipeline). Themes ship their own local gulp/grunt versions

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,11 +22,18 @@ services:
   shop:
     build:
       dockerfile: Dockerfile
+    extra_hosts:
+      # Makes host.docker.internal resolve to the host on Colima / plain Linux
+      # Docker (auto on Docker Desktop). Required for Xdebug to reach the IDE.
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./../:/var/www/html
     environment:
       PATH: /var/www/html/vendor/o3-shop/testing-library/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       TZ: Europe/Berlin
+      # Scan the compiled-in default conf.d (leading ':') PLUS the bind-mounted
+      # xdebug dir, so ./docker.sh xdebug on|off takes effect without a rebuild.
+      PHP_INI_SCAN_DIR: ":/var/www/html/docker/xdebug"
     ports:
       - "${O3SHOP_PORT_HTTP:-8080}:80"
     working_dir: /var/www/html

--- a/docker/xdebug/zz-xdebug-debug.ini.dist
+++ b/docker/xdebug/zz-xdebug-debug.ini.dist
@@ -1,0 +1,8 @@
+; Active step-debugging config. Toggled on/off via `./docker.sh xdebug on|off`.
+; This .dist template is copied to zz-xdebug-debug.ini (loaded by PHP via
+; PHP_INI_SCAN_DIR). PHP only loads files ending in .ini, so this template is inert.
+xdebug.mode=develop,debug,coverage
+xdebug.start_with_request=yes
+xdebug.client_host=host.docker.internal
+xdebug.client_port=9003
+xdebug.log=/tmp/xdebug.log

--- a/docker/xdebug/zz-xdebug-debug.ini.dist
+++ b/docker/xdebug/zz-xdebug-debug.ini.dist
@@ -1,8 +1,17 @@
 ; Active step-debugging config. Toggled on/off via `./docker.sh xdebug on|off`.
 ; This .dist template is copied to zz-xdebug-debug.ini (loaded by PHP via
 ; PHP_INI_SCAN_DIR). PHP only loads files ending in .ini, so this template is inert.
-xdebug.mode=develop,debug,coverage
-xdebug.start_with_request=yes
+; Intentionally NOT including 'develop': on PHP 8.2 the old Doctrine DBAL 2.x /
+; Smarty stack emits tens of thousands of Deprecated notices per request, and
+; 'develop' streams every one to the IDE as an error notification — flooding the
+; debug session and triggering bogus "path mapping" warnings for vendor/ files.
+; Step debugging needs only 'debug'. Coverage kept so test coverage still works.
+xdebug.mode=debug,coverage
+; 'trigger' (not 'yes'): debugging only starts when a request carries an
+; XDEBUG_TRIGGER (the "Xdebug Helper" browser extension, ?XDEBUG_TRIGGER=1, or the
+; env var for CLI). With 'yes' EVERY page request AND every CLI command (oe-console,
+; composer, even `php -r`) opens a session the IDE can grab and freeze — unusable here.
+xdebug.start_with_request=trigger
 xdebug.client_host=host.docker.internal
 xdebug.client_port=9003
 xdebug.log=/tmp/xdebug.log

--- a/docs/development/xdebug-step-debugging.md
+++ b/docs/development/xdebug-step-debugging.md
@@ -1,0 +1,81 @@
+# Step Debugging with Xdebug
+
+Xdebug is installed in the `shop` container. Step debugging is **off by default**
+(coverage-only, zero overhead) and toggled on per developer when needed.
+
+## Toggle
+
+```bash
+./docker.sh xdebug on       # enable step debugging (graceful apache reload)
+./docker.sh xdebug off      # back to coverage-only
+./docker.sh xdebug status   # show current state
+```
+
+`on` connects to your IDE on **every** request while enabled, so turn it **off**
+before running the full test suite. The state is a file under `docker/xdebug/`
+and survives `./docker.sh start`.
+
+> First-time setup only: the `host.docker.internal` resolution and ini scan dir
+> are applied by `docker/docker-compose.yml`. If you set this repo up before that
+> change, run `./docker.sh start` once to recreate the `shop` container.
+
+## PhpStorm
+
+1. **Settings → PHP → Servers** → add a server:
+   - Name: `o3shop` (any name)
+   - Host: `localhost`, Port: `8080`
+   - Debugger: Xdebug
+   - **Use path mappings** → map your project root (this repo) to `/var/www/html`.
+2. **Settings → PHP → Debug** → confirm Debug port `9003`.
+3. **Run → Start Listening for PHP Debug Connections** (the phone icon turns green).
+4. `./docker.sh xdebug on`, set a breakpoint, load a page at `http://localhost:8080`.
+
+## VS Code
+
+1. Install the **PHP Debug** extension (xdebug.php-debug).
+2. Add to `.vscode/launch.json`:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for Xdebug",
+      "type": "php",
+      "request": "launch",
+      "port": 9003,
+      "pathMappings": {
+        "/var/www/html": "${workspaceFolder}"
+      }
+    }
+  ]
+}
+```
+
+3. Start the "Listen for Xdebug" configuration (F5).
+4. `./docker.sh xdebug on`, set a breakpoint, load a page.
+
+## CLI debugging
+
+With xdebug on, `oe-console` and other CLI scripts also connect:
+
+```bash
+docker compose -f docker/docker-compose.yml exec shop php bin/oe-console <command>
+```
+
+## Troubleshooting
+
+- **No breakpoint hit?** Make sure the IDE listener is running *before* you load the page.
+- **Check the connection log inside the container:**
+
+```bash
+docker compose -f docker/docker-compose.yml exec shop cat /tmp/xdebug.log
+```
+
+  `Connected to debugging client` = success. `Could not connect ... 9003` means the
+  IDE isn't listening or the port is blocked.
+- **`host.docker.internal` not resolving?** Confirm the `extra_hosts: host-gateway`
+  entry exists in `docker/docker-compose.yml` and recreate the container with
+  `./docker.sh start`.
+- **Path mapping wrong?** Breakpoints stay hollow / never bind — re-check that the
+  project root maps to `/var/www/html`.

--- a/docs/development/xdebug-step-debugging.md
+++ b/docs/development/xdebug-step-debugging.md
@@ -11,9 +11,23 @@ Xdebug is installed in the `shop` container. Step debugging is **off by default*
 ./docker.sh xdebug status   # show current state
 ```
 
-`on` connects to your IDE on **every** request while enabled, so turn it **off**
-before running the full test suite. The state is a file under `docker/xdebug/`
-and survives `./docker.sh start`.
+The state is a file under `docker/xdebug/` and survives `./docker.sh start`.
+
+### Triggering a debug session
+
+`on` uses **trigger mode** (`start_with_request=trigger`): being "on" does NOT make
+every request debug. A request only breaks into the debugger when it carries an
+`XDEBUG_TRIGGER`. This is deliberate — `start_with_request=yes` would make every page
+request *and* every CLI command (`oe-console`, `composer`, even `php -r`) open a session
+your IDE can grab and freeze, which is unusable against this codebase.
+
+- **Browser:** install the **Xdebug Helper** extension (Chrome/Firefox) and set it to
+  *Debug*, or append `?XDEBUG_TRIGGER=1` to the URL.
+- **CLI:** prefix the command with the env var:
+  ```bash
+  docker compose -f docker/docker-compose.yml exec -e XDEBUG_TRIGGER=1 shop \
+    php bin/oe-console <command>
+  ```
 
 > First-time setup only: the `host.docker.internal` resolution and ini scan dir
 > are applied by `docker/docker-compose.yml`. If you set this repo up before that
@@ -32,7 +46,9 @@ and survives `./docker.sh start`.
      also works.
 2. **Settings → PHP → Debug** → confirm Debug port `9003`.
 3. **Run → Start Listening for PHP Debug Connections** (the phone icon turns green).
-4. `./docker.sh xdebug on`, set a breakpoint, load a page at `http://localhost:8080`.
+4. `./docker.sh xdebug on`, set a breakpoint, then load a **triggered** page (Xdebug
+   Helper set to *Debug*, or `http://localhost:8080/?XDEBUG_TRIGGER=1`). See
+   [Triggering a debug session](#triggering-a-debug-session).
 
 ## VS Code
 
@@ -57,14 +73,17 @@ and survives `./docker.sh start`.
 ```
 
 3. Start the "Listen for Xdebug" configuration (F5).
-4. `./docker.sh xdebug on`, set a breakpoint, load a page.
+4. `./docker.sh xdebug on`, set a breakpoint, then load a **triggered** page (Xdebug
+   Helper set to *Debug*, or `?XDEBUG_TRIGGER=1`).
 
 ## CLI debugging
 
-With xdebug on, `oe-console` and other CLI scripts also connect:
+Prefix the command with `XDEBUG_TRIGGER=1` (trigger mode means a bare command will
+*not* start a debug session — that's what keeps `oe-console`/`composer` from hanging):
 
 ```bash
-docker compose -f docker/docker-compose.yml exec shop php bin/oe-console <command>
+docker compose -f docker/docker-compose.yml exec -e XDEBUG_TRIGGER=1 shop \
+  php bin/oe-console <command>
 ```
 
 ## Troubleshooting
@@ -81,8 +100,13 @@ docker compose -f docker/docker-compose.yml exec shop cat /tmp/xdebug.log
 - **`host.docker.internal` not resolving?** Confirm the `extra_hosts: host-gateway`
   entry exists in `docker/docker-compose.yml` and recreate the container with
   `./docker.sh start`.
-- **Path mapping wrong?** Breakpoints stay hollow / never bind — re-check that the
-  project root maps to `/var/www/html`.
+- **Path mapping wrong?** Breakpoints stay hollow / never bind — re-check that local
+  `source/` maps to `/var/www/html/source` (or repo root → `/var/www/html`).
+- **PhpStorm keeps warning about path mappings for `vendor/...` files?** That was the
+  old `develop` mode forwarding the codebase's thousands of PHP 8.2 deprecation notices
+  (from `vendor/`) to the IDE. The current config uses `xdebug.mode=debug,coverage`
+  (no `develop`), which stops the flood. Re-run `./docker.sh xdebug off && ./docker.sh xdebug on`
+  if you toggled it on before this change.
 - **Debugger stops on the first line of every request (no breakpoint set)?** That's the
   IDE's "break at first line" option, not a misconfiguration — it confirms the connection
   works. Turn it off in PhpStorm under **Run → Break at first line in PHP scripts**, or in

--- a/docs/development/xdebug-step-debugging.md
+++ b/docs/development/xdebug-step-debugging.md
@@ -21,11 +21,15 @@ and survives `./docker.sh start`.
 
 ## PhpStorm
 
-1. **Settings → PHP → Servers** → add a server:
-   - Name: `o3shop` (any name)
+1. **Settings → PHP → Servers** → add a server (PhpStorm may auto-create one on the
+   first incoming connection):
+   - Name: `localhost` (any name)
    - Host: `localhost`, Port: `8080`
    - Debugger: Xdebug
-   - **Use path mappings** → map your project root (this repo) to `/var/www/html`.
+   - **Use path mappings** → map your local **`source/`** directory to
+     **`/var/www/html/source`** (Apache's DocumentRoot is `source/`, not the repo root).
+     PhpStorm usually fills this in for you. Mapping the repo root → `/var/www/html`
+     also works.
 2. **Settings → PHP → Debug** → confirm Debug port `9003`.
 3. **Run → Start Listening for PHP Debug Connections** (the phone icon turns green).
 4. `./docker.sh xdebug on`, set a breakpoint, load a page at `http://localhost:8080`.

--- a/docs/development/xdebug-step-debugging.md
+++ b/docs/development/xdebug-step-debugging.md
@@ -79,3 +79,7 @@ docker compose -f docker/docker-compose.yml exec shop cat /tmp/xdebug.log
   `./docker.sh start`.
 - **Path mapping wrong?** Breakpoints stay hollow / never bind — re-check that the
   project root maps to `/var/www/html`.
+- **Debugger stops on the first line of every request (no breakpoint set)?** That's the
+  IDE's "break at first line" option, not a misconfiguration — it confirms the connection
+  works. Turn it off in PhpStorm under **Run → Break at first line in PHP scripts**, or in
+  VS Code by removing `"stopOnEntry": true` from the launch config.

--- a/docs/superpowers/plans/2026-06-24-xdebug-step-debugging.md
+++ b/docs/superpowers/plans/2026-06-24-xdebug-step-debugging.md
@@ -1,0 +1,512 @@
+# Xdebug Step Debugging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in `./docker.sh xdebug on|off|status` toggle that enables PhpStorm/VS Code step debugging against the `shop` container, with zero cost when off.
+
+**Architecture:** A host-side PHP ini drop-in (`docker/xdebug/zz-xdebug-debug.ini`) lives in the already-bind-mounted repo tree; `PHP_INI_SCAN_DIR` makes PHP load it natively, so toggle state persists across restarts with no extra start logic. `extra_hosts: host-gateway` makes `host.docker.internal` resolve on Colima. The toggle copies/removes the file and `apache2ctl graceful`-reloads.
+
+**Tech Stack:** Docker Compose, PHP 8.2 + Xdebug 3 (apache mod_php), bash (`docker.sh`).
+
+**Spec:** `docs/superpowers/specs/2026-06-24-xdebug-step-debugging-design.md`
+**Branch:** `82-xdebug-step-debugging`
+
+---
+
+## File Structure
+
+- `docker/docker-compose.yml` — add `extra_hosts` + `PHP_INI_SCAN_DIR` to the `shop` service.
+- `docker/Dockerfile` — baked default `xdebug.mode=coverage` (drop `debug`).
+- `docker/xdebug/zz-xdebug-debug.ini.dist` — committed template (the "on" config). **New.**
+- `.gitignore` — ignore the active `docker/xdebug/zz-xdebug-debug.ini`.
+- `docker.sh` — `toggle_xdebug()` function + `xdebug)` case + help text.
+- `docs/development/xdebug-step-debugging.md` — PhpStorm + VS Code guide. **New.**
+
+---
+
+## Task 1: Create the xdebug "on" config template
+
+**Files:**
+- Create: `docker/xdebug/zz-xdebug-debug.ini.dist`
+
+- [ ] **Step 1: Write the template file**
+
+Create `docker/xdebug/zz-xdebug-debug.ini.dist` with exactly:
+
+```ini
+; Active step-debugging config. Toggled on/off via `./docker.sh xdebug on|off`.
+; This .dist template is copied to zz-xdebug-debug.ini (loaded by PHP via
+; PHP_INI_SCAN_DIR). PHP only loads files ending in .ini, so this template is inert.
+xdebug.mode=develop,debug,coverage
+xdebug.start_with_request=yes
+xdebug.client_host=host.docker.internal
+xdebug.client_port=9003
+xdebug.log=/tmp/xdebug.log
+```
+
+- [ ] **Step 2: Verify PHP would ignore the template name**
+
+Run: `ls docker/xdebug/`
+Expected: `zz-xdebug-debug.ini.dist` present. (Name ends in `.dist`, not `.ini`, so PHP's scan-dir loader skips it.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker/xdebug/zz-xdebug-debug.ini.dist
+git commit -m "feat(#82): add xdebug step-debugging ini template
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01WVUDMsh8WVBbWY9T15fQd2"
+```
+
+---
+
+## Task 2: Ignore the active drop-in, keep the template tracked
+
+**Files:**
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Append the ignore rule**
+
+Add to `.gitignore` (under the existing docker entries, after `docker/mailpit/data`):
+
+```
+# Active xdebug step-debugging drop-in, toggled by ./docker.sh xdebug on|off.
+# The .dist template stays tracked; the activated copy is local state.
+docker/xdebug/zz-xdebug-debug.ini
+```
+
+- [ ] **Step 2: Verify the rule works**
+
+```bash
+cp docker/xdebug/zz-xdebug-debug.ini.dist docker/xdebug/zz-xdebug-debug.ini
+git status --porcelain docker/xdebug/
+```
+Expected: only `?? docker/xdebug/zz-xdebug-debug.ini.dist` would appear *if untracked*, but it's committed in Task 1, so output is **empty** — the active `.ini` is ignored and the `.dist` is tracked/clean. Then clean up:
+
+```bash
+rm docker/xdebug/zz-xdebug-debug.ini
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore(#82): gitignore the active xdebug drop-in
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01WVUDMsh8WVBbWY9T15fQd2"
+```
+
+---
+
+## Task 3: Wire compose to load the drop-in and resolve the host
+
+**Files:**
+- Modify: `docker/docker-compose.yml` (the `shop` service)
+
+- [ ] **Step 1: Add `extra_hosts` and `PHP_INI_SCAN_DIR` to the `shop` service**
+
+In `docker/docker-compose.yml`, change the `shop` service from:
+
+```yaml
+  shop:
+    build:
+      dockerfile: Dockerfile
+    volumes:
+      - ./../:/var/www/html
+    environment:
+      PATH: /var/www/html/vendor/o3-shop/testing-library/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      TZ: Europe/Berlin
+    ports:
+      - "${O3SHOP_PORT_HTTP:-8080}:80"
+```
+
+to:
+
+```yaml
+  shop:
+    build:
+      dockerfile: Dockerfile
+    extra_hosts:
+      # Makes host.docker.internal resolve to the host on Colima / plain Linux
+      # Docker (auto on Docker Desktop). Required for Xdebug to reach the IDE.
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./../:/var/www/html
+    environment:
+      PATH: /var/www/html/vendor/o3-shop/testing-library/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      TZ: Europe/Berlin
+      # Scan the compiled-in default conf.d (leading ':') PLUS the bind-mounted
+      # xdebug dir, so ./docker.sh xdebug on|off takes effect without a rebuild.
+      PHP_INI_SCAN_DIR: ":/var/www/html/docker/xdebug"
+    ports:
+      - "${O3SHOP_PORT_HTTP:-8080}:80"
+```
+
+- [ ] **Step 2: Validate the compose file parses**
+
+Run: `cd docker && docker compose config >/dev/null && echo OK; cd ..`
+Expected: `OK` (no YAML/compose errors).
+
+- [ ] **Step 3: Recreate the shop container so env + extra_hosts apply**
+
+Run: `./docker.sh start`
+Expected: containers come up; the `shop` container is recreated (compose detects the config change).
+
+- [ ] **Step 4: Verify host resolution and scan dir inside the container**
+
+```bash
+docker compose -f docker/docker-compose.yml exec shop getent hosts host.docker.internal
+docker compose -f docker/docker-compose.yml exec shop php -i | grep -i "scan this dir\|Scan Dir"
+```
+Expected: `host.docker.internal` resolves to a gateway IP; the additional ini scan dir includes `/var/www/html/docker/xdebug`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/docker-compose.yml
+git commit -m "feat(#82): make host.docker.internal resolve and scan xdebug ini dir
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01WVUDMsh8WVBbWY9T15fQd2"
+```
+
+---
+
+## Task 4: Drop `debug` from the baked default mode
+
+**Files:**
+- Modify: `docker/Dockerfile:46`
+
+- [ ] **Step 1: Change the baked xdebug mode**
+
+In `docker/Dockerfile`, change line 46 from:
+
+```dockerfile
+    && echo "xdebug.mode=coverage,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+```
+
+to:
+
+```dockerfile
+    && echo "xdebug.mode=coverage" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+```
+
+- [ ] **Step 2: Verify the edit**
+
+Run: `grep -n "xdebug.mode" docker/Dockerfile`
+Expected: one match showing `xdebug.mode=coverage` (no `,debug`).
+
+- [ ] **Step 3: Commit** (rebuild is exercised in Task 7; the toggle overrides mode regardless)
+
+```bash
+git add docker/Dockerfile
+git commit -m "feat(#82): default baked xdebug.mode to coverage-only
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01WVUDMsh8WVBbWY9T15fQd2"
+```
+
+---
+
+## Task 5: Add the `xdebug` toggle to `docker.sh`
+
+**Files:**
+- Modify: `docker.sh` (add `toggle_xdebug()` function, `xdebug)` case, help text)
+
+- [ ] **Step 1: Add the `toggle_xdebug` function**
+
+In `docker.sh`, after the `run_quarantine_tests()` function (ends ~line 213) and before `run_npm_audits()`, insert:
+
+```bash
+toggle_xdebug() {
+  GREEN='\033[0;32m'
+  YELLOW='\033[1;33m'
+  RED='\033[0;31m'
+  NC='\033[0m'
+
+  MY_DIR=$(getMyPath)
+  local dist="$MY_DIR/docker/xdebug/zz-xdebug-debug.ini.dist"
+  local active="$MY_DIR/docker/xdebug/zz-xdebug-debug.ini"
+
+  # status needs no container and no docker — just report host-file presence.
+  if [ "$1" = "status" ]; then
+      if [ -f "$active" ]; then
+          echo -e "${GREEN}xdebug step debugging: ON${NC}"
+      else
+          echo -e "${YELLOW}xdebug step debugging: OFF${NC} (coverage-only default)"
+      fi
+      return 0
+  fi
+
+  if [ "$1" != "on" ] && [ "$1" != "off" ]; then
+      echo "Usage: $0 xdebug <on|off|status>"
+      exit 1
+  fi
+
+  cd "$MY_DIR/docker" || { echo "Error: Docker directory not found"; exit 1; }
+  check_docker_compose
+
+  if ! $DOCKER_COMPOSE ps shop 2>/dev/null | grep -q "Up\|running"; then
+      echo -e "${RED} ✗ shop container is NOT running – start it first with './docker.sh start'. ${NC}"
+      exit 1
+  fi
+
+  if [ "$1" = "on" ]; then
+      if [ ! -f "$dist" ]; then
+          echo -e "${RED}Template not found: $dist${NC}"
+          exit 1
+      fi
+      cp "$dist" "$active" || { echo -e "${RED}Failed to write $active${NC}"; exit 1; }
+      $DOCKER_COMPOSE exec shop apache2ctl graceful
+      echo -e "${GREEN}✓ xdebug step debugging ENABLED.${NC}"
+      echo -e "${YELLOW}  → Start your IDE's debug listener on port 9003, then load a page.${NC}"
+      echo -e "${YELLOW}  → Connection log: $DOCKER_COMPOSE exec shop cat /tmp/xdebug.log${NC}"
+      echo -e "${YELLOW}  → Setup guide: docs/development/xdebug-step-debugging.md${NC}"
+  else
+      rm -f "$active"
+      $DOCKER_COMPOSE exec shop apache2ctl graceful
+      echo -e "${GREEN}✓ xdebug step debugging DISABLED (coverage-only).${NC}"
+  fi
+
+  cd "$MY_DIR"
+}
+```
+
+- [ ] **Step 2: Add the `xdebug)` case to the dispatch block**
+
+In `docker.sh`, in the `case "$1" in` block, add this case right after the `cs-fixer)` case (ends with its `;;`):
+
+```bash
+    xdebug)
+        shift
+        toggle_xdebug "$@" || exit 127
+        ;;
+```
+
+- [ ] **Step 3: Add `xdebug` to the help text**
+
+In the `*)` usage branch, after the `cs-fixer` description line:
+
+```bash
+        echo "  cs-fixer     Run php-cs-fixer on the entire codebase"
+```
+
+add:
+
+```bash
+        echo "  xdebug       Toggle step debugging: $0 xdebug <on|off|status>"
+```
+
+- [ ] **Step 4: Verify bash syntax and the new command surface**
+
+```bash
+bash -n docker.sh && echo "syntax OK"
+./docker.sh 2>&1 | grep xdebug
+```
+Expected: `syntax OK`; help text shows the `xdebug` line.
+
+- [ ] **Step 5: Verify `status` works with the container up (no .ini present)**
+
+Run: `./docker.sh xdebug status`
+Expected: `xdebug step debugging: OFF (coverage-only default)`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docker.sh
+git commit -m "feat(#82): add ./docker.sh xdebug on|off|status toggle
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01WVUDMsh8WVBbWY9T15fQd2"
+```
+
+---
+
+## Task 6: Write the developer setup guide
+
+**Files:**
+- Create: `docs/development/xdebug-step-debugging.md`
+
+- [ ] **Step 1: Write the guide**
+
+Create `docs/development/xdebug-step-debugging.md` with:
+
+````markdown
+# Step Debugging with Xdebug
+
+Xdebug is installed in the `shop` container. Step debugging is **off by default**
+(coverage-only, zero overhead) and toggled on per developer when needed.
+
+## Toggle
+
+```bash
+./docker.sh xdebug on       # enable step debugging (graceful apache reload)
+./docker.sh xdebug off      # back to coverage-only
+./docker.sh xdebug status   # show current state
+```
+
+`on` connects to your IDE on **every** request while enabled, so turn it **off**
+before running the full test suite. The state is a file under `docker/xdebug/`
+and survives `./docker.sh start`.
+
+> First-time setup only: the `host.docker.internal` resolution and ini scan dir
+> are applied by `docker/docker-compose.yml`. If you set this repo up before that
+> change, run `./docker.sh start` once to recreate the `shop` container.
+
+## PhpStorm
+
+1. **Settings → PHP → Servers** → add a server:
+   - Name: `o3shop` (any name)
+   - Host: `localhost`, Port: `8080`
+   - Debugger: Xdebug
+   - **Use path mappings** → map your project root (this repo) to `/var/www/html`.
+2. **Settings → PHP → Debug** → confirm Debug port `9003`.
+3. **Run → Start Listening for PHP Debug Connections** (the phone icon turns green).
+4. `./docker.sh xdebug on`, set a breakpoint, load a page at `http://localhost:8080`.
+
+## VS Code
+
+1. Install the **PHP Debug** extension (xdebug.php-debug).
+2. Add to `.vscode/launch.json`:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for Xdebug",
+      "type": "php",
+      "request": "launch",
+      "port": 9003,
+      "pathMappings": {
+        "/var/www/html": "${workspaceFolder}"
+      }
+    }
+  ]
+}
+```
+
+3. Start the "Listen for Xdebug" configuration (F5).
+4. `./docker.sh xdebug on`, set a breakpoint, load a page.
+
+## CLI debugging
+
+With xdebug on, `oe-console` and other CLI scripts also connect:
+
+```bash
+docker compose -f docker/docker-compose.yml exec shop php bin/oe-console <command>
+```
+
+## Troubleshooting
+
+- **No breakpoint hit?** Make sure the IDE listener is running *before* you load the page.
+- **Check the connection log inside the container:**
+
+```bash
+docker compose -f docker/docker-compose.yml exec shop cat /tmp/xdebug.log
+```
+
+  `Connected to debugging client` = success. `Could not connect ... 9003` means the
+  IDE isn't listening or the port is blocked.
+- **`host.docker.internal` not resolving?** Confirm the `extra_hosts: host-gateway`
+  entry exists in `docker/docker-compose.yml` and recreate the container with
+  `./docker.sh start`.
+- **Path mapping wrong?** Breakpoints stay hollow / never bind — re-check that the
+  project root maps to `/var/www/html`.
+````
+
+- [ ] **Step 2: Verify the file renders as valid markdown (no broken fences)**
+
+Run: `grep -c '```' docs/development/xdebug-step-debugging.md`
+Expected: an **even** number (all code fences closed).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/development/xdebug-step-debugging.md
+git commit -m "docs(#82): add PhpStorm + VS Code xdebug setup guide
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01WVUDMsh8WVBbWY9T15fQd2"
+```
+
+---
+
+## Task 7: End-to-end verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Rebuild so the baked `xdebug.mode=coverage` default lands**
+
+Run: `./docker.sh rebuild`
+Expected: image rebuilds, containers start.
+
+- [ ] **Step 2: Confirm the OFF default is coverage-only**
+
+```bash
+./docker.sh xdebug status
+docker compose -f docker/docker-compose.yml exec shop php -i | grep "xdebug.mode"
+```
+Expected: status `OFF`; `xdebug.mode => coverage => coverage`.
+
+- [ ] **Step 3: Toggle ON and confirm the mode + connection config**
+
+```bash
+./docker.sh xdebug on
+docker compose -f docker/docker-compose.yml exec shop php -i | grep -E "xdebug.mode|xdebug.client_host|xdebug.client_port|start_with_request"
+```
+Expected: `xdebug.mode => develop,debug,coverage`, `client_host => host.docker.internal`, `client_port => 9003`, `start_with_request => yes`.
+
+- [ ] **Step 4: Confirm a connection attempt is logged**
+
+```bash
+curl -s -o /dev/null http://localhost:8080/
+docker compose -f docker/docker-compose.yml exec shop cat /tmp/xdebug.log
+```
+Expected: a `[Step Debug]` line attempting to connect to `host.docker.internal:9003` (it will fail to connect with no IDE listening — that proves config is active and reaching the host).
+
+- [ ] **Step 5: Real breakpoint check (manual, PhpStorm or VS Code)**
+
+Start the IDE listener (per the guide), set a breakpoint in a controller (e.g. a
+`render()` method), reload `http://localhost:8080/`. Expected: execution pauses at the
+breakpoint. Repeat once for the other IDE if available.
+
+- [ ] **Step 6: Toggle OFF and confirm coverage-only is restored**
+
+```bash
+./docker.sh xdebug off
+docker compose -f docker/docker-compose.yml exec shop php -i | grep "xdebug.mode"
+curl -s -o /dev/null http://localhost:8080/
+```
+Expected: `xdebug.mode => coverage => coverage`; no new connection attempts in `/tmp/xdebug.log` from this load.
+
+- [ ] **Step 7: Confirm the test suite still passes with xdebug OFF**
+
+Run: `./docker.sh test`
+Expected: suite passes (coverage mode intact, no step-debug regression).
+
+- [ ] **Step 8: Run the quality gate**
+
+Run: `/finish` (cs-fixer + full tests + coverage), then update `.claude/memory/` with any lessons.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `extra_hosts` host-gateway → Task 3 ✓
+- `PHP_INI_SCAN_DIR` → Task 3 ✓
+- Baked `xdebug.mode=coverage` → Task 4 ✓
+- `zz-xdebug-debug.ini.dist` template (mode/start_with_request/client_host/client_port/log) → Task 1 ✓
+- `.gitignore` active drop-in → Task 2 ✓
+- `./docker.sh xdebug on|off|status` (guard, graceful reload, host-file ops) → Task 5 ✓
+- PhpStorm + VS Code + troubleshooting guide → Task 6 ✓
+- Verification (status, mode, log, breakpoint, tests pass) → Task 7 ✓
+
+No spec requirement left without a task.
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"; every code/edit step shows exact content and exact commands with expected output.
+
+**Type/name consistency:** Active file `docker/xdebug/zz-xdebug-debug.ini`, template `…​.ini.dist`, function `toggle_xdebug`, command `xdebug on|off|status`, scan dir `/var/www/html/docker/xdebug`, port `9003`, host `host.docker.internal` — all used identically across Tasks 1, 3, 5, 6, 7.

--- a/docs/superpowers/specs/2026-06-24-xdebug-step-debugging-design.md
+++ b/docs/superpowers/specs/2026-06-24-xdebug-step-debugging-design.md
@@ -1,0 +1,170 @@
+# Xdebug Step Debugging — Design (#82)
+
+**Issue:** [#82](https://github.com/o3-shop/shop-ce/issues/82) — *setup xdebug in shop-app container for step debugging with IDE*
+**Date:** 2026-06-24
+**Branch:** `82-xdebug-step-debugging` (off `b-1.6`)
+
+## Problem
+
+Xdebug is already installed in the `shop` container (`docker/Dockerfile:44-46`) with
+`xdebug.mode=coverage,debug`, but **no step-debugging connection settings exist**:
+no `client_host`, no `client_port`, no request-activation config. Xdebug initiates the
+connection *to* the IDE, so without these it can never reach an IDE running on the host —
+which is why every attempt in the issue failed.
+
+Two concrete gaps:
+
+1. **No connection target.** Xdebug doesn't know where the IDE is.
+2. **`host.docker.internal` does not resolve on Colima / plain Linux Docker.** There is no
+   `extra_hosts` / `host-gateway` entry in `docker-compose.yml`. On Docker Desktop for Mac
+   this name resolves automatically; on the project's Colima setup it does not.
+
+## Goals
+
+- Step debugging from PhpStorm **and** VS Code against the `shop` container.
+- **Zero performance cost by default** — normal contributors are unaffected.
+- Explicit, ergonomic opt-in: a `./docker.sh xdebug on|off|status` toggle.
+- Toggle state **persists across `./docker.sh start`** without bespoke re-apply logic.
+- Coverage (`xdebug.mode=coverage`) keeps working for the test suite at all times.
+
+## Non-goals
+
+- Profiling / tracing configuration (out of scope; `mode` only carries `coverage` by
+  default and `develop,debug,coverage` when toggled on).
+- Trigger-based (browser-extension) activation. Decided: when **on**, connect on **every**
+  request (`start_with_request=yes`). When **off**, no debug at all.
+- Acceptance/Playwright debugging.
+
+## Decisions (from brainstorming)
+
+| Question | Decision |
+|---|---|
+| Activation model | **Toggle script** — off by default, explicit `./docker.sh xdebug on` |
+| On-mode behaviour | **Connect every request** (`start_with_request=yes`) |
+| IDE docs | **PhpStorm + VS Code** |
+| Persistence mechanism | **`PHP_INI_SCAN_DIR` + host-side ini file** (no marker file) |
+
+## Architecture
+
+The toggle controls a single PHP ini drop-in **on the host**, inside a directory that is
+already bind-mounted into the container (`./../:/var/www/html`). PHP is told to scan that
+directory via `PHP_INI_SCAN_DIR`, so the file is loaded natively on every container boot —
+persistence is free, and `start_containers()` needs no extra logic.
+
+```
+host: docker/xdebug/zz-xdebug-debug.ini   ──bind mount──▶  /var/www/html/docker/xdebug/zz-xdebug-debug.ini
+                                                                         │
+                          PHP_INI_SCAN_DIR=":/var/www/html/docker/xdebug"│  (default conf.d + this dir)
+                                                                         ▼
+                                            php (apache mod_php + `exec shop php` CLI) loads it
+```
+
+- File **present** → step debugging on. File **absent** → coverage-only default from the image.
+- `apache2ctl graceful` re-reads PHP ini for the web SAPI; the CLI re-reads on next invocation.
+
+## Components
+
+### 1. `docker/docker-compose.yml` — `shop` service
+Add (merging into the existing `environment` map):
+```yaml
+extra_hosts:
+  - "host.docker.internal:host-gateway"
+environment:
+  # existing PATH, TZ ...
+  PHP_INI_SCAN_DIR: ":/var/www/html/docker/xdebug"
+```
+The leading `:` keeps the compiled-in default scan dir (`/usr/local/etc/php/conf.d`) **and**
+adds ours. Both changes require a one-time container recreate (next `./docker.sh start`).
+
+### 2. `docker/Dockerfile:46`
+Change the baked default from:
+```
+xdebug.mode=coverage,debug
+```
+to:
+```
+xdebug.mode=coverage
+```
+Off-state is then strictly coverage-only (no step-debug machinery), regardless of any
+`start_with_request` default. Needs a `./docker.sh rebuild` to take effect, but the toggle's
+drop-in overrides `xdebug.mode` regardless, so `xdebug on` works even before a rebuild.
+
+### 3. `docker/xdebug/zz-xdebug-debug.ini.dist` (committed template)
+PHP only loads files ending in `.ini`, so the `.dist` template is inert until copied to the
+active `.ini` name by the toggle.
+```ini
+xdebug.mode=develop,debug,coverage
+xdebug.start_with_request=yes
+xdebug.client_host=host.docker.internal
+xdebug.client_port=9003
+xdebug.log=/tmp/xdebug.log
+```
+- `develop` adds nicer var dumps / stack traces while debugging.
+- `coverage` retained so coverage still works if a run happens while on.
+- `xdebug.log` makes failed connections diagnosable (the #1 support issue for step debugging).
+
+### 4. `docker.sh` — new `xdebug` subcommand
+`xdebug on|off|status`, dispatched from the `case "$1"` block; help text updated.
+- **on**: copy `docker/xdebug/zz-xdebug-debug.ini.dist` → `docker/xdebug/zz-xdebug-debug.ini`
+  (host file via the bind mount), then `$DOCKER_COMPOSE exec shop apache2ctl graceful`.
+  Print confirmation + reminder to start the IDE listener on port 9003.
+- **off**: remove `docker/xdebug/zz-xdebug-debug.ini`, then graceful reload.
+- **status**: report on/off purely from host-file presence (no `exec` needed).
+- Reuse the existing container-running guard pattern (as in `run_tests` / `run_php_cs_fixer`).
+  `on`/`off` need the container up (for the reload); `status` does not.
+
+### 5. `.gitignore`
+Ignore the active drop-in; keep the template tracked:
+```
+docker/xdebug/zz-xdebug-debug.ini
+```
+
+### 6. `docs/development/xdebug-step-debugging.md`
+Developer guide:
+- Toggle commands (`./docker.sh xdebug on|off|status`).
+- **PhpStorm**: Settings → PHP → Servers — name (any), host `localhost`, port `8080`,
+  "Use path mappings", map repo root → `/var/www/html`; debug port `9003`;
+  Run → Start Listening for PHP Debug Connections; set a breakpoint; load a page.
+- **VS Code**: install *PHP Debug* extension; `launch.json` "Listen for Xdebug" with
+  `"port": 9003` and `"pathMappings": { "/var/www/html": "${workspaceFolder}" }`.
+- **Troubleshooting**: read `/tmp/xdebug.log` inside the container
+  (`./docker.sh ... exec shop cat /tmp/xdebug.log`); note the `host.docker.internal` /
+  `host-gateway` requirement; remind that the IDE listener must be running first.
+
+## Data flow
+
+`./docker.sh xdebug on`
+→ writes host ini → `apache2ctl graceful` re-reads it
+→ PHP (web + CLI) now connects to `host.docker.internal:9003` on every request
+→ IDE (listening) breaks at breakpoints.
+
+`./docker.sh xdebug off`
+→ deletes the ini → graceful reload → coverage-only default restored.
+
+## Error handling
+
+- `xdebug on/off` when the container is down → clear error + abort (mirrors existing guards).
+- `.dist` template missing → error in `on` rather than silently producing no-op.
+- Failed `host.docker.internal` resolution → surfaced via `/tmp/xdebug.log` connection errors,
+  documented in the troubleshooting section. The `extra_hosts` entry is the fix.
+
+## Testing & verification
+
+`docker.sh` is bash, not under PHPUnit. Verification is observable:
+
+1. `./docker.sh xdebug status` reflects on/off correctly.
+2. After `on`: `exec shop php -i | grep "xdebug.mode"` shows `develop,debug,coverage`;
+   `/tmp/xdebug.log` records a connection attempt to `host.docker.internal:9003`.
+3. A real breakpoint hit from PhpStorm (and VS Code) against a shop page.
+4. `./docker.sh test` still passes with xdebug **off** (coverage intact, no regression).
+5. After `off` + a page load: no connection attempts; `xdebug.mode` is `coverage`.
+
+## Risks
+
+- **Recreate required**: the compose env/`extra_hosts` changes only apply after the next
+  `start`/recreate. Documented.
+- **`start_with_request=yes` while on** means CLI tools (incl. the test suite) also try to
+  connect every invocation. Acceptable: the toggle defaults off, and the guide notes to turn
+  it off before running the full suite.
+- **`apache2ctl graceful` re-reads ini**: relied upon for instant pickup; if an environment
+  doesn't honour it, a `./docker.sh stop && start` is the documented fallback.


### PR DESCRIPTION
Closes o3-shop/o3-shop#82

## Summary

- Adds an opt-in `./docker.sh xdebug on|off|status` toggle for PhpStorm/VS Code step debugging against the `shop` container. **Off by default = coverage-only, zero overhead.**
- Root cause of prior failures: xdebug was installed but had **no connection config**, and on Colima `host.docker.internal` did not resolve. Fixed with `extra_hosts: host.docker.internal:host-gateway` on the `shop` service.
- Toggle persists across `./docker.sh start` for free: a host-side ini (`docker/xdebug/zz-xdebug-debug.ini`) loaded via `PHP_INI_SCAN_DIR`; the committed `.dist` template is the activated config.
- On-config is `xdebug.mode=debug,coverage` + `start_with_request=trigger` (deliberately **not** `develop`, and **not** `yes`): `develop` streamed ~33k PHP 8.2 deprecation notices per request to the IDE; `yes` opened a debug session on every page request and CLI command, freezing the site/commands. Trigger mode activates only on `XDEBUG_TRIGGER`.
- Baked default lowered to `xdebug.mode=coverage` (was `coverage,debug`).
- Hardening: `apache2ctl graceful` calls are error-guarded; `run_tests()` warns if the active ini is present.
- Developer guide: `docs/development/xdebug-step-debugging.md` (PhpStorm + VS Code, path mapping `source/` → `/var/www/html/source`, triggering, troubleshooting).

## Test plan

- [x] `./docker.sh test-all-coverage` — cs-fixer clean + **9693 tests pass**, coverage **90.8% ≥ 90%**
- [x] `./docker.sh xdebug status` reflects on/off; `on` yields `mode=debug,coverage`, `start_with_request=trigger`, client `host.docker.internal:9003`; `off` restores `coverage`
- [x] `host.docker.internal` resolves inside the container (Colima)
- [x] Triggered HTTP request connects to the IDE listener (`Connected to debugging client: host.docker.internal:9003`); untriggered requests do **not** connect (no hang)
- [x] Manual: breakpoints hit in PhpStorm against a triggered page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)