### PR TITLE
test: harden b-1.7 order-email tests against theme getArticle() calls

### DIFF
--- a/tests/Unit/Core/EmailTest.php
+++ b/tests/Unit/Core/EmailTest.php
@@ -1286,7 +1286,7 @@ class EmailTest extends \OxidTestCase
         $priceStub->method('getBruttoPrice')->will($this->returnValue(8));
 
         $basketItemStub = $this->getMockBuilder(BasketItem::class)
-            ->setMethods(['getPrice', 'getUnitPrice', 'getRegularUnitPrice', 'getTitle'])
+            ->setMethods(['getPrice', 'getUnitPrice', 'getRegularUnitPrice', 'getTitle', 'getArticle'])
             ->getMock();
         $basketItemStub->method('getPrice')->will($this->returnValue($priceStub));
         $basketItemStub->method('getUnitPrice')->will($this->returnValue($priceStub));
@@ -1298,6 +1298,12 @@ class EmailTest extends \OxidTestCase
         $article->setId('_testArticleId');
         $article->setId('_testArticleId');
         $article->oxarticles__oxtitle = new oxField();
+
+        // A theme's order-confirmation template may call $basketitem->getArticle()
+        // directly (e.g. the wave #219 durability-guarantee label). Without this stub
+        // the real BasketItem::getArticle() runs against a product-less mock and throws
+        // EXCEPTION_ARTICLE_NOPRODUCTID, erroring these tests. Return the test article.
+        $basketItemStub->method('getArticle')->will($this->returnValue($article));
 
         $priceStub->setPrice(0);
 

--- a/tests/Unit/Core/EmailUtf8Test.php
+++ b/tests/Unit/Core/EmailUtf8Test.php
@@ -77,7 +77,7 @@ class EmailUtf8Test extends \OxidTestCase
         $oPrice->expects($this->any())->method('getPrice')->will($this->returnValue(256));
         $oPrice->expects($this->any())->method('getBruttoPrice')->will($this->returnValue(8));
 
-        $oBasketItem = $this->getMock(\OxidEsales\Eshop\Application\Model\BasketItem::class, ['getPrice', 'getUnitPrice', 'getRegularUnitPrice', 'getTitle']);
+        $oBasketItem = $this->getMock(\OxidEsales\Eshop\Application\Model\BasketItem::class, ['getPrice', 'getUnitPrice', 'getRegularUnitPrice', 'getTitle', 'getArticle']);
         $oBasketItem->expects($this->any())->method('getPrice')->will($this->returnValue($oPrice));
         $oBasketItem->expects($this->any())->method('getUnitPrice')->will($this->returnValue($oPrice));
         $oBasketItem->expects($this->any())->method('getRegularUnitPrice')->will($this->returnValue($oPrice));
@@ -88,6 +88,11 @@ class EmailUtf8Test extends \OxidTestCase
         $oArticle->setId('_testArticleId');
         $oArticle->setId('_testArticleId');
         $oArticle->oxarticles__oxtitle = new oxField();
+        // A theme's order-confirmation template may call $basketitem->getArticle()
+        // directly (e.g. the wave #219 durability-guarantee label). Without this stub
+        // the real BasketItem::getArticle() runs against a product-less mock and throws
+        // EXCEPTION_ARTICLE_NOPRODUCTID, erroring this test. Return the test article.
+        $oBasketItem->expects($this->any())->method('getArticle')->will($this->returnValue($oArticle));
 
         $aBasketContents[] = $oBasketItem;
         $aBasketArticles[] = $oArticle;

--- a/tests/Unit/Core/EmailWaveTplTest.php
+++ b/tests/Unit/Core/EmailWaveTplTest.php
@@ -172,7 +172,7 @@ class EmailWaveTplTest extends \OxidTestCase
         /** @var oxBasketItem|PHPUnit\Framework\MockObject\MockObject $oBasketItem */
         $oBasketItem = $this->getMock(
             'oxBasketItem',
-            ['getRegularUnitPrice', 'getVatPercent', 'getAmount', 'getTitle', 'getProductId']
+            ['getRegularUnitPrice', 'getVatPercent', 'getAmount', 'getTitle', 'getProductId', 'getArticle']
         );
 
         $oBasketItem->expects($this->any())->method('getRegularUnitPrice')->will($this->returnValue($oPrice));
@@ -180,6 +180,9 @@ class EmailWaveTplTest extends \OxidTestCase
         $oBasketItem->expects($this->any())->method('getAmount')->will($this->returnValue(1));
         $oBasketItem->expects($this->any())->method('getTitle')->will($this->returnValue('testArticle'));
         $oBasketItem->expects($this->any())->method('getProductId')->will($this->returnValue('_testArticleId'));
+        // Theme order_cust.tpl may call getArticle() directly (wave #219 guarantee label);
+        // stub it or the real getArticle() throws EXCEPTION_ARTICLE_NOPRODUCTID.
+        $oBasketItem->expects($this->any())->method('getArticle')->will($this->returnValue($this->_oArticle));
 
         $oBasketItem->oxarticles__oxtitle = new oxField();
         $oBasketItem->oxarticles__oxvarselect = new oxField();


### PR DESCRIPTION
## Summary

- `EmailTest::getOrderStub()` builds a mocked basket item and renders the **live, downloaded** wave theme's `order_cust.tpl`. The mock only stubbed `getPrice/getUnitPrice/getRegularUnitPrice/getTitle`.
- When a theme template calls `$basketitem->getArticle()` directly — as the wave **#219** durability-guarantee label does — the un-stubbed mock runs the real `BasketItem::getArticle()` against a product-less item and throws `EXCEPTION_ARTICLE_NOPRODUCTID`, erroring the whole order-email suite. This is what turned b-1.7 CI red (unrelated to the `actions/checkout@v7` dependabot bump that merely triggered the run).
- Fix: stub `getArticle()` on the basket-item mock to return the existing test article, so these tests no longer depend on whether the active theme touches the article object. This mirrors the fixture already present on `b-2.0`.

## Test plan

- [x] Reproduced the failure: with the wave #219 `order_cust.tpl` in place and the **unfixed** stub → 4 errors (`EXCEPTION_ARTICLE_NOPRODUCTID` at `BasketItem.php:512 ← order_cust.tpl.php:261 ← Email.php:643`), matching CI exactly.
- [x] With the fix + #219 template → `OK (4 tests, 4 assertions)`.
- [x] Full file with the clean (reverted) template: `./docker.sh test --fast tests/Unit/Core/EmailTest.php` → `OK` (74 tests, 143 assertions; 1 pre-existing risky, unrelated).
- [x] `php-cs-fixer` on the changed file → 0 changes.

## Notes

Relates to o3-shop/o3-shop#219 — this unblocks re-landing the EU guarantee-label feature (which was reverted on `wave-theme` main) without turning b-1.7 CI red on the order-email tests.