### PR TITLE
feat(release): open the b-1.7 release line

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -29,6 +29,7 @@ Shared memory for all Claude agents working in this repository. Read this first,
 - [!] [Theme repos are external](architecture_theme-repos.md) — wave + o3-theme live in separate GitHub repos; their dirs in shop-ce are gitignored snapshots
 - [!] [o3-theme migration](project_o3-theme-migration.md) — wave → o3-theme cutover before 2026-05-01; keep new storefront templates portable
 - [o3-theme npm audit](project_o3-theme-dep-audit.md) — pre-existing brace-expansion vulnerability blocks test-all-coverage; use test --fast for PHP-only changes
+- [!] [bin/release branch selection & execution gotchas](release-tooling-branch-selection.md) — `--to` does NOT pick the branch (only DefaultBranchResolver does); pre-flight runs last so a missing branch is a `Plan failed:` 404, not a gate error; live mode fires with no confirmation and bare `--dry-run` skips pre-flight entirely
 - [bin/release intermediate-node re-tag gap](release-tooling-intermediate-node-retag-gap.md) — resolver "reuses" an intermediate fat node (the metapackage) while bumping its child pin → orphaned edit; force a re-tag during the fold-out cut (#169)
 - [!] [cs-fixer dirties nested clones](cs-fixer-pollutes-nested-clones.md) — ./docker.sh cs-fixer reformats testing-library/themes/demodata clones → aborts bin/release pre-flight; clean them before a cut
 - [!] [ExitHandler interface-guard bug](shop-ce-exithandler-interface-guard-bug.md) — bootstrap.php uses class_exists() on the ExitHandlerInterface (always false) → fresh-install Setup redirect dies in a DB-error loop; fix: interface_exists()

--- a/.claude/memory/release-tooling-branch-selection.md
+++ b/.claude/memory/release-tooling-branch-selection.md
@@ -1,0 +1,63 @@
+---
+name: release-tooling-branch-selection
+description: bin/release picks branches only from DefaultBranchResolver, runs pre-flight last, and fires live with no confirmation
+type: reference
+---
+
+# `bin/release` — branch selection and execution gotchas
+
+Learned opening the `b-1.7` line (2026-07-27). All of these cost real
+debugging time and none are visible from the CLI help.
+
+## `--to` does not choose the branch
+
+`DefaultBranchResolver::PACKAGE_TO_BRANCH` is the **only** input to branch
+selection. `--to=1.7.0-RC1` has zero influence — passing a 1.7 version while
+the map still says `b-1.6` aborts on `BranchGate` with
+`expected 'b-1.6' (release branch for this repo)`. There is no CLI override;
+the map must be edited.
+
+The nine shop-line repos (`o3-shop`, `shop-ce`, `shop-metapackage-ce`,
+`testing-library`, `shop-facts`, `shop-ide-helper`,
+`shop-unified-namespace-generator`, `shop-doctrine-migration-wrapper`,
+`shop-demodata-installer`) branch per shop minor and move as a group. The
+`b-1.0` / `b-7.0.x` / `b-6.5.x` / `support/2.6` / `main` groups version
+independently and never move with the shop line.
+
+## Pre-flight runs LAST, so a missing branch is not a gate error
+
+Pre-flight is the final step inside `ReleasePlanner::plan()`, after the
+dep-tree walk. Bumping the map before the branches exist on the remote means
+`DepTreeWalker`'s raw `composer.json` fetch 404s first — you get
+`Plan failed: ...` and **no gate ever runs**. Cut the branches, then bump the
+map. `BranchGate` only covers the opposite case: a local checkout sitting on
+the wrong branch.
+
+## Live mode executes with no confirmation prompt
+
+Omitting `--dry-run` means: gates pass → `LiveExecutor::execute()` runs
+immediately. Tags are cut, PRs opened, draft releases created. There is no
+"are you sure".
+
+To exercise the gates *without* state changes, use `--dry-run` **plus**
+explicit `--repo-path <pkg>=<abs path>` for each package. `--dry-run` alone
+returns an empty repo-path map and therefore **skips pre-flight entirely** —
+a clean dry run proves nothing about the gates.
+
+## `UpToDateGate` mutates your local clones
+
+It is not read-only. A behind-only branch is fast-forwarded
+(`git merge --ff-only`) during the run, including runs that go on to abort.
+The `WARN ... fast-forwarded to match` lines are edits that already happened.
+
+## The merge-back PR's head IS the release branch
+
+`b-1.6` is the head branch of `Merge v1.6.x release into main`. If
+`delete_branch_on_merge` were `true`, merging it deletes the maintenance
+line. Keep it `false` on every release repo; `DeleteBranchOnMergeGate`
+enforces this and fails closed. That gate is scoped to repos whose release
+branch is not `main` — a `main`-line repo cannot have a merge-back PR at all,
+so auto-delete there is harmless feature-branch hygiene and must not block
+the release.
+
+See also [[release-tooling-intermediate-node-retag-gap]].

--- a/source/Internal/ReleaseTooling/Command/ReleaseCommand.php
+++ b/source/Internal/ReleaseTooling/Command/ReleaseCommand.php
@@ -353,10 +353,13 @@ class ReleaseCommand extends Command
             new ComposerInstallGate($exec, $this->resolveBundledComposer()),
             new TestSuiteGate($exec, $skipTestsResolver),
             new IncomingPrGate($exec),
-            // Ordered before MergeBackPrGate: that gate points at the
-            // merge-back PR whose head IS the release branch, so the
-            // repo must be known-safe against auto-delete before the
-            // maintainer is told to go merge it.
+            // Adjacent to MergeBackPrGate because they concern the same
+            // PR — that gate points at the merge-back whose head IS the
+            // release branch, this one proves merging it cannot delete
+            // that branch. Placement is presentational only: the runner
+            // evaluates every gate unconditionally and never
+            // short-circuits, so order affects the report, not control
+            // flow.
             new DeleteBranchOnMergeGate($exec),
             new MergeBackPrGate($exec),
         ]);

