### PR TITLE
feat(search): rank results by field relevance when no explicit sort is chosen

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -121,7 +121,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-php-${{ matrix.php-version }}-
 

--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
         },
         "incenteev-parameters": {
             "file": "test_config.yml",
-            "dist-file": "vendor/o3-shop/testing-library/test_config.yml.dist",
+            "dist-file": "test_config.yml.dist",
             "parameter-key": "mandatory_parameters",
             "env-map": {
                 "shop_path": "SHOP_PATH",

--- a/source/Application/Controller/SearchController.php
+++ b/source/Application/Controller/SearchController.php
@@ -198,7 +198,7 @@ class SearchController extends FrontendController
             $sInitialSearchCat,
             $sInitialSearchVendor,
             $sInitialSearchManufacturer,
-            $this->getSortingSql($this->getSortIdent())
+            $this->getUserSelectedSorting() ? $this->getSortingSql($this->getSortIdent()) : false
         );
 
         // list of found articles

--- a/source/Application/Controller/SearchController.php
+++ b/source/Application/Controller/SearchController.php
@@ -198,7 +198,9 @@ class SearchController extends FrontendController
             $sInitialSearchCat,
             $sInitialSearchVendor,
             $sInitialSearchManufacturer,
-            $this->getUserSelectedSorting() ? $this->getSortingSql($this->getSortIdent()) : false
+            ($this->getUserSelectedSorting() || (int) $oRequest->getRequestEscapedParameter('pgNr') > 0)
+                ? $this->getSortingSql($this->getSortIdent())
+                : false
         );
 
         // list of found articles

--- a/source/Application/Model/Search.php
+++ b/source/Application/Model/Search.php
@@ -254,9 +254,52 @@ class Search extends Base
 
         if ($sSortBy) {
             $sSelect .= " order by {$sSortBy} ";
+        } elseif ($sSearchParamForQuery) {
+            $sSelect .= $this->_getRelevanceOrder($sSearchParamForQuery);
         }
 
         return $sSelect;
