### PR TITLE
feat(#213): fail closed when CAPTCHA consent is required but not granted

### DIFF
--- a/docs/captcha-provider-modules.md
+++ b/docs/captcha-provider-modules.md
@@ -232,3 +232,19 @@ services:
 ```
 
 As a CAPTCHA provider author, you should **not** load remote scripts unconditionally in `getHeadScript()` or emit tracking pixels in `renderWidget()`. Return `null` / empty string when consent has not been given, and let the consent adapter drive the injection. The core checks consent before calling these methods when the consent gate is active.
+
+### Consent-exempt providers
+
+A provider that makes **no third-party calls** and sets **no tracking cookies or pixels** (for example, a self-hosted proof-of-work CAPTCHA like [Altcha](https://altcha.org/)) may additionally implement `ConsentExemptCaptchaProviderInterface`:
+
+```php
+use OxidEsales\EshopCommunity\Internal\Domain\Captcha\Provider\ConsentExemptCaptchaProviderInterface;
+use OxidEsales\EshopCommunity\Internal\Domain\Captcha\Provider\CaptchaProviderInterface;
+
+final class AltchaCaptchaProvider implements CaptchaProviderInterface, ConsentExemptCaptchaProviderInterface
+{
+    // ... implementation
+}
+```
+
+When `CaptchaService` detects that the active provider implements `ConsentExemptCaptchaProviderInterface`, it skips the consent gate entirely and calls `renderWidget()` and `verify()` directly. Providers that do **not** implement this marker interface continue to be consent-gated as before.

--- a/source/Application/translations/de/lang.php
+++ b/source/Application/translations/de/lang.php
@@ -845,5 +845,5 @@ $aLang = [
 
 // Core CAPTCHA provider feature (issue #213) — storefront texts
 'O3_CAPTCHA_FAILED'                                           => 'Die Sicherheitsüberprüfung ist fehlgeschlagen. Bitte versuchen Sie es erneut.',
-'O3_CAPTCHA_CONSENT_NOTICE'                                   => 'Der Spam-Schutz ist deaktiviert, bis Sie die erforderlichen Cookies akzeptieren.',
+'O3_CAPTCHA_CONSENT_NOTICE'                                   => 'Bitte akzeptieren Sie die erforderlichen Cookies. Andernfalls können wir nicht prüfen, ob Sie ein Mensch sind, und das Formular kann nicht abgesendet werden.',
 ];

--- a/source/Application/translations/en/lang.php
+++ b/source/Application/translations/en/lang.php
@@ -841,5 +841,5 @@ $aLang = [
 
 // Core CAPTCHA provider feature (issue #213) — storefront texts
 'O3_CAPTCHA_FAILED'                                           => 'The security check failed. Please try again.',
-'O3_CAPTCHA_CONSENT_NOTICE'                                   => 'Spam protection is disabled until you accept the required cookies.',
+'O3_CAPTCHA_CONSENT_NOTICE'                                   => 'Please accept the required cookies. Otherwise we cannot verify that you are human, and the form cannot be submitted.',
 ];

--- a/source/Internal/Domain/Captcha/CaptchaService.php
+++ b/source/Internal/Domain/Captcha/CaptchaService.php
@@ -28,6 +28,7 @@ use OxidEsales\EshopCommunity\Internal\Domain\Captcha\Configuration\CaptchaConfi
 use OxidEsales\EshopCommunity\Internal\Domain\Captcha\Consent\CaptchaConsentInterface;
 use OxidEsales\EshopCommunity\Internal\Domain\Captcha\Provider\CaptchaProviderInterface;
 use OxidEsales\EshopCommunity\Internal\Domain\Captcha\Provider\CaptchaProviderLocator;
+use OxidEsales\EshopCommunity\Internal\Domain\Captcha\Provider\ConsentExemptCaptchaProviderInterface;
 
 final class CaptchaService implements CaptchaServiceInterface
 {
@@ -60,13 +61,14 @@ final class CaptchaService implements CaptchaServiceInterface
         if (!$this->isEnabledForForm($formId)) {
             return '';
         }
-        if (!$this->consent->isConsentGranted(Registry::getRequest())) {
+        $provider = $this->activeProvider();
+        if (!($provider instanceof ConsentExemptCaptchaProviderInterface)
+            && !$this->consent->isConsentGranted(Registry::getRequest())) {
             return '<div class="o3-captcha-consent-notice">'
                 . htmlspecialchars((string) Registry::getLang()->translateString('O3_CAPTCHA_CONSENT_NOTICE'), ENT_QUOTES)
                 . '</div>';
         }
 
-        $provider = $this->activeProvider();
         $html = '';
         if (!$this->headScriptEmitted) {
             $script = $provider->getHeadScript();
@@ -83,10 +85,12 @@ final class CaptchaService implements CaptchaServiceInterface
         if (!$this->isEnabledForForm($formId)) {
             return true;
         }
-        if (!$this->consent->isConsentGranted($request)) {
+        $provider = $this->activeProvider();
+        if (!($provider instanceof ConsentExemptCaptchaProviderInterface)
+            && !$this->consent->isConsentGranted($request)) {
             return true;
         }
-        return $this->activeProvider()->verify($request, $formId);
+        return $provider->verify($request, $formId);
     }
 
     private function activeProvider(): CaptchaProviderInterface

--- a/source/Internal/Domain/Captcha/CaptchaService.php
+++ b/source/Internal/Domain/Captcha/CaptchaService.php
@@ -88,7 +88,14 @@ final class CaptchaService implements CaptchaServiceInterface
         $provider = $this->activeProvider();
         if (!($provider instanceof ConsentExemptCaptchaProviderInterface)
             && !$this->consent->isConsentGranted($request)) {
-            return true;
+            // Fail closed: consent is required but not granted, so the captcha cannot
+            // load or verify. Passing the submission through would let bots bypass the
+            // captcha entirely, so the verification fails instead.
+            Registry::getLogger()->info(
+                __METHOD__ . " - Blocking submission for form '$formId': "
+                . 'consent is required but not granted, so the captcha cannot be verified.'
+            );
+            return false;
         }
         return $provider->verify($request, $formId);
     }

--- a/source/Internal/Domain/Captcha/Provider/ConsentExemptCaptchaProviderInterface.php
+++ b/source/Internal/Domain/Captcha/Provider/ConsentExemptCaptchaProviderInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of O3-Shop.
+ *
+ * O3-Shop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * O3-Shop is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with O3-Shop.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * @copyright  Copyright (c) 2026 O3-Shop (https://www.o3-shop.com)
+ * @license    https://www.gnu.org/licenses/gpl-3.0  GNU General Public License 3 (GPLv3)
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\EshopCommunity\Internal\Domain\Captcha\Provider;
+
+/**
+ * Opt-in marker: a provider that makes no third-party calls and sets no
+ * tracking (e.g. a self-hosted proof-of-work CAPTCHA) implements this so the
+ * CaptchaService loads/verifies it WITHOUT the consent gate. Providers that do
+ * not implement it stay consent-gated.
+ */
+interface ConsentExemptCaptchaProviderInterface
+{
+}

--- a/tests/Unit/Internal/Domain/Captcha/CaptchaServiceConsentExemptTest.php
+++ b/tests/Unit/Internal/Domain/Captcha/CaptchaServiceConsentExemptTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * This file is part of O3-Shop.
+ *
+ * O3-Shop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * O3-Shop is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with O3-Shop.  If not, see <http://www.gnu.org/licenses/>
+ *
+ * @copyright  Copyright (c) 2026 O3-Shop (https://www.o3-shop.com)
+ * @license    https://www.gnu.org/licenses/gpl-3.0  GNU General Public License 3 (GPLv3)
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\Domain\Captcha;
+
+use OxidEsales\Eshop\Core\Request;
+use OxidEsales\EshopCommunity\Internal\Domain\Captcha\CaptchaService;
+use OxidEsales\EshopCommunity\Internal\Domain\Captcha\Configuration\CaptchaConfigurationInterface;
+use OxidEsales\EshopCommunity\Internal\Domain\Captcha\Consent\CaptchaConsentInterface;
+use OxidEsales\EshopCommunity\Internal\Domain\Captcha\Provider\CaptchaProviderInterface;
+use OxidEsales\EshopCommunity\Internal\Domain\Captcha\Provider\CaptchaProviderLocator;
+use OxidEsales\EshopCommunity\Internal\Domain\Captcha\Provider\ConsentExemptCaptchaProviderInterface;
+use OxidEsales\EshopCommunity\Internal\Domain\Captcha\Provider\NullCaptchaProvider;
+use PHPUnit\Framework\TestCase;
+
+class CaptchaServiceConsentExemptTest extends TestCase
+{
+    private function exemptProvider(): CaptchaProviderInterface
+    {
+        return new class () implements CaptchaProviderInterface, ConsentExemptCaptchaProviderInterface {
+            public function getId(): string { return 'exempt'; }
+            public function getTitle(): string { return 'Exempt'; }
+            public function isConfigured(): bool { return true; }
+            public function getConfigFields(): array { return []; }
+            public function getHeadScript(): ?string { return '<script id="head"></script>'; }
+            public function renderWidget(string $formId): string { return '<div id="widget"></div>'; }
+            public function verify(Request $request, string $formId): bool { return true; }
+        };
+    }
+
+    private function service(CaptchaProviderInterface $provider): CaptchaService
+    {
+        $config = $this->createMock(CaptchaConfigurationInterface::class);
+        $config->method('getActiveProviderId')->willReturn($provider->getId());
+        $config->method('isFormEnabled')->willReturn(true);
+        $consent = $this->createMock(CaptchaConsentInterface::class);
+        $consent->method('isConsentGranted')->willReturn(false);
+        $locator = new CaptchaProviderLocator([$provider], new NullCaptchaProvider());
+        return new CaptchaService($locator, $config, $consent);
+    }
+
+    public function testExemptProviderRendersAndVerifiesWithoutConsent(): void
+    {
+        $svc = $this->service($this->exemptProvider());
+        $html = $svc->renderForForm('contact');
+        $this->assertStringContainsString('id="widget"', $html, 'Exempt provider renders its widget even without consent.');
+        $this->assertTrue($svc->verifyForForm('contact', $this->createMock(Request::class)));
+    }
+}

--- a/tests/Unit/Internal/Domain/Captcha/CaptchaServiceConsentExemptTest.php
+++ b/tests/Unit/Internal/Domain/Captcha/CaptchaServiceConsentExemptTest.php
@@ -37,13 +37,34 @@ class CaptchaServiceConsentExemptTest extends TestCase
     private function exemptProvider(): CaptchaProviderInterface
     {
         return new class () implements CaptchaProviderInterface, ConsentExemptCaptchaProviderInterface {
-            public function getId(): string { return 'exempt'; }
-            public function getTitle(): string { return 'Exempt'; }
-            public function isConfigured(): bool { return true; }
-            public function getConfigFields(): array { return []; }
-            public function getHeadScript(): ?string { return '<script id="head"></script>'; }
-            public function renderWidget(string $formId): string { return '<div id="widget"></div>'; }
-            public function verify(Request $request, string $formId): bool { return true; }
+            public function getId(): string
+            {
+                return 'exempt';
+            }
+            public function getTitle(): string
+            {
+                return 'Exempt';
+            }
+            public function isConfigured(): bool
+            {
+                return true;
+            }
+            public function getConfigFields(): array
+            {
+                return [];
+            }
+            public function getHeadScript(): ?string
+            {
+                return '<script id="head"></script>';
+            }
+            public function renderWidget(string $formId): string
+            {
+                return '<div id="widget"></div>';
+            }
+            public function verify(Request $request, string $formId): bool
+            {
+                return true;
+            }
         };
     }
 

--- a/tests/Unit/Internal/Domain/Captcha/CaptchaServiceTest.php
+++ b/tests/Unit/Internal/Domain/Captcha/CaptchaServiceTest.php
@@ -81,13 +81,14 @@ class CaptchaServiceTest extends TestCase
         $this->assertTrue($svc->verifyForForm('contact', $this->createMock(Request::class)));
     }
 
-    public function testConsentRequiredButNotGrantedShowsNoticeAndSkipsVerification(): void
+    public function testConsentRequiredButNotGrantedShowsNoticeAndBlocksVerification(): void
     {
         $svc = $this->service($this->provider('p'), ['consent' => false]);
         $html = $svc->renderForForm('contact');
         $this->assertStringContainsString('o3-captcha-consent-notice', $html);
         $this->assertStringNotContainsString('id="widget"', $html);
-        $this->assertTrue($svc->verifyForForm('contact', $this->createMock(Request::class)));
+        // Fail closed: without consent the captcha cannot load, so submission is blocked.
+        $this->assertFalse($svc->verifyForForm('contact', $this->createMock(Request::class)));
     }
 
     public function testHeadScriptEmittedOncePerRequest(): void


### PR DESCRIPTION
## Summary

Follow-up to the pluggable core CAPTCHA layer (#180). Closes a bot-bypass gap: when a consent-requiring provider is active but consent has **not** been granted, the captcha cannot load — and the layer previously let the submission through (`verifyForForm()` returned `true`). It now **fails closed**.

- `CaptchaService::verifyForForm()` returns `false` (and logs an `info` line) when the active provider is **not** consent-exempt and consent is required but not granted. Bots can no longer bypass a consent-gated captcha by simply never granting consent.
- Adds the `ConsentExemptCaptchaProviderInterface` marker: providers that make no third-party calls and set no cookies (e.g. a self-hosted proof-of-work captcha) implement it to opt out of the consent gate, so they are never blocked by the fail-closed rule.
- Rewords the storefront consent notice (`O3_CAPTCHA_CONSENT_NOTICE`, EN + DE) to tell visitors they must accept the required cookies, otherwise they cannot be verified as human and the form cannot be submitted.
- Documents the consent-exempt marker in `docs/captcha-provider-modules.md`.

Strict by default, no toggle: if consent is needed and the captcha can't load, the submission is blocked.

## Test plan

- [x] `./docker.sh test --fast tests/Unit/Internal/Domain/Captcha/` — `OK (20 tests, 42 assertions)`
- [x] `./docker.sh cs-fixer` — clean
- [x] Consent granted → widget renders, `verify()` runs as before
- [x] Consent required + not granted (non-exempt provider) → notice shown, submission blocked
- [x] Consent-exempt provider → unaffected (verifies regardless of consent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)