--- a/source/Internal/ReleaseTooling/Command/ReleaseCommand.php
+++ b/source/Internal/ReleaseTooling/Command/ReleaseCommand.php
@@ -28,6 +28,7 @@ use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Constraint\ConstraintUpdat
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\ComposerJsonConstraintWriter;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\Gates\BranchGate;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\Gates\ComposerInstallGate;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\Gates\DeleteBranchOnMergeGate;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\Gates\IncomingPrGate;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\Gates\MergeBackPrGate;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\Gates\TestSuiteGate;
@@ -352,6 +353,11 @@ class ReleaseCommand extends Command
             new ComposerInstallGate($exec, $this->resolveBundledComposer()),
             new TestSuiteGate($exec, $skipTestsResolver),
             new IncomingPrGate($exec),
+            // Ordered before MergeBackPrGate: that gate points at the
+            // merge-back PR whose head IS the release branch, so the
+            // repo must be known-safe against auto-delete before the
+            // maintainer is told to go merge it.
+            new DeleteBranchOnMergeGate($exec),
             new MergeBackPrGate($exec),
         ]);
     }

--- a/source/Internal/ReleaseTooling/Flow/Gates/DeleteBranchOnMergeGate.php
+++ b/source/Internal/ReleaseTooling/Flow/Gates/DeleteBranchOnMergeGate.php
@@ -36,6 +36,14 @@ use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\ProcessExecutor;
  * it needs no local checkout (and `$repoPath` is intentionally unused).
  * Fails CLOSED — any unverifiable result aborts.
  *
+ * Scoped to repos that HAVE a separate maintenance line. When the
+ * release branch is `main`, the merge-back PR would need `main` as
+ * both base and head, so no such PR can exist and no release branch
+ * is reachable by auto-delete — there `delete_branch_on_merge = true`
+ * is ordinary feature-branch hygiene, not a hazard. Aborting on it
+ * would turn a benign repo setting anywhere in the network into a
+ * full release blocker, so those repos are skipped outright.
+ *
  * Output assumption: `--jq .delete_branch_on_merge` renders the JSON
  * boolean as the lowercase strings `true`/`false`; anything else
  * (e.g. `null`) is treated as unverifiable and aborts.