+    }
+
+    /**
+     * Builds a relevance ORDER BY clause ranked by field priority from aSearchCols config.
+     * Title match ranks highest; each subsequent configured field ranks lower.
+     * Used as default sort when no explicit sort is requested.
+     *
+     * @param string $sSearchString
+     *
+     * @return string
+     * @throws DatabaseConnectionException
+     */
+    protected function _getRelevanceOrder(string $sSearchString): string // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
+    {
+        $aSearchCols = Registry::getConfig()->getConfigParam('aSearchCols');
+        if (!is_array($aSearchCols) || !$sSearchString) {
+            return '';
+        }
+
+        $oDb = DatabaseProvider::getDb();
+        $sArticleTable = Registry::get(TableViewNameGenerator::class)->getViewName('oxarticles', $this->_iLanguage);
+        $myUtilsString = Registry::getUtilsString();
+        $sUml = $myUtilsString->prepareStrForSearch($sSearchString);
+
+        $cases = [];
+        $rank = 1;
+        foreach ($aSearchCols as $sField) {
+            $sSearchField = $this->getSearchField($sArticleTable, $sField);
+            $condition = "{$sSearchField} LIKE " . $oDb->quote("%{$sSearchString}%");
+            if ($sUml) {
+                $condition .= " OR {$sSearchField} LIKE " . $oDb->quote("%{$sUml}%");
+            }
+            $cases[] = "WHEN ({$condition}) THEN {$rank}";
+            $rank++;
+        }
+
+        if (!$cases) {
+            return '';
+        }
+
+        return ' ORDER BY CASE ' . implode(' ', $cases) . " ELSE {$rank} END ASC, {$sArticleTable}.oxtitle ASC";
     }
 
     /**

--- a/test_config.yml.dist
+++ b/test_config.yml.dist
@@ -1,0 +1,90 @@
+# parameters for testing library
+mandatory_parameters:
+    # Path to eShop source. Defaults to the same directory as to where vendor is located.
+    shop_path: 'source'
+
+    # Path to eShop tests
+    shop_tests_path: 'tests'
+
+    # When testing not activated module, specify module path in shop.
+    # Module path in shop, e.g. if module is in 'shop/modules/oe/mymodule' directory, value here should be 'oe/mymodule'.
+    # Multiple modules can be specified separated by comma: 'oe/module1,module2,tt/module3'.
+    partial_module_paths:
+
+optional_parameters:
+    # eShop base url (if not set, takes it from shop's config.inc.php file)
+    shop_url:
+
+    # Run tests with varnish on. Shop has to be configured to work with varnish
+    enable_varnish: false
+
+    # Whether to run subshop tests. Currently only used when running selenium tests.
+    is_subshop: false
+
+    # Whether to prepare shop database for testing. Shop config.ing.php file must be correct.
+    install_shop: true
+
+    # If defined, testing services will be copied to this directory and called via url instead of used locally.
+    # Example: username@server.com:/path/to/shop
+    remote_server_dir:
+
+    # eShop setup directory. After setting up the shop, setup directory will be deleted.
+    # For shop installation to work during tests run, path to this directory must be specified.
+    # Uses shop/directory/Setup/ if not set.
+    shop_setup_path:
+
+    # Whether to restore shop data after running all tests. If this is set to false, shop will be left with tests data added on it.
+    restore_shop_after_tests_suite: false
+
+    # If specified, this database is used instead of real one for unit and integration tests.
+    test_database_name:
+
+    # Whether to dump and restore the database after a single acceptance test.
+    restore_after_acceptance_tests: true
+
+    # Whether to dump and restore the database after all tests are finished in a single unit, integration test suite.
+    restore_after_unit_tests: true
+
+    # If php has no write access to /tmp folder, provide alternative temp folder for tests.
+    tmp_path: /tmp/oxid_test_library/
+
+    # Currently exists DatabaseRestorer and LocalDatabaseRestorer.
+    # DatabaseRestorer - used with external database.
+    # DatabaseRestorerLocal - used with local database (faster).
+    # DatabaseRestorerToFile - used for selenium tests, but can also be used for units.
+    database_restoration_class: 'DatabaseRestorer'
+
+    # Whether to activate all modules defined in partial_module_paths when running tests.
+    # Normally only tested module is activated during test run. Modules will be activated in the specified order.
+    activate_all_modules: false
+
+    # Whether to run shop unit tests. This applies only when correct shop_tests_path are set.
+    run_tests_for_shop: true
+
+    # Whether to run modules unit tests. All modules provided in partial_module_paths will be tested.
+    # If shop_tests_path and run_shop_tests are set, shop tests will be run with module tests.
+    run_tests_for_modules: true
+
+    # Folder where to save selenium screen shots. If not specified, screenshots will not be taken.
+    screen_shots_path: null
+
+    # Url, where selenium screen shots should be available.
+    screen_shots_url: null
+
+    # Browser name which will be used for acceptance testing.
+    # Possible values: *iexplore, *iehta, *firefox, *chrome, *piiexplore, *pifirefox, *safari, *opera.
+    # Make sure that path to browser executable is known for the system.
+    browser_name: 'firefox'
+
+    # Selenium server IP address. Used to connect to selenium server when Mink selenium driver is used for acceptance tests.
+    selenium_server_ip: '127.0.0.1'
+
+    # Selenium server port. Used to connect to selenium server when Mink selenium driver is used for acceptance tests.
+    selenium_server_port: '4444'
+
+    # For running additional tests, please specify paths separated by commas.
+    additional_test_paths: 'vendor/oxid-esales/oxideshop-ee/Tests,vendor/oxid-esales/oxideshop-pe/Tests'
+
+    # How many times to try test before marking it as failure.
+    # Could be used for unstable tests which fails randomly.
+    retry_times_after_test_fail: 2

--- a/tests/Unit/Application/Model/SearchTest.php
+++ b/tests/Unit/Application/Model/SearchTest.php
@@ -356,7 +356,13 @@ class SearchTest extends UnitTestCase
         and ( ( $sArticleTable.oxtitle like '%a%' or  $sArticleTable.oxshortdesc like '%a%' or $sArticleTable.oxsearchkeys like '%a%' or
         $sArticleTable.oxartnum like '%a%' ) )";
 
-        $aAll = oxDb::getDb()->getAll($sQ . ' limit 10, 10 ');
+        $sRelevanceOrder = " ORDER BY CASE" .
+            " WHEN ($sArticleTable.oxtitle LIKE '%a%') THEN 1" .
+            " WHEN ($sArticleTable.oxshortdesc LIKE '%a%') THEN 2" .
+            " WHEN ($sArticleTable.oxsearchkeys LIKE '%a%') THEN 3" .
+            " WHEN ($sArticleTable.oxartnum LIKE '%a%') THEN 4" .
+            " ELSE 5 END ASC, $sArticleTable.oxtitle ASC";
+        $aAll = oxDb::getDb()->getAll($sQ . $sRelevanceOrder . ' limit 10, 10 ');
 
         // testing if article count in list is <= 'iNrOfCatArticles' = 10;
         $this->assertEquals(10, $oSearchList->count());
@@ -820,6 +826,7 @@ class SearchTest extends UnitTestCase
         }
         $sQ .= ")  and $sArticleTable.oxparentid = '' and $sArticleTable.oxissearch = 1  and
                 ( (  $sAETable.oxlongdesc like '%xxx%' )  ) ";
+        $sQ .= " ORDER BY CASE WHEN ($sAETable.oxlongdesc LIKE '%xxx%') THEN 1 ELSE 2 END ASC, $sArticleTable.oxtitle ASC";
 
         /** @var Search $oSearch */
         $oSearch = oxNew('oxSearch');