@@ -60,6 +68,10 @@ class DeleteBranchOnMergeGate implements PreFlightGate
 
     public function evaluate(string $repoPath, string $expectedBranch, string $packageName): GateOutcome
     {
+        if ($expectedBranch === MergeBackPrGate::MERGE_BACK_BASE) {
+            return GateOutcome::passed(self::NAME); // no merge-back possible, nothing to guard
+        }
+
         $slug = PackageRepoSlug::resolve($packageName);
         $outcome = $this->exec->execute(
             [$this->ghBin, 'api', 'repos/' . $slug, '--jq', '.delete_branch_on_merge'],

--- a/source/Internal/ReleaseTooling/Flow/Gates/MergeBackPrGate.php
+++ b/source/Internal/ReleaseTooling/Flow/Gates/MergeBackPrGate.php
@@ -40,6 +40,15 @@ class MergeBackPrGate implements PreFlightGate
 {
     public const NAME = 'merge-back-pending';
 
+    /**
+     * Branch every merge-back PR targets. Also the signal for "this
+     * repo has no separate maintenance line": a package released from
+     * this branch cannot have a merge-back PR at all, since base and
+     * head would coincide. DeleteBranchOnMergeGate keys its skip on
+     * this, so the two gates cannot drift apart.
+     */
+    public const MERGE_BACK_BASE = 'main';
+
     private ProcessExecutor $exec;
     private string $ghBin;
 
@@ -61,7 +70,7 @@ class MergeBackPrGate implements PreFlightGate
                 $this->ghBin, 'pr', 'list',
                 '--repo', PackageRepoSlug::resolve($packageName),
                 '--state', 'open',
-                '--base', 'main',
+                '--base', self::MERGE_BACK_BASE,
                 '--head', $expectedBranch,
                 '--json', 'number,title,url',
                 '--limit', '50',

--- a/source/Internal/ReleaseTooling/Planning/DefaultBranchResolver.php
+++ b/source/Internal/ReleaseTooling/Planning/DefaultBranchResolver.php
@@ -27,21 +27,30 @@ namespace OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning;
  * from. The map matches the per-repo branch decisions made during
  * Section 1.5 (archive.exclude rollout).
  *
+ * The `b-1.<n>` group is the shop release line: every one of those
+ * repos branches per shop minor, so opening a new line (1.6 -> 1.7)
+ * means cutting `b-1.<n>` in each of them and bumping the whole
+ * group here in lockstep. A package whose branch is missing on the
+ * remote fails pre-flight (BranchGate / UpToDateGate) rather than
+ * silently releasing from the wrong ref. The other groups —
+ * `b-1.0`, `b-7.0.x`, `b-6.5.x`, `support/2.6`, `main` — version
+ * independently of the shop line and do not move with it.
+ *
  * Repos not in the map fall back to `main`.
  */
 final class DefaultBranchResolver
 {
     /** @var array<string,string> package => branch */
     public const PACKAGE_TO_BRANCH = [
-        'o3-shop/o3-shop' => 'b-1.6',
-        'o3-shop/shop-ce' => 'b-1.6',
-        'o3-shop/shop-metapackage-ce' => 'b-1.6',
-        'o3-shop/testing-library' => 'b-1.6',
-        'o3-shop/shop-facts' => 'b-1.6',
-        'o3-shop/shop-ide-helper' => 'b-1.6',
-        'o3-shop/shop-unified-namespace-generator' => 'b-1.6',
-        'o3-shop/shop-doctrine-migration-wrapper' => 'b-1.6',
-        'o3-shop/shop-demodata-installer' => 'b-1.6',
+        'o3-shop/o3-shop' => 'b-1.7',
+        'o3-shop/shop-ce' => 'b-1.7',
+        'o3-shop/shop-metapackage-ce' => 'b-1.7',
+        'o3-shop/testing-library' => 'b-1.7',
+        'o3-shop/shop-facts' => 'b-1.7',
+        'o3-shop/shop-ide-helper' => 'b-1.7',
+        'o3-shop/shop-unified-namespace-generator' => 'b-1.7',
+        'o3-shop/shop-doctrine-migration-wrapper' => 'b-1.7',
+        'o3-shop/shop-demodata-installer' => 'b-1.7',
         'o3-shop/gdpr-optin-module' => 'b-1.0',
         'o3-shop/paypal-module' => 'b-1.0',
         'o3-shop/usercentrics' => 'b-1.0',

--- a/source/Internal/ReleaseTooling/Planning/DefaultBranchResolver.php
+++ b/source/Internal/ReleaseTooling/Planning/DefaultBranchResolver.php
@@ -30,11 +30,14 @@ namespace OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning;
  * The `b-1.<n>` group is the shop release line: every one of those
  * repos branches per shop minor, so opening a new line (1.6 -> 1.7)
  * means cutting `b-1.<n>` in each of them and bumping the whole
- * group here in lockstep. A package whose branch is missing on the
- * remote fails pre-flight (BranchGate / UpToDateGate) rather than
- * silently releasing from the wrong ref. The other groups —
- * `b-1.0`, `b-7.0.x`, `b-6.5.x`, `support/2.6`, `main` — version
- * independently of the shop line and do not move with it.
+ * group here in lockstep. Bump this map only once those branches
+ * exist: pre-flight runs LAST inside ReleasePlanner::plan(), so a
+ * branch that is missing on the remote surfaces earlier and less
+ * legibly as a raw composer.json 404 from DepTreeWalker, reported as
+ * `Plan failed:` — no gate ever runs. BranchGate covers the other
+ * direction, a local checkout sitting on the wrong branch. The other
+ * groups — `b-1.0`, `b-7.0.x`, `b-6.5.x`, `support/2.6`, `main` —
+ * version independently of the shop line and do not move with it.
  *
  * Repos not in the map fall back to `main`.
  */

--- a/tests/Unit/Internal/ReleaseTooling/Command/ReleaseCommandTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Command/ReleaseCommandTest.php
@@ -24,6 +24,9 @@ namespace OxidEsales\EshopCommunity\Tests\Unit\Internal\ReleaseTooling\Command;
 
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Command\ReleaseCommand;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\LiveExecutor;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\PreFlightGate;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\PreFlightRunner;
+use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Flow\SymfonyProcessExecutor;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning\DryRunPrinter;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning\ReleasePlan;
 use OxidEsales\EshopCommunity\Internal\ReleaseTooling\Planning\ReleasePlanner;
@@ -474,6 +477,72 @@ class ReleaseCommandTest extends TestCase
         $buildLiveExecutor->setAccessible(true);
         $live = $buildLiveExecutor->invoke($command, null);
         $this->assertInstanceOf(LiveExecutor::class, $live);
+    }
+
+    /**
+     * Every gate that exists MUST be wired into the production runner.
+     *
+     * DeleteBranchOnMergeGate was written, unit-tested and left
+     * unregistered, so its protection was inert while looking present
+     * in the codebase. Asserting a hand-written list would not have
+     * caught that — the list and the registration would have been
+     * forgotten together. So this discovers gate classes from disk:
+     * adding a new gate fails here until it is actually registered.
+     */
+    public function testEveryGateClassIsRegisteredInProductionRunner(): void
+    {
+        $command = new ReleaseCommand();
+        $build = new \ReflectionMethod(ReleaseCommand::class, 'buildDefaultPreFlightRunner');
+        $build->setAccessible(true);
+        $runner = $build->invoke($command, new SymfonyProcessExecutor());
+        $this->assertInstanceOf(PreFlightRunner::class, $runner);
+
+        $gatesProperty = new \ReflectionProperty(PreFlightRunner::class, 'gates');
+        $gatesProperty->setAccessible(true);
+        $registered = array_map(
+            static fn (PreFlightGate $gate): string => $gate->name(),
+            $gatesProperty->getValue($runner)
+        );
+
+        $this->assertSame(
+            array_unique($registered),
+            $registered,
+            'A gate is registered more than once in buildDefaultPreFlightRunner().'
+        );
+
+        foreach ($this->gateClassesOnDisk() as $class) {
+            $this->assertContains(
+                $class::NAME,
+                $registered,
+                sprintf(
+                    '%s exists but is not registered in buildDefaultPreFlightRunner(), '
+                    . 'so it never runs and the protection it implements is inert.',
+                    $class
+                )
+            );
+        }
+    }
+
+    /**
+     * @return array<int,class-string<PreFlightGate>>
+     */
+    private function gateClassesOnDisk(): array
+    {
+        $interfaceFile = (new \ReflectionClass(PreFlightGate::class))->getFileName();
+        $this->assertIsString($interfaceFile);
+        $files = glob(dirname($interfaceFile) . '/Gates/*.php');
+        $this->assertIsArray($files);
+        $this->assertNotEmpty($files, 'No gate classes found on disk — the discovery path is wrong.');
+
+        $classes = [];
+        foreach ($files as $file) {
+            $class = 'OxidEsales\\EshopCommunity\\Internal\\ReleaseTooling\\Flow\\Gates\\'
+                . basename($file, '.php');
+            if (is_subclass_of($class, PreFlightGate::class)) {
+                $classes[] = $class;
+            }
+        }
+        return $classes;
     }
 
     private function planThatAborts(): ReleasePlan

--- a/tests/Unit/Internal/ReleaseTooling/Flow/Gates/DeleteBranchOnMergeGateTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Flow/Gates/DeleteBranchOnMergeGateTest.php
@@ -71,6 +71,28 @@ class DeleteBranchOnMergeGateTest extends TestCase
         $this->assertStringContainsString('unexpected value', $outcome->messages()[0]);
     }
 
+    /**
+     * A repo released from `main` has no separate maintenance line, so
+     * no merge-back PR can exist and auto-delete cannot reach a release
+     * branch. Aborting there would let a benign setting on any theme or
+     * satellite repo block the whole release.
+     */
+    public function testSkipsRepoReleasedFromMainWithoutQueryingGitHub(): void
+    {
+        $exec = new FakeProcessExecutor([]);
+        $outcome = (new DeleteBranchOnMergeGate($exec))->evaluate('', 'main', 'o3-shop/wave-theme');
+        $this->assertTrue($outcome->isPassed());
+        $this->assertSame([], $exec->commands(), 'Skipped repos must not cost a gh round-trip.');
+    }
+
+    public function testStillAbortsForMaintenanceLineRepoEvenWhenNamedLikeMain(): void
+    {
+        $cmd = 'gh api repos/o3-shop/smarty --jq .delete_branch_on_merge';
+        $exec = new FakeProcessExecutor([$cmd => new ProcessOutcome(0, "true\n", '')]);
+        $outcome = (new DeleteBranchOnMergeGate($exec))->evaluate('', 'support/2.6', 'o3-shop/smarty');
+        $this->assertTrue($outcome->aborts());
+    }
+
     public function testResolvesRenamedSlugForGhApi(): void
     {
         $cmd = 'gh api repos/o3-shop/o3-Theme --jq .delete_branch_on_merge';

--- a/tests/Unit/Internal/ReleaseTooling/Flow/RepoPathDiscoveryTest.php
+++ b/tests/Unit/Internal/ReleaseTooling/Flow/RepoPathDiscoveryTest.php
@@ -111,7 +111,7 @@ final class RepoPathDiscoveryTest extends TestCase
             $branchIdx = array_search('--branch', $cmd, true);
             $cloneBranches[end($cmd)] = $cmd[$branchIdx + 1];
         }
-        $this->assertSame('b-1.6', $cloneBranches[$base . '/testing-library']);
+        $this->assertSame('b-1.7', $cloneBranches[$base . '/testing-library']);
         $this->assertSame('main', $cloneBranches[$base . '/o3-Theme']);
 
         $this->assertSame($base . '/testing-library', $resolved['o3-shop/testing-library']);


### PR DESCRIPTION
## Why

`bin/release --from=v1.6.2 --to=1.7.0-RC1` aborts in pre-flight. `BranchGate` reads the release branch from `DefaultBranchResolver::PACKAGE_TO_BRANCH`, which still mapped the shop-line repos to `b-1.6` while `shop-ce` is on `b-1.7`. The `--to` version has no influence on branch selection — the map is the only input — so 1.7 could not be cut at all.

## What changed

**1. Shop-line group moved to `b-1.7`** (9 entries). Those repos branch per shop minor, so opening a line moves the whole group in lockstep. The `b-1.0`, `b-7.0.x`, `b-6.5.x`, `support/2.6` and `main` groups version independently and are untouched. The docblock records that rule, and warns that the map must only be bumped once the branches exist — pre-flight runs *last* inside `ReleasePlanner::plan()`, so a missing remote branch surfaces earlier and far less legibly as a raw `composer.json` 404 from `DepTreeWalker`, reported as `Plan failed:`.

**2. `DeleteBranchOnMergeGate` registered in `buildDefaultPreFlightRunner`.** It was fully written and unit-tested but never wired into the runner, so its protection was inert while looking present. It matters here specifically: the merge-back PR's head branch *is* the release branch, so a repo with `delete_branch_on_merge = true` loses its maintenance line on merge.

**3. That gate is scoped to repos with a separate maintenance line.** As first written it ran for all 24 packages — but a repo released from `main` cannot have a merge-back PR at all (base and head would coincide), so auto-delete there is ordinary feature-branch hygiene, not a hazard. Unscoped, a benign setting on any theme or satellite repo would have blocked the entire release. All 24 repos read `false` today, so this was latent rather than live. The skip keys off `MergeBackPrGate::MERGE_BACK_BASE`, now a shared constant, so the two gates cannot drift apart.

**4. A test asserts every gate class on disk is registered.** A hand-written expected-list would not have caught the original bug — the list and the registration get forgotten together — so the test discovers gate classes from the filesystem. Adding a new gate now fails until it is actually wired. Verified it fails with the intended message when the registration is removed.

## Not done in this PR

The `b-1.7` branches do not yet exist in the other eight repos. Until they are cut from each repo's `b-1.6` tip, planning still fails — as a `Plan failed:` 404, per the note above. That is a separate, remote-only operation, and it never deletes or moves `b-1.6`.

## Testing

- `./docker.sh test` — **OK (9860 tests, 18349 assertions)**
- `./docker.sh cs-fixer` — clean; no changes to any file in this diff
- Negative-verified the new registration test by removing the gate registration and confirming it fails with the intended message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZmamVdSES5Gw8HCWFnNwj