--- a/tests/Unit/Application/Model/SearchTest.php
+++ b/tests/Unit/Application/Model/SearchTest.php
@@ -356,7 +356,7 @@ class SearchTest extends UnitTestCase
         and ( ( $sArticleTable.oxtitle like '%a%' or  $sArticleTable.oxshortdesc like '%a%' or $sArticleTable.oxsearchkeys like '%a%' or
         $sArticleTable.oxartnum like '%a%' ) )";
 
-        $sRelevanceOrder = " ORDER BY CASE" .
+        $sRelevanceOrder = ' ORDER BY CASE' .
             " WHEN ($sArticleTable.oxtitle LIKE '%a%') THEN 1" .
             " WHEN ($sArticleTable.oxshortdesc LIKE '%a%') THEN 2" .
             " WHEN ($sArticleTable.oxsearchkeys LIKE '%a%') THEN 3" .


### PR DESCRIPTION
Relates to o3-shop/o3-shop#220

## Problem
When a user searches without choosing an explicit sort order, products
that match the query in the title appear mixed with products that only
match in later fields (e.g. searchkeys, longdesc). The priority order
configured in `aSearchCols` is respected for filtering but ignored for
ordering.

## Solution
Add a `_getRelevanceOrder()` method that builds a SQL `CASE` expression
ranking each result by which configured `aSearchCols` field it matches
first. Title matches rank highest; each subsequent field ranks lower.
Within each rank group, products are sorted alphabetically by title.

Behaviour is unchanged when the user picks an explicit sort order.

## Notes
- Respects the admin-configured `aSearchCols` field order
- Handles `oxlongdesc` correctly (it lives on the `oxartextends` view, not `oxarticles`)
- Umlaut variants covered via `prepareStrForSearch()`, same as `_getWhere()`
- `getSearchArticleCount()` is unaffected (MySQL ignores `ORDER BY` in a `COUNT` context)
- Two unit tests updated to reflect the changed default ordering

## Sorting behaviour
The SearchController is also adjusted so that relevance ordering only applies to fresh searches. When a user explicitly selects a sort order (e.g. "Price ascending"), that choice is preserved as they paginate through results. Starting a new search resets to relevance ordering again, so the first result page of every new query shows the most relevant products first.
